### PR TITLE
Fixes reCAPTCHA token validation issue.

### DIFF
--- a/app/contact-agent/page.tsx
+++ b/app/contact-agent/page.tsx
@@ -6,6 +6,7 @@ import OptionalInformationForBuyer from "@/components/ContactAgents/OptionalInfo
 import Image from "next/image";
 import GetListedLendersProfileInfo from "@/components/GetListedLenders/GetListedLendersProfileInfo";
 import { contactAgentPostForm } from "@/services/salesForcePostFormsService";
+import useTimestamp from "@/hooks/useTimestamp";
 
 interface FormData {
   firstName: string;
@@ -39,20 +40,20 @@ export default function Home() {
   const [shouldSubmitForm, setShouldSubmitForm] = useState<boolean>(false);
 
   const handleNext = () => {
-    setCurrentStep(prev => Math.min(prev + 1, 4)); 
+    setCurrentStep(prev => Math.min(prev + 1, 4));
   };
-  
+
   const handleBack = () => {
-    setCurrentStep(prev => Math.max(prev - 1, 1)); 
+    setCurrentStep(prev => Math.max(prev - 1, 1));
   };
-  
+
   const handleSubmit = (stepData: any) => {
     setFormData(prev => ({
       ...prev,
       ...stepData
     }));
-    
-      handleNext();
+
+    handleNext();
   };
 
   const shouldSubmit = () => {
@@ -83,7 +84,9 @@ export default function Home() {
       handleFormSubmission();
     }
   }, [formData, shouldSubmitForm, queryString]);
-  
+
+  useTimestamp();
+
   const renderProgressBar = () => {
     return (
       <div className="flex md:justify-start justify-center">
@@ -102,6 +105,7 @@ export default function Home() {
 
   return (
     <>
+
       <div className="container mx-auto w-full">
         <div className="flex flex-wrap md:flex-nowrap justify-between items-center md:pt-[140px] pt-[80px] md:mx-0 mx-5">
           <div>

--- a/app/contact-lender/page.tsx
+++ b/app/contact-lender/page.tsx
@@ -3,7 +3,6 @@ import { ContactFormData } from "@/components/ContactLender/ContactLender";
 import ContactLender from "@/components/ContactLender/ContactLender";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-
 export interface FormData {
   firstName: string;
   lastName: string;
@@ -20,8 +19,8 @@ async function submitForm(formData: ContactFormData, fullQueryString: string) {
   "use server"
 
   const paramsObj: { [key: string]: string } = {};
-  new URLSearchParams (fullQueryString).forEach((value, key) => {
-      paramsObj[key] = value;
+  new URLSearchParams(fullQueryString).forEach((value, key) => {
+    paramsObj[key] = value;
   });
 
   const formBody = new URLSearchParams({
@@ -41,12 +40,13 @@ async function submitForm(formData: ContactFormData, fullQueryString: string) {
     "00N4x00000QPksj": formData.howDidYouHear || "",
     "00N4x00000QPS7V": formData.tellusMore || "",
     "00N4x00000bfgFA": formData.additionalComments || "",
-    recaptcha_token: formData.captchaToken || "",
+    "g-recaptcha-response": formData.captchaToken || "",
+    "captcha_settings": formData.captcha_settings || "",
   }).toString();
 
   try {
     const response = await fetch(
-      "https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8&orgId=00D4x000003yaV2",
+      "https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8",
       {
         method: 'POST',
         headers: {
@@ -61,7 +61,7 @@ async function submitForm(formData: ContactFormData, fullQueryString: string) {
     }
 
     revalidatePath('/');
-    
+
     // console.log('NEXT_PUBLIC_API_BASE_URL:', process.env.NEXT_PUBLIC_API_BASE_URL);
     // redirect("http://127.0.0.1:3000/");
   } catch (error) {
@@ -71,6 +71,7 @@ async function submitForm(formData: ContactFormData, fullQueryString: string) {
 }
 
 export default function Home() {
+
   return (
     <>
       <div className="container mx-auto w-full">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import "@/styles/globals.css";
-import ClientLayoutWrapper from "@/components/ClientLayoutWrapper"; // Import wrapper
+import ClientLayoutWrapper from "@/components/ClientLayoutWrapper"; // Import wrapper'
+import useTimestamp from "@/hooks/useTimestamp";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -23,6 +24,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <script defer src="https://www.google.com/recaptcha/api.js"></script>
+      </head>
       <body className={inter.className}>
         <ClientLayoutWrapper>{children}</ClientLayoutWrapper>
       </body>

--- a/components/ContactAgents/OptionalInformationForBuyer.tsx
+++ b/components/ContactAgents/OptionalInformationForBuyer.tsx
@@ -15,6 +15,7 @@ export interface FormData {
   maxPrice: string;
   preApproval: string | null;
   captchaToken: string;
+  captcha_settings: string | null;
 }
 
 // Define validation schema using Yup
@@ -35,16 +36,28 @@ const OptionalInformationForBuyer = ({ onSubmit, shouldSubmit }: ContactFormProp
       typeOfHome: null,
       bedrooms: '',
       bathrooms: '',
-      maxPrice: '', 
+      maxPrice: '',
       preApproval: null,
       captchaToken: '',
+      captcha_settings: '',
     }
   });
 
   const onCaptchaChange = (token: string | null) => {
-    setValue('captchaToken', token || '', { 
-      shouldValidate: true // This triggers validation after setting the value
-    });
+    if (token) {
+      const captchaSettingsElem = document.getElementById('captcha_settings') as HTMLInputElement | null;
+      if (captchaSettingsElem) {
+        const captchaSettings = JSON.parse(captchaSettingsElem.value);
+        captchaSettings.ts = JSON.stringify(new Date().getTime());
+        captchaSettingsElem.value = JSON.stringify(captchaSettings);
+        setValue('captcha_settings', captchaSettingsElem.value, {
+          shouldValidate: false // This triggers validation after setting the value
+        });
+        setValue('captchaToken', token, {
+          shouldValidate: true // This triggers validation after setting the value
+        });
+      }
+    }
   };
 
   // Handle form submission
@@ -57,6 +70,7 @@ const OptionalInformationForBuyer = ({ onSubmit, shouldSubmit }: ContactFormProp
     <div className="md:py-12 py-4 md:px-0 px-5">
       <div className="md:w-[456px] mx-auto my-10">
         <form onSubmit={handleSubmit(onSubmitHandler)}>
+          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' />
           <div className="flex flex-col gap-8">
             <div className="md:text-left text-center">
               <h1 className="text-[#7E1618] tahoma lg:text-[32px] md:text-[32px] sm:text-[24px] text-[24px] font-bold leading-8">
@@ -210,7 +224,7 @@ const OptionalInformationForBuyer = ({ onSubmit, shouldSubmit }: ContactFormProp
                     sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ''}
                     onChange={onCaptchaChange} // Handle reCAPTCHA value change
                   />
-                   {errors.captchaToken && (
+                  {errors.captchaToken && (
                     <span className="text-red-500">{errors.captchaToken.message}</span>
                   )}
                 </div>

--- a/hooks/useTimestamp.tsx
+++ b/hooks/useTimestamp.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect } from "react";
+
+const useTimestamp = () => {
+    useEffect(() => {
+        const updateTimestamp = () => {
+            const response = document.getElementById("g-recaptcha-response") as HTMLInputElement;
+            if (!response || response.value.trim() === "") {
+                const captchaSettingsElem = document.getElementById("captcha_settings") as HTMLInputElement | null;
+                if (captchaSettingsElem) {
+                    const captchaSettings = JSON.parse(captchaSettingsElem.value);
+                    captchaSettings.ts = JSON.stringify(new Date().getTime());
+                    captchaSettingsElem.value = JSON.stringify(captchaSettings);
+                }
+            }
+        };
+
+        const interval = setInterval(updateTimestamp, 500);
+
+        // Cleanup interval on component unmount
+        return () => clearInterval(interval);
+    }, []);
+};
+
+export default useTimestamp;

--- a/services/salesForcePostFormsService.tsx
+++ b/services/salesForcePostFormsService.tsx
@@ -7,10 +7,10 @@ import { redirect } from 'next/navigation'
 export async function contactAgentPostForm(formData: any, queryString: string) {
     try {
         const paramsObj: { [key: string]: string } = {};
-        new URLSearchParams (queryString).forEach((value, key) => {
+        new URLSearchParams(queryString).forEach((value, key) => {
             paramsObj[key] = value;
         });
-
+        console.log("formData", formData)
         console.log("agent", paramsObj)
 
         const formBody = new URLSearchParams({
@@ -43,9 +43,9 @@ export async function contactAgentPostForm(formData: any, queryString: string) {
             "00N4x00000Lpb2Z": formData.bathrooms || "",
             "00N4x00000LsaCy": formData.maxPrice || "",
             "00N4x00000Lpbfw": formData.preApproval || "",
-            recaptcha_token: formData.captchaToken || "",
+            "g-recaptcha-response": formData.captchaToken || "",
+            "captcha_settings": formData.captcha_settings || "",
         }).toString();
-
 
         const response = await fetch(
             "https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8&orgId=00D4x000003yaV2",


### PR DESCRIPTION
Salesforce requires captcha_settings and g-recaptcha-response to be sent in the form data.
The captcha_settings object contains the timestamp of the form submission.
This timestamp is used to validate the reCAPTCHA token on the server-side.
The timestamp is updated every 500ms to ensure that it is always current.
The g-recaptcha-response token is sent by the reCAPTCHA widget when the user completes the challenge.
Both values are now sent in the form data when the form is submitted.