### PR TITLE
Update FamilySupport component usage to pass link and component_slug props

### DIFF
--- a/app/(site)/impact/page.tsx
+++ b/app/(site)/impact/page.tsx
@@ -60,7 +60,10 @@ export default function ImpactPage() {
       <YourImpact />
       <MakeAnImpact />
       <Testimonials />
-      <FamilySupport />
+      <FamilySupport
+        link="https://freedomservicedogs.org"
+        component_slug="freedom-service-dogs"
+      />
       <WearBlueSection />
       <VeteranPcsGivesBack />
       <ReviewsList />

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -35,7 +35,10 @@ export default function Home() {
       <Testimonials />
       <MovingBonusCalculator />
       <Covered />
-      <FamilySupport />
+      <FamilySupport
+        link="https://www.veteranpcs.com/impact"
+        component_slug="support-our-veteran-community"
+      />
       <VeteranPCS />
       <ReviewsList />
       <MakeItHome />

--- a/app/(site)/pcs-resources/page.tsx
+++ b/app/(site)/pcs-resources/page.tsx
@@ -95,7 +95,10 @@ export default function PcsResourcesPage() {
       <CommonBlog component="PCS Help" limit={3} />
       <PcsResourcesHowDoesWork />
       <MovingBonusCalculator />
-      <FamilySupport />
+      <FamilySupport
+        link="https://www.veteranpcs.com/impact"
+        component_slug="support-our-veteran-community"
+      />
       <FrequentlyAskedQuestion />
       <PcsResourcesEmployment />
       <ReviewsList />

--- a/app/(site)/stories/page.tsx
+++ b/app/(site)/stories/page.tsx
@@ -57,7 +57,10 @@ export default function StoriesPage() {
       <OptionSection />
       <VideoFamily />
       <Covered />
-      <FamilySupport />
+      <FamilySupport
+        link="https://www.veteranpcs.com/impact"
+        component_slug="support-our-veteran-community"
+      />
       <WhyVeteranPcs />
       <FrequentlyAskedQuestion />
       <KeepInTouch />

--- a/app/(site)/va-loan-help/page.tsx
+++ b/app/(site)/va-loan-help/page.tsx
@@ -84,7 +84,10 @@ export default function VaLoanPage() {
             <PcsResourcesCalculators />
             <CommonBlog component="VA Loan Help" />
             <PcsResourcesHowDoesWork />
-            <FamilySupport />
+            <FamilySupport
+                link="https://www.veteranpcs.com/impact"
+                component_slug="support-our-veteran-community"
+            />
             <FrequentlyAskedQuestion />
             <PcsResourcesEmployment />
             <ReviewsList />

--- a/components/homepage/FamilySupport/FamilySupport.tsx
+++ b/components/homepage/FamilySupport/FamilySupport.tsx
@@ -9,19 +9,19 @@ import { VeteranCommunityProps } from "@/components/homepage/VeteranCommunity/Ve
 
 type BlockStyle = "h1" | "h2" | "h3" | "normal";
 
-const FamilySupport = async () => {
+const FamilySupport = async ({ link, component_slug }: { link: string, component_slug: string }) => {
   let pageData: VeteranCommunityProps | null = null;
 
   try {
     pageData = await veterenceSupportService.fetchVeterenceSupport(
-      "support-our-veteran-community"
+      component_slug
     );
   } catch (error) {
     console.error("Failed to fetch Veterence Data:", error);
     return <p>Failed to load Veterence Data.</p>;
   }
 
-  const validateBlockStyle = (style: string): BlockStyle => {
+  const validateBlockStyle = (style: string | undefined): BlockStyle => {
     const validStyles: BlockStyle[] = ["h1", "h2", "h3", "normal"];
     return validStyles.includes(style as BlockStyle)
       ? (style as BlockStyle)
@@ -54,7 +54,7 @@ const FamilySupport = async () => {
               <Image
                 width={100}
                 height={150}
-                className="w-auto h-auto min-w-64"
+                className={component_slug === "freedom-service-dogs" ? "w-auto h-auto min-w-64" : "hidden md:block w-auto h-auto lg:min-w-32 min-w-32"}
                 src={pageData?.icon?.asset?.image_url || "/icon/userplus.svg"}
                 alt={pageData?.icon?.alt || "Description of the image"}
               />
@@ -104,7 +104,7 @@ const FamilySupport = async () => {
             </div>
 
             <Link
-              href="https://freedomservicedogs.org"
+              href={link}
               className="flex lg:justify-start md:justify-start sm:justify-center justify-center items-center"
             >
               <Button buttonText={pageData?.button_text || "Learn More"} />

--- a/components/homepage/FamilySupport/SupportContent.tsx
+++ b/components/homepage/FamilySupport/SupportContent.tsx
@@ -7,8 +7,8 @@ interface Child {
 }
 
 interface Block {
-  children?: Child[]; 
-  style: "h1" | "h2" | "h3" | "normal"; 
+  children?: Child[];
+  style: "h1" | "h2" | "h3" | "normal";
 }
 
 interface TextSpanProps {
@@ -24,9 +24,9 @@ const TextSpan: React.FC<TextSpanProps> = ({ child }) => {
     </React.Fragment>
   ));
 
-  if (child.marks.includes("strong")) {
+  if (child.marks && child.marks.includes("strong")) {
     return <strong className="font-bold">{formattedText}</strong>;
-  } else if (child.marks.includes("em")) {
+  } else if (child.marks && child.marks.includes("em")) {
     return <em className="italic">{formattedText}</em>;
   }
 


### PR DESCRIPTION
- Modified all usages of <FamilySupport /> to explicitly pass `link` and `component_slug` props.
- Ensures each page provides the correct URL and slug for the FamilySupport section.
- Improves clarity and flexibility for the FamilySupport component across pages.