### PR TITLE
feat: add limit prop to CommonBlog and fetchBlogsByComponent for PCS Help section

### DIFF
--- a/app/(site)/pcs-resources/page.tsx
+++ b/app/(site)/pcs-resources/page.tsx
@@ -92,7 +92,7 @@ export default function PcsResourcesPage() {
       />
       <PcsResourcesCalculators />
       <BAHCalculator />
-      <CommonBlog component="PCS Help" />
+      <CommonBlog component="PCS Help" limit={3} />
       <PcsResourcesHowDoesWork />
       <MovingBonusCalculator />
       <FamilySupport />

--- a/components/BlogPage/BlogPage/BlogCTA/CommonBlog.tsx
+++ b/components/BlogPage/BlogPage/BlogCTA/CommonBlog.tsx
@@ -29,11 +29,11 @@ export interface Category {
     title: string;
 }
 
-const CommonBlog = async ({ component }: { component: string }) => {
+const CommonBlog = async ({ component, limit }: { component: string; limit?: number }) => {
     let blogList: BlogDetails[] = [];
 
     try {
-        blogList = await blogService.fetchBlogsByComponent(component);
+        blogList = await blogService.fetchBlogsByComponent(component, limit);
     } catch (error) {
         console.error("Error fetching blogs", error);
     }

--- a/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx
+++ b/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx
@@ -27,11 +27,11 @@ const MovingBonusCalculator = () => {
             return 1000;
         } else if (value >= 400000 && value <= 499999) {
             return 1200;
-        } else if (value >= 500000 && value <= 599999) {
+        } else if (value >= 500000 && value <= 649999) {
             return 1500;
-        } else if (value >= 600000 && value <= 749999) {
+        } else if (value >= 650000 && value <= 799999) {
             return 2000;
-        } else if (value >= 750000 && value <= 999999) {
+        } else if (value >= 800000 && value <= 999999) {
             return 3000;
         } else { // $1,000,000+
             return 4000;

--- a/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx
+++ b/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx
@@ -103,10 +103,10 @@ const MovingBonusCalculator = () => {
                             <div className="flex-1">
                                 {/* Header */}
                                 <div className="mb-8">
-                                    <h2 className="text-[#27306d] font-bold text-2xl lg:text-3xl mb-2 font-['Tahoma,sans-serif']">
+                                    <h2 className="text-[#27306d] font-bold text-2xl lg:text-3xl mb-2 tahoma">
                                         Estimated <span className="font-normal">Veteran</span>PCS Bonus
                                     </h2>
-                                    <p className="text-[#231f20] text-sm font-['Tahoma,sans-serif']">
+                                    <p className="text-[#231f20] text-sm tahoma">
                                         Adjust the slider to see your estimated Move-In-Bonus! Are you a Veteran? See if you qualify today!
                                     </p>
                                 </div>
@@ -132,7 +132,7 @@ const MovingBonusCalculator = () => {
                                 <div className="flex flex-col md:grid md:grid-cols-3 gap-6 md:items-center">
                                     {/* Home Price Input */}
                                     <div>
-                                        <label className="block text-[#231f20] text-sm mb-2 font-['Tahoma,sans-serif']">
+                                        <label className="block text-[#231f20] text-sm mb-2 tahoma">
                                             Home Price
                                         </label>
                                         <input
@@ -140,16 +140,16 @@ const MovingBonusCalculator = () => {
                                             value={homeValue === 0 ? '' : formatCurrency(homeValue)}
                                             onChange={handleInputChange}
                                             placeholder="$0"
-                                            className="w-full px-3 py-2 border border-gray-300 rounded text-[#231f20] text-sm font-['Tahoma,sans-serif']"
+                                            className="w-full px-3 py-2 border border-gray-300 rounded text-[#231f20] text-sm tahoma"
                                         />
                                     </div>
 
                                     {/* Move-In-Bonus Display */}
                                     <div className="text-center md:text-center">
-                                        <p className="text-[#231f20] text-sm mb-1 font-['Tahoma,sans-serif']">
+                                        <p className="text-[#231f20] text-sm mb-1 tahoma">
                                             Move-In-Bonus
                                         </p>
-                                        <p className="text-[#27306d] font-bold text-2xl font-['Tahoma,sans-serif']">
+                                        <p className="text-[#27306d] font-bold text-2xl tahoma">
                                             {formatCurrency(movingBonus)}
                                         </p>
                                     </div>
@@ -170,7 +170,7 @@ const MovingBonusCalculator = () => {
 
                     {/* Disclaimer */}
                     <div className="mt-8 text-center">
-                        <p className="text-gray-500 text-sm max-w-2xl mx-auto font-['Tahoma,sans-serif']">
+                        <p className="text-gray-500 text-sm max-w-2xl mx-auto tahoma">
                             * Bonus amounts are estimates and may vary based on final purchase price and actual commission rates.
                         </p>
                     </div>

--- a/components/TermsOfUse/TermsOfUse.tsx
+++ b/components/TermsOfUse/TermsOfUse.tsx
@@ -923,7 +923,7 @@ const ContactForm = () => {
                 </tr>
                 <tr className="border">
                   <td className="text-[#000000] roboto p-3">
-                    <b>$500,000 – $599,999</b>
+                    <b>$500,000 – $649,999</b>
                   </td>
                   <td className="text-[#000000] roboto font-normal leading-8 p-3">
                     $1,500
@@ -934,7 +934,7 @@ const ContactForm = () => {
                 </tr>
                 <tr className="border">
                   <td className="text-[#000000] roboto p-3">
-                    <b>$600,000 – $749,999</b>
+                    <b>$650,000 – $799,999</b>
                   </td>
                   <td className="text-[#000000] roboto font-normal leading-8 p-3">
                     $2,000
@@ -945,7 +945,7 @@ const ContactForm = () => {
                 </tr>
                 <tr className="border">
                   <td className="text-[#000000] roboto p-3">
-                    <b>$750,000 – $999,999</b>
+                    <b>$800,000 – $999,999</b>
                   </td>
                   <td className="text-[#000000] roboto font-normal leading-8 p-3">
                     $3,000


### PR DESCRIPTION
- Updated `CommonBlog` component to accept an optional `limit` prop.
- Modified `blogService.fetchBlogsByComponent` to support limiting the number of blogs returned.
- Updated PCS Resources page to show only 3 "PCS Help" blogs by passing `limit={3}` to `CommonBlog`.