### PR TITLE
Hide NMLS and Brokerage info when Company NMLS ID is not available.

### DIFF
--- a/components/StatePage/StatePageCityAgents/StatePageCityAgents.tsx
+++ b/components/StatePage/StatePageCityAgents/StatePageCityAgents.tsx
@@ -78,7 +78,7 @@ const StatePageCityAgents = ({ city, agent_data, state }: Props) => {
                     </h3>
                     <div className="text-[#6C757D] tahoma lg:text-[18px] md:text-[18px] sm:text-[10px] text-[10px] font-normal sm:mt-4 mt-0">
                       <p>
-                        {`${agent.BillingAddress?.city ? toTitleCase(agent.BillingAddress?.city) : ""}, ${agent.BillingAddress?.state}`}
+                        {`${agent.BillingAddress?.city ? toTitleCase(agent.BillingAddress?.city) + "," : ""} ${agent.BillingAddress?.state}`}
                       </p>
                       <p className="font-bold">
                         {orderMilitaryServiceInfo(agent?.Military_Status__pc || "", agent?.Military_Service__pc || "")}

--- a/components/StatePage/StatePageCityAgents/StatePageCityAgents.tsx
+++ b/components/StatePage/StatePageCityAgents/StatePageCityAgents.tsx
@@ -4,10 +4,11 @@ import Image from "next/image";
 import Button from "@/components/common/Button";
 import Link from "next/link";
 import orderMilitaryServiceInfo from "@/utils/getMilitaryServiceInfo";
+import { Agent } from "@/services/stateService";
 
 type Props = {
   city: string;
-  agent_data: AgentData[];
+  agent_data: Agent[];
   state: string;
 };
 
@@ -25,8 +26,18 @@ export type AgentData = {
   Brokerage_Name__pc: string;
 };
 
-const StatePageCityAgents = ({ city, agent_data, state }: Props) => {
+function toTitleCase(str: string): string {
+  if (!str) return "";
 
+  return str
+    .toLowerCase()
+    .split(" ")
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+const StatePageCityAgents = ({ city, agent_data, state }: Props) => {
+  console.log(agent_data);
   return (
     // <div id={city.replace(/\s+/g, "-").toLowerCase()}>
     <div id={city.toLowerCase().split(" ").join("-")}>
@@ -67,7 +78,7 @@ const StatePageCityAgents = ({ city, agent_data, state }: Props) => {
                     </h3>
                     <div className="text-[#6C757D] tahoma lg:text-[18px] md:text-[18px] sm:text-[10px] text-[10px] font-normal sm:mt-4 mt-0">
                       <p>
-                        {agent?.BillingCity ? `${agent?.BillingCity, agent?.BillingState}` : agent?.BillingState ? agent?.BillingState : ""}
+                        {`${agent.BillingAddress?.city ? toTitleCase(agent.BillingAddress?.city) : ""}, ${agent.BillingAddress?.state}`}
                       </p>
                       <p className="font-bold">
                         {orderMilitaryServiceInfo(agent?.Military_Status__pc || "", agent?.Military_Service__pc || "")}

--- a/components/StatePage/StatePageVaLoan/StatePageVaLoan.tsx
+++ b/components/StatePage/StatePageVaLoan/StatePageVaLoan.tsx
@@ -52,8 +52,12 @@ const StatePageVaLoan = ({ cityName, lendersData, state }: { cityName: string, l
                         {orderMilitaryServiceInfo(lender?.Military_Status__pc || "", lender?.Military_Service__pc || "")}
                       </p>
                       <p>NMLS: {lender.Individual_NMLS_ID__pc}</p>
-                      <p>{lender.Brokerage_Name__pc}</p>
-                      <p>NMLS: {lender.Company_NMLS_ID__pc}</p>
+                      {lender.Company_NMLS_ID__pc &&
+                        <>
+                          <p>{lender.Brokerage_Name__pc}</p>
+                          <p>NMLS: {lender.Company_NMLS_ID__pc}</p>
+                        </>
+                      }
                     </div>
                     <div className="relative">
                       {/* Hidden checkbox to track toggle state */}

--- a/services/stateService.tsx
+++ b/services/stateService.tsx
@@ -42,8 +42,10 @@ export interface Agent {
   Military_Status__pc: string;
   Military_Service__pc: string;
   Brokerage_Name__pc: string;
-  BillingCity?: string | null;
-  BillingState: string;
+  BillingAddress: {
+    city?: string;
+    state: string;
+  };
   BillingStateCode: string;
   State_s_Licensed_in__pc: string;
   Other_States__pc?: string[]; // INCLUDES can return an array
@@ -121,7 +123,7 @@ const stateService = {
     try {
       const query = `
         SELECT Name, PhotoUrl, AccountId_15__c, FirstName, Agent_Bio__pc, Military_Status__pc,
-              Military_Service__pc, Brokerage_Name__pc, BillingCity, BillingState,
+              Military_Service__pc, Brokerage_Name__pc, BillingAddress,
               (SELECT Id, Name, Area__r.Name, Area__r.State__c FROM Area_Assignments__r)
         FROM Account
         WHERE isAgent__pc = true


### PR DESCRIPTION
Corrects minor UI issue where the Brokerage Name and NMLS ID were displayed even when the Company NMLS ID was not available.
Also fixes minor UI issue where a comma was displayed before state on the agent cards even when city is not present.