### PR TITLE
Add state-based OpenPhone routing and admin mapping for contact forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,30 @@ VeteranPCS is a NextJS-based web application designed to connect military person
 
 ### Server Action: `sendOpenPhoneMessage`
 
-- **Description**: Sends SMS messages via OpenPhone API.
+- **Description**: Sends SMS messages via OpenPhone API with state-based routing.
 - **Parameters**:
   - `content`: string - Message content
-  - `from`: string - Sender phone number
+  - `from`: string - Sender phone number (automatically routed based on state)
   - `to`: string[] - Array of recipient phone numbers
 - **Response**: OpenPhone API response data
 - **Authentication**: Requires OpenPhone API key
 - **Side Effects**: Sends SMS messages to recipients
+- **State Routing**: Automatically selects admin phone number based on agent/lender state
+
+---
+
+### Service: `stateRoutingService`
+
+- **Description**: Routes OpenPhone messages to appropriate admin phone numbers based on state.
+- **Admin Assignments**:
+  - **Beth (719-249-5359)**: Alaska, Arizona, California, Colorado, Hawaii, Idaho, Iowa, Kansas, Missouri, Montana, Nebraska, Nevada, New Mexico, North Dakota, Oregon, South Dakota, Utah, Washington, Wyoming
+  - **Jessica (719-782-5065)**: Alabama, Arkansas, Florida, Georgia, Kentucky, Louisiana, Mississippi, North Carolina, Oklahoma, South Carolina, Tennessee, Texas
+  - **Stephanie (719-249-4757)**: Connecticut, Delaware, Illinois, Indiana, Maine, Maryland, Massachusetts, Michigan, Minnesota, New Hampshire, New Jersey, New York, Ohio, Pennsylvania, Rhode Island, Vermont, Virginia, West Virginia, Wisconsin, Washington D.C., Puerto Rico
+- **Functions**:
+  - `getAdminContactForState(state)`: Returns admin contact info for a state
+  - `getAdminPhoneNumberForState(state)`: Returns admin phone number for a state
+  - `getStatesByAdmin(adminKey)`: Returns all states managed by an admin
+- **Fallback**: Uses `OPEN_PHONE_FROM_NUMBER` for unmapped or missing states
 
 ---
 

--- a/services/salesForcePostFormsService.tsx
+++ b/services/salesForcePostFormsService.tsx
@@ -5,6 +5,7 @@ import { formatPhoneNumberForDisplay, formatPhoneNumberE164 } from '@/utils/form
 import stateService from '@/services/stateService';
 import { logDebug, logError, logInfo } from './loggingService';
 import { FormSubmissionStatus, trackFormSubmission, updateSubmissionStatus } from './formTrackingService';
+import { getAdminPhoneNumberForState } from '@/services/stateRoutingService';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 const OPEN_PHONE_FROM_NUMBER = process.env.OPEN_PHONE_FROM_NUMBER || "";
@@ -144,7 +145,7 @@ Phone: ${formatPhoneNumberForDisplay(formData.phone)}
 ${formData.currentBase ? `Current Base: ${formData.currentBase}` : ''}
 ${formData.destinationBase ? `Destination Base: ${formData.destinationBase}` : ''}
 ${formData.additionalComments ? `Additional Comments: ${formData.additionalComments}` : ''}`,
-                from: OPEN_PHONE_FROM_NUMBER,
+                from: getAdminPhoneNumberForState(paramsObj.state),
                 to: [formatPhoneNumberE164(agentInfo?.PersonMobilePhone || OPEN_PHONE_FROM_NUMBER)]
             })
         ]).catch(error => {
@@ -591,7 +592,7 @@ Phone: ${formatPhoneNumberForDisplay(formData.phone)}
 ${formData.currentBase ? `Current Base: ${formData.currentBase}` : ''}
 ${formData.destinationBase ? `Destination Base: ${formData.destinationBase}` : ''}
 ${formData.additionalComments ? `Additional Comments: ${formData.additionalComments}` : ''}`,
-                from: OPEN_PHONE_FROM_NUMBER,
+                from: getAdminPhoneNumberForState(paramsObj.state),
                 to: [formatPhoneNumberE164(agentInfo?.PersonMobilePhone || OPEN_PHONE_FROM_NUMBER)]
             })
         ]).catch(error => {

--- a/services/stateRoutingService.ts
+++ b/services/stateRoutingService.ts
@@ -1,0 +1,141 @@
+/**
+ * State-based OpenPhone routing service
+ * Maps states to appropriate admin phone numbers for contact form notifications
+ */
+
+export interface AdminContact {
+    name: string;
+    phoneNumber: string;
+}
+
+// Admin contact information
+export const ADMIN_CONTACTS = {
+    BETH: {
+        name: 'Beth',
+        phoneNumber: process.env.BETH_PHONE_NUMBER || '+17192495359',
+    },
+    JESSICA: {
+        name: 'Jessica',
+        phoneNumber: process.env.JESSICA_PHONE_NUMBER || '+17197825065',
+    },
+    STEPHANIE: {
+        name: 'Stephanie',
+        phoneNumber: process.env.STEPHANIE_PHONE_NUMBER || '+17192494757',
+    },
+} as const;
+
+// State-to-admin mapping based on provided chart
+const STATE_TO_ADMIN_MAP: Record<string, keyof typeof ADMIN_CONTACTS> = {
+    // Beth's states
+    'alaska': 'BETH',
+    'arizona': 'BETH',
+    'california': 'BETH',
+    'colorado': 'BETH',
+    'hawaii': 'BETH',
+    'idaho': 'BETH',
+    'iowa': 'BETH',
+    'kansas': 'BETH',
+    'missouri': 'BETH',
+    'montana': 'BETH',
+    'nebraska': 'BETH',
+    'nevada': 'BETH',
+    'new-mexico': 'BETH',
+    'north-dakota': 'BETH',
+    'oregon': 'BETH',
+    'south-dakota': 'BETH',
+    'utah': 'BETH',
+    'washington': 'BETH',
+    'wyoming': 'BETH',
+
+    // Jessica's states
+    'alabama': 'JESSICA',
+    'arkansas': 'JESSICA',
+    'florida': 'JESSICA',
+    'georgia': 'JESSICA',
+    'kentucky': 'JESSICA',
+    'louisiana': 'JESSICA',
+    'mississippi': 'JESSICA',
+    'north-carolina': 'JESSICA',
+    'oklahoma': 'JESSICA',
+    'south-carolina': 'JESSICA',
+    'tennessee': 'JESSICA',
+    'texas': 'JESSICA',
+
+    // Stephanie's states
+    'connecticut': 'STEPHANIE',
+    'delaware': 'STEPHANIE',
+    'illinois': 'STEPHANIE',
+    'indiana': 'STEPHANIE',
+    'maine': 'STEPHANIE',
+    'maryland': 'STEPHANIE',
+    'massachusetts': 'STEPHANIE',
+    'michigan': 'STEPHANIE',
+    'minnesota': 'STEPHANIE',
+    'new-hampshire': 'STEPHANIE',
+    'new-jersey': 'STEPHANIE',
+    'new-york': 'STEPHANIE',
+    'ohio': 'STEPHANIE',
+    'pennsylvania': 'STEPHANIE',
+    'rhode-island': 'STEPHANIE',
+    'vermont': 'STEPHANIE',
+    'virginia': 'STEPHANIE',
+    'west-virginia': 'STEPHANIE',
+    'wisconsin': 'STEPHANIE',
+    'washington-dc': 'STEPHANIE',
+    'puerto-rico': 'STEPHANIE',
+};
+
+/**
+ * Get the appropriate admin phone number for a given state
+ * @param state - State in lowercase with hyphens (e.g., "new-hampshire")
+ * @returns Admin contact information
+ */
+export function getAdminContactForState(state?: string): AdminContact {
+    // Fallback to default if no state provided
+    if (!state) {
+        console.warn('No state provided for OpenPhone routing, using fallback number');
+        return {
+            name: 'Default',
+            phoneNumber: process.env.OPEN_PHONE_FROM_NUMBER || '719-249-5359',
+        };
+    }
+
+    // Normalize state string
+    const normalizedState = state.toLowerCase().trim();
+
+    // Get admin for this state
+    const adminKey = STATE_TO_ADMIN_MAP[normalizedState];
+
+    if (!adminKey) {
+        console.warn(`No admin mapping found for state: ${state}, using fallback number`);
+        return {
+            name: 'Default',
+            phoneNumber: process.env.OPEN_PHONE_FROM_NUMBER || '719-249-5359',
+        };
+    }
+
+    const adminContact = ADMIN_CONTACTS[adminKey];
+    console.log(`OpenPhone routing: ${state} -> ${adminContact.name} (${adminContact.phoneNumber})`);
+
+    return adminContact;
+}
+
+/**
+ * Get admin phone number for a state (simplified interface)
+ * @param state - State in lowercase with hyphens
+ * @returns Phone number string
+ */
+export function getAdminPhoneNumberForState(state?: string): string {
+    return getAdminContactForState(state).phoneNumber;
+}
+
+/**
+ * Get all states managed by a specific admin
+ * @param adminKey - Admin identifier
+ * @returns Array of state names
+ */
+export function getStatesByAdmin(adminKey: keyof typeof ADMIN_CONTACTS): string[] {
+    return Object.entries(STATE_TO_ADMIN_MAP)
+        .filter(([, admin]) => admin === adminKey)
+        .map(([state]) => state);
+} 


### PR DESCRIPTION
- Introduce `stateRoutingService` to map states to admin phone numbers for OpenPhone SMS notifications.
- Update `sendOpenPhoneMessage` usage to automatically select the correct admin phone number based on the agent/lender's state.
- Document new routing logic and admin assignments in README.
- Ensure fallback to default number for unmapped or missing states.
- Improves notification accuracy and admin workflow for inbound leads.