### PR TITLE
Filter out agents/lenders without a photo.

### DIFF
--- a/services/stateService.tsx
+++ b/services/stateService.tsx
@@ -144,13 +144,16 @@ const stateService = {
                 agent.PhotoUrl = photoResponse;
               } catch (error) {
                 console.error(`Error fetching photo URL for agent ${agent.AccountId_15__c}:`, error);
+                agent.PhotoUrl = undefined;
               }
             }
             return agent;
           })
         );
 
-        return { ...response.data, records: recordsWithUpdatedPhotoUrl } as AgentsData;
+        const filterAgentsWithOutPhotos = recordsWithUpdatedPhotoUrl.filter((agent: Agent) => agent.PhotoUrl !== undefined);
+
+        return { ...response.data, records: filterAgentsWithOutPhotos } as AgentsData;
       } else if (response?.status === 401) {
         // Token expired: Refresh and retry
         try {
@@ -193,13 +196,17 @@ const stateService = {
                 // agent.PhotoUrl = photoResponse?.data; // Ensure fallback to original URL
               } catch (error) {
                 console.error(`Error fetching photo URL for agent ${agent.AccountId_15__c}:`, error);
+                agent.PhotoUrl = undefined;
               }
             }
             return agent;
           })
         );
 
-        return { ...response.data, records: recordsWithUpdatedPhotoUrl } as LendersData;
+        const filterAgentsWithOutPhotos = recordsWithUpdatedPhotoUrl.filter((agent: Agent) => agent.PhotoUrl !== undefined);
+
+        return { ...response.data, records: filterAgentsWithOutPhotos } as LendersData;
+
       } else if (response?.status === 401) {
         try {
           await getSalesforceToken();


### PR DESCRIPTION
In some cases, an agent/lender is marked as active on the website before the photo is available.
Filtering out the agent/lenders without a photo will prevent the website from displaying a broken image icon for that agent.