### PR TITLE
Update area assignments to filter by state.

### DIFF
--- a/components/ContactAgents/ContactAgent.tsx
+++ b/components/ContactAgents/ContactAgent.tsx
@@ -4,7 +4,6 @@ import { useForm, SubmitHandler } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import ReCAPTCHA from 'react-google-recaptcha';
-import { set } from "sanity";
 
 export interface FormData {
   firstName: string;

--- a/services/stateService.tsx
+++ b/services/stateService.tsx
@@ -53,6 +53,7 @@ export interface Agent {
       Name: string;
       Area__r: {
         Name: string;
+        State__c: string;
       };
     }[];
   };
@@ -121,7 +122,7 @@ const stateService = {
       const query = `
         SELECT Name, PhotoUrl, AccountId_15__c, FirstName, Agent_Bio__pc, Military_Status__pc,
               Military_Service__pc, Brokerage_Name__pc, BillingCity, BillingState,
-              (SELECT Id, Name, Area__r.Name FROM Area_Assignments__r)
+              (SELECT Id, Name, Area__r.Name, Area__r.State__c FROM Area_Assignments__r)
         FROM Account
         WHERE isAgent__pc = true
           AND Active_on_Website__pc = true


### PR DESCRIPTION
Previously area assignments only returned the first record. This meant that agents assigned to multiple areas within a state would only be listed under the first area. This change filters the area assignments to only include areas within the current state, and then groups agents by each area.
Additionally, agents assigned to multiple states could have an area assignment from another state listed under the current state.
This change filters the area assignments to only include areas within the current state and ignores agents without an assigned area.