### PR TITLE
Update author schema to match blog contact section

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -39,7 +39,7 @@ export default async function Home({ params }: { params: { slug: string } }) {
             <Testimonials />
             <BlogDetailsCta />
             <EndBlogPostDetails blog={blog} />
-            <CommonBlog component="Related Posts"/>
+            <CommonBlog component="Related Posts" />
             <MemoizedFrequentlyAskedQuestion />
             <KeepInTouch />
             <Footer />

--- a/components/BlogDetails/BlogBeginingBlogPostAgent/BlogBeginingBlogPostAgent.tsx
+++ b/components/BlogDetails/BlogBeginingBlogPostAgent/BlogBeginingBlogPostAgent.tsx
@@ -3,6 +3,7 @@ import "@/styles/globals.css";
 import Button from "@/components/common/Button";
 import Image from "next/image";
 import BlogContent from "@/components/Blog/BlockContent";
+import Link from "next/link";
 import { formatDate } from "@/utils/helper";
 
 const BlogBeginningBlogPostAgent = ({ blog }: { blog: Record<string, any> }) => {
@@ -35,16 +36,18 @@ const BlogBeginningBlogPostAgent = ({ blog }: { blog: Record<string, any> }) => 
               <p className="text-[#495057] roboto text-sm font-normal mt-5">
                 <b className="text-[#495057] tahoma">{blog?.author?.name}</b>
                 <br />
-                Birmingham, AL
+                {blog?.author?.location || ""}
                 <br />
                 <b className="text-[#495057]">
-                  Active Duty Army
+                  {blog?.author?.military_status || ""}
                   <br />
-                  Lokation Real Estate
+                  {blog?.author?.brokerage || ""}
                 </b>
               </p>
               <div>
-                <Button buttonText="Get in Touch" />
+                <Link href={`/${blog?.author?.slug}`}>
+                  <Button buttonText="Get in Touch" />
+                </Link>
               </div>
             </div>
           </div>

--- a/components/ContactAgents/OptionalInformationForBuyer.tsx
+++ b/components/ContactAgents/OptionalInformationForBuyer.tsx
@@ -70,7 +70,7 @@ const OptionalInformationForBuyer = ({ onSubmit, shouldSubmit }: ContactFormProp
     <div className="md:py-12 py-4 md:px-0 px-5">
       <div className="md:w-[456px] mx-auto my-10">
         <form onSubmit={handleSubmit(onSubmitHandler)}>
-          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' />
+          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' readOnly />
           <div className="flex flex-col gap-8">
             <div className="md:text-left text-center">
               <h1 className="text-[#7E1618] tahoma lg:text-[32px] md:text-[32px] sm:text-[24px] text-[24px] font-bold leading-8">

--- a/components/ContactLender/ContactLender.tsx
+++ b/components/ContactLender/ContactLender.tsx
@@ -144,7 +144,7 @@ const ContactForm: React.FC<ContactFormProps> = ({ onSubmit }) => {
     <div className="md:py-12 py-4 md:px-0 px-5">
       <div className="md:w-[456px] mx-auto my-10">
         <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' />
+          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' readOnly />
           <div className="flex flex-col gap-8">
             <div className="md:text-left text-center">
               <h1 className="text-[#7E1618] tahoma lg:text-[32px] md:text-[32px] sm:text-[24px] text-[24px] font-bold leading-8">

--- a/components/GetListedAgents/AgentInfo.tsx
+++ b/components/GetListedAgents/AgentInfo.tsx
@@ -132,7 +132,7 @@ const AgentInfo = ({ onSubmit, onBack, shouldSubmit }: ContactFormProps) => {
     <div className="md:py-12 py-4 md:px-0 px-5">
       <div className="md:w-[456px] mx-auto my-10">
         <form onSubmit={handleSubmit(onSubmitHandler)}>
-          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' />
+          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' readOnly />
           <div className="flex flex-col gap-8">
             <div className="md:text-left text-center">
               <h1 className="text-[#7E1618] tahoma lg:text-[32px] md:text-[32px] sm:text-[24px] text-[24px] font-bold leading-8">

--- a/components/GetListedLenders/MortgageCompanyInfo.tsx
+++ b/components/GetListedLenders/MortgageCompanyInfo.tsx
@@ -145,7 +145,7 @@ const MortgageCompanyInfo = ({ onSubmit, onBack, shouldSubmit }: ContactFormProp
     <div className="md:py-12 py-4 md:px-0 px-5">
       <div className="md:w-[456px] mx-auto my-10">
         <form onSubmit={handleSubmit(onFormSubmit)}>
-          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' />
+          <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' readOnly />
           <div className="flex flex-col gap-8">
             <div className="md:text-left text-center">
               <h1 className="text-[#7E1618] tahoma lg:text-[32px] md:text-[32px] sm:text-[24px] text-[24px] font-bold leading-8">

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Link from "next/link";
 import "@/styles/globals.css";
 
 interface ButtonProps {

--- a/components/homepage/KeepInTouch/KeepInTouch.tsx
+++ b/components/homepage/KeepInTouch/KeepInTouch.tsx
@@ -151,7 +151,7 @@ const KeepInTouch = () => {
           <div className="mt-5 lg:mt-0 md:mt-0 sm:mt-5">
             <div className={classes.CustomResponsiveCenter}>
               <form onSubmit={handleSubmit(handleFormSubmission)}>
-                <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' />
+                <input className="hidden" id="captcha_settings" value='{"keyname":"vpcs_next_website","fallback":"true","orgId":"00D4x000003yaV2","ts":""}' readOnly />
                 <h2 className="lg:text-[36px] sm:text-[25px] text-[25px] poppins font-bold text-[#292F6C] lg:text-left md:text-left sm:text-center text-center">
                   Keep In Touch
                 </h2>

--- a/sanity/schemas/author.ts
+++ b/sanity/schemas/author.ts
@@ -12,16 +12,25 @@ export default defineType({
     }),
     defineField({
       name: 'slug',
-      title: 'Slug',
+      title: 'Salesforce Contact Form Parameters',
       type: 'slug',
-      options: {
-        source: 'name',
-        maxLength: 96,
-      },
+      description: 'e.g. contact-agent?form=agent&agent=Jason&id=0014x00000HWTqI&state=colorado'
     }),
     defineField({
-      name: 'designation',
-      title: 'Designation',
+      name: 'military_status',
+      title: 'Military Status and Affiliation',
+      type: 'string',
+      description: 'e.g. Active Duty Air Force, Army Veteran, Military Spouse, Retired Navy, etc.',
+    }),
+    defineField({
+      name: 'location',
+      title: 'Location',
+      type: 'string',
+      description: 'e.g. San Diego, CA',
+    }),
+    defineField({
+      name: 'brokerage',
+      title: 'Brokerage',
       type: 'string',
     }),
     defineField({

--- a/services/blogService.tsx
+++ b/services/blogService.tsx
@@ -57,7 +57,10 @@ const blogService = {
                               author->{
                                 _id,
                                 name,
-                                designation,
+                                military_status,
+                                "slug": slug.current,
+                                location,
+                                brokerage,
                                 "image": image.asset->url // Fetch author's image URL
                               },
                               categories[]->{


### PR DESCRIPTION
Adds new fields to the author schema to match the contact section of the blog post. The new fields are military_status, location, and brokerage. The military_status field is a string that represents the author's military status and affiliation. The location field is a string that represents the author's location. The brokerage field is a string that represents the author's brokerage.