### PR TITLE
Phase 2: Concierge widget gated behind feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ docs/migration
 
 # blog migration raw dumps (recon)
 /docs/blog-migration/raw
+
+# AI-first project journal — local only
+docs/ai-first/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# CLAUDE.md — VeteranPCS
+
+Operational guide for Claude (and any other AI assistant) working in this repo. Keep this short and load-bearing; long-form context lives in `docs/ai-first/PROJECT.md`.
+
+> See [docs/ai-first/PROJECT.md](docs/ai-first/PROJECT.md) for the AI-first reimagining: phase status, key decisions, bugs fixed, and what's next.
+
+## What this product is
+
+VeteranPCS is a Next.js site that connects active-duty service members, veterans, and military spouses doing a PCS (Permanent Change of Station) move to vetted, military-experienced real estate agents and VA-loan lenders. The site is read-mostly marketing surface (state pages, blog) plus form-driven lead capture; Phase 2 is layering an LLM concierge on top of that.
+
+- Source of truth for agents/lenders/customers/deals: **Salesforce** (Person Account model with `__pc` custom fields; Customer `RecordTypeId = '0124x000000Z7G3AAK'`).
+- Source of truth for marketing content (states, blog, headshots, copy): **Sanity CMS** + `public/images/`.
+- Lead intake: server actions → Salesforce REST + Slack notification + OpenPhone SMS.
+
+## Tech stack
+
+- **Framework:** Next.js 16 App Router (Turbopack), React 19.2, Node runtime.
+- **CMS:** Sanity (`next-sanity`, GROQ). Studio mounted at `/studio`.
+- **CRM:** Salesforce REST (SOQL); token retrieval via `services/salesForceTokenService.tsx`, queries via `services/api.tsx` + `services/stateService.tsx`.
+- **AI:** Vercel AI SDK v6 (`ai`, `@ai-sdk/react`) routed through **Vercel AI Gateway** (model id `anthropic/claude-sonnet-4-6` in `lib/ai/models.ts`). No direct provider SDK is wired up — use the Gateway.
+- **Rate limit + bot defense:** `@upstash/ratelimit` + Upstash Redis, `botid` (Vercel BotID), both applied in `app/api/chat/route.ts`.
+- **Notifications:** Slack webhook (`actions/sendToSlack.ts`), OpenPhone SMS (`actions/sendOpenPhoneMessage.ts`). No Resend on this branch.
+- **Test runner:** Vitest 3 (Node env, `**/__tests__/**/*.test.ts`). Pre-commit does NOT run tests yet — run `npm test` before pushing AI-touching changes.
+- **Hosting:** Vercel. Use `vercel env` for env management. Prefer Fluid Compute defaults; do not assume edge runtime.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `npm run dev` | Next dev server at `http://127.0.0.1:3000` |
+| `npm run build` | Production build (runs in pre-commit hook) |
+| `npm run lint` | ESLint (pre-commit) |
+| `npm run type-check` | `tsc --noEmit` (pre-commit) |
+| `npm test` | Vitest one-shot |
+| `npm run test:watch` | Vitest watch mode |
+
+Pre-commit hook (`.husky/pre-commit`) runs `lint && type-check && build`. **It does not run tests** — run `npm test` manually for AI/scraper changes. Never use `--no-verify` to bypass it unless the user explicitly asks.
+
+## Repo layout
+
+```
+app/
+  (site)/              marketing pages (homepage, about, partners, etc.)
+  [state]/             state landing pages (SSR from Sanity + Salesforce)
+  blog/                MDX-driven blog
+  studio/              Sanity Studio
+  api/
+    chat/              concierge streaming endpoint (Phase 2)
+    v1/                public REST: areas, bah, impact, revalidate
+    mcp/               MCP server entry
+lib/
+  ai/                  concierge: models.ts, session.ts, system-prompt.ts, tools/
+  bah-scraper.ts       DTMO BAH lookup (see "BAH year format" gotcha)
+  feature-flags.ts     NEXT_PUBLIC_CONCIERGE_ENABLED + future gates
+  email.ts             (legacy on other branches; not wired here)
+services/
+  stateService.tsx     Sanity state list + Salesforce agent/lender fetch
+  agentService.tsx     agent detail
+  api.tsx              SOQL builder + REST wrappers
+  salesForceTokenService.tsx
+  loggingService.tsx
+actions/               server actions (Slack, OpenPhone, form submits)
+components/
+  Concierge/           Phase 2 widget (Provider, Widget, MessageRenderer, cards)
+  Forms/               lead-capture forms
+sanity/                Studio config + schemas
+scripts/               Node scripts (audits, ingest, headshot classify, etc.)
+emails/                React Email templates (other branches; unused here)
+docs/
+  ai-first/PROJECT.md  AI-first journal — read this for current goals/status
+  REVERSION-PLAN.md    why we stayed on Salesforce (vs. the Attio migration)
+  salesforce-schema/   Salesforce field reference
+```
+
+## Conventions and gotchas
+
+### Salesforce / SOQL
+
+- Customer queries **must** filter `WHERE RecordTypeId = '0124x000000Z7G3AAK'`. Person Account fields use the `__pc` suffix (`Current_location__pc`, `Military_Status__pc`, `Have_you_personally_PCS_d__pc`, etc.).
+- Role flags are booleans: `isAgent__pc`, `isLender__pc`, `isCustomer__pc`.
+- License-state filters use **2-letter codes**, not full names: `State_s_Licensed_in__pc LIKE '%TX%' OR Other_States__pc INCLUDES ('TX')`.
+- `stateService.fetchAgentsListByState` / `fetchLendersListByState` expect a 2-letter state code (`short_name`), **not** the full state name or slug. They accept an optional `{ requireHeadshot?: boolean }`; the concierge tools pass `false` so the LLM still gets matches when a headshot is missing, while SSR pages keep the `true` default.
+- Scripts that talk to Salesforce use **inline API helpers** (not `import { attio }`-style top-level imports) so env vars are read after `dotenv` runs.
+
+### Sanity
+
+- `state_list` documents drive state pages. The GROQ projection in `services/stateService.tsx` must include `state_name` (it was silently dropped before — see PROJECT.md "Bugs fixed").
+- Headshot routing convention: `scripts/classify-headshot-ids.mjs` plus the `public/images/agents/` vs `public/images/lenders/` folders.
+
+### Concierge (Phase 2)
+
+- Entry point: `POST /api/chat` (`app/api/chat/route.ts`). It runs BotID first, then Upstash rate-limit, then `streamText` with the tools from `lib/ai/tools/index.ts`. Errors from `streamText` are caught and returned as JSON 500 — do not let it silently fail.
+- Session: cookie `vpcs_concierge_sid`, 30-day, httpOnly, sameSite lax, secure in prod (`lib/ai/session.ts`). No DB; memory is cookie-scoped only for Phase 2.
+- Feature flag: `NEXT_PUBLIC_CONCIERGE_ENABLED` (`'1'` or `'true'`). Off by default.
+- System prompt and brand voice live in `lib/ai/system-prompt.ts`. Three words: **Trusted. Patriotic. Helpful.** No emoji, no hype, 5th–7th grade reading level.
+- Tools must never invent agents, lenders, or BAH rates — always go through the tool layer.
+
+### BAH scraper
+
+- DTMO endpoint expects a **2-digit year on the wire** (`YEAR=25`), but the rest of the app uses a 4-digit year. `lib/bah-scraper.ts` has `toDtmoYear` / `toFourDigitYear` helpers for the round trip. If you change the year handling, run `lib/__tests__/bah-scraper.test.ts`.
+- DTMO caps officer rates at `O-7/O-7+`. `lib/ai/tools/calc-tools.ts` aliases `O-8`/`O-9`/`O-10` to the same rank id.
+- The scraper exports `__testables.fetchPage` so Vitest can `vi.spyOn` it without monkey-patching `node:https`. Only import `__testables` from tests.
+
+### Forms & lead routing
+
+- Lead-capture forms write to **both** the Salesforce Person Account (Customer record type) and the appropriate Opportunity. `destination_city` and `current_location` mappings are documented in auto-memory; ask before changing them.
+- Default blog byline is `VeteranPCS`, never `The VeteranPCS Team`.
+
+### Env vars
+
+The current `ai/phase-2-concierge` branch uses:
+
+- Salesforce: `SALESFORCE_CLIENT_ID`, `SALESFORCE_CLIENT_SECRET`, `SALESFORCE_USERNAME`, `SALESFORCE_PASSWORD`, `SALESFORCE_TOKEN`, `SALESFORCE_LOGIN_BASE_URL`, `SALESFORCE_API_VERSION`, `VPCS_SALESFORCE_BASE_URL`, `SALESFORCE_WEBHOOK_SECRET`
+- Sanity: `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NEXT_PUBLIC_SANITY_DATASET`, `NEXT_PUBLIC_SANITY_API_VERSION`, `NEXT_PUBLIC_SANITY_API_TOKEN`, `SANITY_REVALIDATE_KEY`
+- AI: `AI_GATEWAY_API_KEY` (Vercel AI Gateway), `NEXT_PUBLIC_CONCIERGE_ENABLED`
+- Rate limit / bot: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` (BotID is auto-wired on Vercel)
+- Notifications: `SLACK_WEBHOOK_URL`, `OPEN_PHONE_API_KEY`, `OPEN_PHONE_FROM_NUMBER`, plus per-partner `*_PHONE_NUMBER`
+- Misc: `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID`, `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`, Google Reviews / GA4 / GSC creds
+
+No `RESEND_*` keys on this branch — transactional email is off here. Don't add Resend-based code without checking PROJECT.md first.
+
+## Working agreements
+
+- **Diagnose root cause before fixing.** Don't paper over symptoms; trace through `services/`/`lib/` until you understand why.
+- **Verify before recommending.** A memory or plan that names a file/flag may be stale; `grep` or `Read` it before suggesting it to the user.
+- **Don't bypass the pre-commit hook.** Lint, type-check, and build must pass.
+- **Tests are not in pre-commit yet.** Run `npm test` manually for changes to `lib/ai/**`, `lib/bah-scraper.ts`, or `services/**`.
+- **Use TodoWrite for non-trivial work** — branch state should always reflect a clear punch list.
+- **Force-push requires explicit per-task authorization** (don't reuse a prior session's authorization).
+- **Never commit `.env*` files or anything containing secrets.** Stage files by name rather than `git add -A`.
+- **Default blog byline:** `VeteranPCS`. Default tone everywhere user-facing: calm, direct, plain.

--- a/README.md
+++ b/README.md
@@ -513,3 +513,20 @@ All public API endpoints are versioned under `/api/v1/` to support future iterat
 - BAH calculator (`/api/v1/bah`)
 - Geographic areas lookup (`/api/v1/areas`)
 - Cache revalidation webhooks (`/api/v1/revalidate/salesforce`, `/api/v1/revalidate/sanity`)
+
+---
+
+## Utilities
+
+### Google Search Console — Blog Indexing
+
+After publishing new blog posts or updating existing ones, submit them to the Google Indexing API to prompt re-crawling:
+
+```bash
+cd ../Utilities/search-console-indexer
+node index-blog-posts.js
+```
+
+This reads all `.mdx` files from `content/blog/`, constructs their canonical URLs, and submits a `URL_UPDATED` notification for each one via the Google Indexing API. Google typically re-crawls within a few hours to two days. Verify status in Google Search Console under **URL Inspection**.
+
+> **Note:** `service-account-key.json` (required for auth) lives only in the local `Utilities/` directory and is never committed.

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,6 +1,8 @@
 import "../globals.css";
+import { BotIdClient } from "botid/client";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer/Footer"
+import { ConciergeProvider, ConciergeWidget } from "@/components/Concierge"
 
 
 export default function RootLayout({
@@ -9,10 +11,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <>
+    <ConciergeProvider>
+      <BotIdClient protect={[{ path: '/api/chat', method: 'POST' }]} />
       <Header />
       {children}
       <Footer />
-    </>
+      <ConciergeWidget />
+    </ConciergeProvider>
   );
 }

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -3,6 +3,7 @@ import { BotIdClient } from "botid/client";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer/Footer"
 import { ConciergeProvider, ConciergeWidget } from "@/components/Concierge"
+import { featureFlags } from "@/lib/feature-flags";
 
 
 export default function RootLayout({
@@ -10,13 +11,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const conciergeEnabled = featureFlags.conciergeEnabled;
   return (
     <ConciergeProvider>
-      <BotIdClient protect={[{ path: '/api/chat', method: 'POST' }]} />
+      {conciergeEnabled && <BotIdClient protect={[{ path: '/api/chat', method: 'POST' }]} />}
       <Header />
       {children}
       <Footer />
-      <ConciergeWidget />
+      {conciergeEnabled && <ConciergeWidget />}
     </ConciergeProvider>
   );
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,78 @@
+import {
+  convertToModelMessages,
+  streamText,
+  stepCountIs,
+  type UIMessage,
+} from 'ai';
+import { checkBotId } from 'botid/server';
+import { buildTools } from '@/lib/ai/tools';
+import { buildSystemPrompt, type PageContext } from '@/lib/ai/system-prompt';
+import { MODELS } from '@/lib/ai/models';
+import { getOrCreateSessionId } from '@/lib/ai/session';
+import { featureFlags } from '@/lib/feature-flags';
+import { chatLimiter } from '@/lib/rate-limit';
+import { logError } from '@/services/loggingService';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+interface ChatRequestBody {
+  messages: UIMessage[];
+  pageContext?: PageContext;
+}
+
+function clientIp(req: Request): string {
+  const fwd = req.headers.get('x-forwarded-for');
+  if (fwd) {
+    const first = fwd.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return req.headers.get('x-real-ip')?.trim() || 'anonymous';
+}
+
+export async function POST(req: Request) {
+  if (!featureFlags.conciergeEnabled) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  let body: ChatRequestBody;
+  try {
+    body = (await req.json()) as ChatRequestBody;
+  } catch (error) {
+    logError('Concierge: failed to parse request body', undefined, error);
+    return new Response('Invalid request', { status: 400 });
+  }
+
+  const verification = await checkBotId();
+  if (verification.isBot) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const limit = await chatLimiter.limit(clientIp(req));
+  if (!limit.success) {
+    const retryAfter = Math.max(1, Math.ceil((limit.reset - Date.now()) / 1000));
+    return new Response('Too many requests', {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfter) },
+    });
+  }
+
+  const { messages, pageContext } = body;
+  const [{ sessionId }, modelMessages] = await Promise.all([
+    getOrCreateSessionId(),
+    convertToModelMessages(messages),
+  ]);
+
+  const result = streamText({
+    model: MODELS.chat,
+    system: buildSystemPrompt(pageContext),
+    messages: modelMessages,
+    tools: buildTools(),
+    stopWhen: stepCountIs(12),
+    experimental_telemetry: { isEnabled: false },
+  });
+
+  return result.toUIMessageStreamResponse({
+    headers: { 'X-Session-Id': sessionId },
+  });
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -63,16 +63,24 @@ export async function POST(req: Request) {
     convertToModelMessages(messages),
   ]);
 
-  const result = streamText({
-    model: MODELS.chat,
-    system: buildSystemPrompt(pageContext),
-    messages: modelMessages,
-    tools: buildTools(),
-    stopWhen: stepCountIs(12),
-    experimental_telemetry: { isEnabled: false },
-  });
+  try {
+    const result = streamText({
+      model: MODELS.chat,
+      system: buildSystemPrompt(pageContext),
+      messages: modelMessages,
+      tools: buildTools(),
+      stopWhen: stepCountIs(12),
+      experimental_telemetry: { isEnabled: false },
+    });
 
-  return result.toUIMessageStreamResponse({
-    headers: { 'X-Session-Id': sessionId },
-  });
+    return result.toUIMessageStreamResponse({
+      headers: { 'X-Session-Id': sessionId },
+    });
+  } catch (error) {
+    logError('Concierge: streamText failed', { sessionId }, error);
+    return new Response(
+      JSON.stringify({ error: 'Concierge is temporarily unavailable.' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
 }

--- a/components/Concierge/AgentCard.tsx
+++ b/components/Concierge/AgentCard.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+export interface AgentListItem {
+  id: string;
+  name: string;
+  firstName?: string;
+  lastName?: string;
+  brokerage?: string;
+  city?: string;
+  militaryStatus?: string;
+  militaryService?: string;
+}
+
+interface Props {
+  list: AgentListItem[];
+  kind: 'agent' | 'lender';
+  onSelect?(item: AgentListItem): void;
+}
+
+export default function AgentCard({ list, kind, onSelect }: Props) {
+  if (!list || list.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
+        No matches available right now. A team member can hand-match you — just ask.
+      </div>
+    );
+  }
+
+  const label = kind === 'agent' ? 'agent' : 'lender';
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs uppercase tracking-wide text-gray-500">
+        Top {label}{list.length === 1 ? '' : 's'} for you
+      </p>
+      <ul className="flex flex-col gap-2">
+        {list.slice(0, 5).map((item) => (
+          <li
+            key={item.id}
+            className="rounded-lg border border-gray-200 bg-white p-3 flex flex-col gap-2"
+          >
+            <div className="flex flex-col">
+              <span className="text-sm font-semibold text-primary">{item.name}</span>
+              {item.brokerage ? (
+                <span className="text-xs text-gray-600">{item.brokerage}</span>
+              ) : null}
+              {item.city ? (
+                <span className="text-xs text-gray-500">{item.city}</span>
+              ) : null}
+            </div>
+            {item.militaryStatus || item.militaryService ? (
+              <div className="flex flex-wrap gap-1">
+                {item.militaryStatus ? (
+                  <span className="inline-block rounded-full bg-primary/10 text-primary text-[11px] px-2 py-0.5">
+                    {item.militaryStatus}
+                  </span>
+                ) : null}
+                {item.militaryService ? (
+                  <span className="inline-block rounded-full bg-gray-100 text-gray-700 text-[11px] px-2 py-0.5">
+                    {item.militaryService}
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+            {onSelect ? (
+              <button
+                type="button"
+                onClick={() => onSelect(item)}
+                className="mt-1 inline-flex min-h-[44px] items-center justify-center rounded-md bg-accent-red px-3 py-2 text-sm font-medium text-white motion-safe:transition-colors hover:bg-accent-red-dark"
+              >
+                Connect with {item.firstName || item.name}
+              </button>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/Concierge/BAHResult.tsx
+++ b/components/Concierge/BAHResult.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { BAHData } from '@/lib/bah-scraper';
+
+interface Props {
+  data: Partial<BAHData>;
+}
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
+
+function formatAmount(value: number | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '—';
+  }
+  return currency.format(value);
+}
+
+export default function BAHResult({ data }: Props) {
+  if (data?.isValid === false) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
+        I could not find a BAH rate for that ZIP and rank. Double-check the inputs and try again.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 flex flex-col gap-2">
+      <div className="flex items-baseline justify-between">
+        <span className="text-xs uppercase tracking-wide text-gray-500">BAH Estimate</span>
+        <span className="text-xs text-gray-500">
+          {data?.year ?? ''} {data?.rank ? `· ${data.rank}` : ''}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="rounded-md bg-primary/5 p-2">
+          <p className="text-[11px] uppercase tracking-wide text-gray-500">With dependents</p>
+          <p className="text-base font-semibold text-primary">
+            {formatAmount(data?.withDependents)}
+            <span className="ml-1 text-xs font-normal text-gray-500">/mo</span>
+          </p>
+        </div>
+        <div className="rounded-md bg-primary/5 p-2">
+          <p className="text-[11px] uppercase tracking-wide text-gray-500">Without dependents</p>
+          <p className="text-base font-semibold text-primary">
+            {formatAmount(data?.withoutDependents)}
+            <span className="ml-1 text-xs font-normal text-gray-500">/mo</span>
+          </p>
+        </div>
+      </div>
+      <p className="text-[11px] text-gray-500">
+        ZIP {data?.zipCode || '—'}
+        {data?.mha ? ` · MHA ${data.mha}` : ''}
+      </p>
+    </div>
+  );
+}

--- a/components/Concierge/ConciergeProvider.tsx
+++ b/components/Concierge/ConciergeProvider.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+export interface ConciergeSeed {
+  openingMessage?: string;
+  topic?: string;
+}
+
+export interface ConciergeContextValue {
+  isOpen: boolean;
+  open(seed?: ConciergeSeed): void;
+  close(): void;
+  toggle(): void;
+  pendingSeed: ConciergeSeed | null;
+  clearPendingSeed(): void;
+}
+
+const ConciergeContext = createContext<ConciergeContextValue | null>(null);
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function ConciergeProvider({ children }: Props) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [pendingSeed, setPendingSeed] = useState<ConciergeSeed | null>(null);
+
+  const open = useCallback((seed?: ConciergeSeed) => {
+    if (seed) {
+      setPendingSeed(seed);
+    }
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  const clearPendingSeed = useCallback(() => {
+    setPendingSeed(null);
+  }, []);
+
+  const value = useMemo<ConciergeContextValue>(
+    () => ({
+      isOpen,
+      open,
+      close,
+      toggle,
+      pendingSeed,
+      clearPendingSeed,
+    }),
+    [isOpen, open, close, toggle, pendingSeed, clearPendingSeed],
+  );
+
+  return <ConciergeContext.Provider value={value}>{children}</ConciergeContext.Provider>;
+}
+
+export function useConcierge(): ConciergeContextValue {
+  const ctx = useContext(ConciergeContext);
+  if (!ctx) {
+    throw new Error('useConcierge must be used within a ConciergeProvider');
+  }
+  return ctx;
+}

--- a/components/Concierge/ConciergeWidget.tsx
+++ b/components/Concierge/ConciergeWidget.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai';
+import { usePathname } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { featureFlags } from '@/lib/feature-flags';
+import MessageRenderer from './MessageRenderer';
+import type { AgentListItem } from './AgentCard';
+import { useConcierge } from './ConciergeProvider';
+
+const PANEL_TITLE = 'VeteranPCS Concierge';
+const GREETING =
+  "Hi — I'm the VeteranPCS concierge. I can help you find a vetted military-friendly agent or lender, look up BAH rates, or answer PCS questions. Where are you headed?";
+
+interface ChatBubbleIconProps {
+  className?: string;
+}
+
+function ChatBubbleIcon({ className }: ChatBubbleIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="h-5 w-5"
+    >
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+function SendIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="h-5 w-5"
+    >
+      <line x1="22" y1="2" x2="11" y2="13" />
+      <polygon points="22 2 15 22 11 13 2 9 22 2" />
+    </svg>
+  );
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
+
+interface PageContextHolder {
+  path: string | undefined;
+  topic: string | undefined;
+}
+
+export default function ConciergeWidget() {
+  const { isOpen, open, close, pendingSeed, clearPendingSeed } = useConcierge();
+  const pathname = usePathname();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const previousActiveElementRef = useRef<HTMLElement | null>(null);
+  const seedConsumedRef = useRef<boolean>(false);
+
+  const pageContextRef = useRef<PageContextHolder>({
+    path: undefined,
+    topic: undefined,
+  });
+
+  useEffect(() => {
+    pageContextRef.current.path = pathname ?? undefined;
+  }, [pathname]);
+
+  useEffect(() => {
+    pageContextRef.current.topic = pendingSeed?.topic;
+  }, [pendingSeed]);
+
+  // The transport closure runs at send time (outside render), so reading
+  // pageContextRef.current here is safe — the react-hooks/refs lint rule
+  // can't tell that and flags it as render-time access.
+  const transport = useMemo(
+    () =>
+      // eslint-disable-next-line react-hooks/refs
+      new DefaultChatTransport({
+        api: '/api/chat',
+        prepareSendMessagesRequest({ messages, id, trigger, messageId }) {
+          return {
+            body: {
+              id,
+              trigger,
+              messageId,
+              messages,
+              pageContext: {
+                path: pageContextRef.current.path,
+                topic: pageContextRef.current.topic,
+              },
+            },
+          };
+        },
+      }),
+    [],
+  );
+
+  const { messages, sendMessage, status, error, addToolApprovalResponse } = useChat({
+    transport,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+  });
+
+  const isStreaming = status === 'submitted' || status === 'streaming';
+
+  // Consume pending seed once on open.
+  useEffect(() => {
+    if (!isOpen) return;
+    if (seedConsumedRef.current) return;
+    if (!pendingSeed?.openingMessage) return;
+    if (messages.length > 0) return;
+    seedConsumedRef.current = true;
+    void sendMessage({ text: pendingSeed.openingMessage });
+    clearPendingSeed();
+  }, [isOpen, pendingSeed, messages.length, sendMessage, clearPendingSeed]);
+
+  // Reset seed-consumed flag when the panel closes so a future open works.
+  useEffect(() => {
+    if (!isOpen) {
+      seedConsumedRef.current = false;
+    }
+  }, [isOpen]);
+
+  // ESC closes and basic focus trap.
+  useEffect(() => {
+    if (!isOpen) return;
+    previousActiveElementRef.current = document.activeElement as HTMLElement | null;
+
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const root = panelRef.current;
+      if (!root) return;
+      const focusables = Array.from(
+        root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute('disabled') && el.tabIndex !== -1);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (event.shiftKey) {
+        if (active === first || !root.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKey);
+    const focusTimer = window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      window.clearTimeout(focusTimer);
+      const prev = previousActiveElementRef.current;
+      if (prev && typeof prev.focus === 'function') {
+        prev.focus();
+      }
+    };
+  }, [isOpen, close]);
+
+  // Auto-scroll the message list when new messages stream.
+  const listRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!isOpen) return;
+    const el = listRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [isOpen, messages]);
+
+  const handleSelectAgent = (item: AgentListItem) => {
+    if (isStreaming) return;
+    void sendMessage({ text: `I'd like to connect with ${item.name}.` });
+  };
+
+  const handleApprove = useCallback(
+    (id: string, approved: boolean) => {
+      void addToolApprovalResponse({ id, approved });
+    },
+    [addToolApprovalResponse],
+  );
+
+  const inputFormRef = useRef<HTMLFormElement | null>(null);
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formEl = event.currentTarget;
+    const field = formEl.elements.namedItem('concierge-input') as HTMLInputElement | null;
+    if (!field) return;
+    const text = field.value.trim();
+    if (!text) return;
+    if (isStreaming) return;
+    void sendMessage({ text });
+    field.value = '';
+  };
+
+  if (!featureFlags.conciergeEnabled) {
+    return null;
+  }
+
+  return (
+    <>
+      {!isOpen ? (
+        <button
+          type="button"
+          onClick={() => open()}
+          aria-label="Open chat with VeteranPCS concierge"
+          className="fixed bottom-6 right-6 z-concierge h-14 w-14 rounded-full bg-primary text-white shadow-lg flex items-center justify-center motion-safe:transition-colors hover:bg-primary-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
+        >
+          <ChatBubbleIcon className="h-6 w-6" />
+        </button>
+      ) : null}
+
+      {isOpen ? (
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={PANEL_TITLE}
+          className="fixed z-concierge bg-white shadow-2xl flex flex-col inset-0 sm:inset-auto sm:right-6 sm:bottom-20 sm:h-[560px] sm:w-[380px] sm:rounded-xl overflow-hidden border border-gray-200"
+        >
+          {/* Header */}
+          <div className="bg-primary text-white px-4 py-3 flex items-center justify-between">
+            <span className="font-semibold text-base">{PANEL_TITLE}</span>
+            <button
+              type="button"
+              onClick={close}
+              aria-label="Close concierge"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-md text-white motion-safe:transition-colors hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            >
+              <CloseIcon />
+            </button>
+          </div>
+
+          {/* Message list */}
+          <div
+            ref={listRef}
+            className="flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-3 bg-gray-50"
+          >
+            {messages.length === 0 ? (
+              <div className="rounded-lg bg-white border border-gray-200 p-3 text-sm text-gray-800">
+                {GREETING}
+              </div>
+            ) : null}
+
+            {messages.map((message) => (
+              <MessageRenderer
+                key={message.id}
+                message={message}
+                onSelectAgent={handleSelectAgent}
+                onApprove={handleApprove}
+              />
+            ))}
+
+            {error ? (
+              <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
+                Something went wrong — try again or reach us at support@veteranpcs.com
+              </div>
+            ) : null}
+          </div>
+
+          {/* Input footer */}
+          <form
+            ref={inputFormRef}
+            onSubmit={handleSubmit}
+            className="border-t border-gray-200 bg-white p-2 flex items-center gap-2"
+          >
+            <label htmlFor="concierge-input" className="sr-only">
+              Message the concierge
+            </label>
+            <input
+              ref={inputRef}
+              id="concierge-input"
+              name="concierge-input"
+              type="text"
+              autoComplete="off"
+              placeholder="Type a message…"
+              disabled={isStreaming}
+              className="flex-1 min-h-[44px] rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-gray-100"
+            />
+            <button
+              type="submit"
+              disabled={isStreaming}
+              aria-label="Send message"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-md bg-accent-red text-white motion-safe:transition-colors hover:bg-accent-red-dark disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              <SendIcon />
+            </button>
+          </form>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/components/Concierge/MessageRenderer.tsx
+++ b/components/Concierge/MessageRenderer.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import {
+  getToolName,
+  isTextUIPart,
+  isToolUIPart,
+  type UIMessage,
+} from 'ai';
+import AgentCard, { AgentListItem } from './AgentCard';
+import StateCard from './StateCard';
+import BAHResult from './BAHResult';
+import { SUCCESS_MESSAGE } from '@/lib/ai/tools/lead-tools';
+
+interface Props {
+  message: UIMessage;
+  onSelectAgent?(item: AgentListItem): void;
+  onApprove?(id: string, approved: boolean): void;
+}
+
+interface ToolEnvelope<T> {
+  ok?: boolean;
+  data?: T;
+  error?: string;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function asEnvelope<T>(output: unknown): ToolEnvelope<T> | null {
+  if (!isObject(output)) return null;
+  return output as ToolEnvelope<T>;
+}
+
+function ErrorBubble({ message }: { message?: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
+      {message || 'Something went wrong — try again or reach us at support@veteranpcs.com'}
+    </div>
+  );
+}
+
+function LoadingBubble({ label }: { label: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-500">
+      {label}
+    </div>
+  );
+}
+
+function ConfirmationBubble({ message }: { message?: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-primary/5 p-3 text-sm text-primary">
+      {message || SUCCESS_MESSAGE}
+    </div>
+  );
+}
+
+function DeniedBubble() {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
+      Okay — I won&apos;t send anything yet. Let me know when you&apos;re ready.
+    </div>
+  );
+}
+
+interface ApprovalCardProps {
+  approvalId: string;
+  onApprove?(id: string, approved: boolean): void;
+}
+
+function ApprovalCard({ approvalId, onApprove }: ApprovalCardProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 flex flex-col gap-2">
+      <p className="text-sm text-gray-900">
+        I&apos;m about to send your details to VeteranPCS so a real partner can reach out. Ready to send?
+      </p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => onApprove?.(approvalId, true)}
+          disabled={!onApprove}
+          className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-white motion-safe:transition-colors hover:bg-primary-hover disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
+        >
+          Yes, send it
+        </button>
+        <button
+          type="button"
+          onClick={() => onApprove?.(approvalId, false)}
+          disabled={!onApprove}
+          className="inline-flex h-9 items-center justify-center rounded-md border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 motion-safe:transition-colors hover:bg-gray-50 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        >
+          Not yet
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const SUBMIT_TOOL_NAMES = new Set<string>([
+  'submitAgentRequest',
+  'submitLenderRequest',
+  'submitGeneralInquiry',
+  'submitVALoanGuideRequest',
+]);
+
+function loadingLabel(toolName: string): string {
+  switch (toolName) {
+    case 'getAgentsForState':
+      return 'Looking up agents…';
+    case 'getLendersForState':
+      return 'Looking up lenders…';
+    case 'getStateDetails':
+      return 'Pulling up state info…';
+    case 'listStates':
+      return 'Loading states…';
+    case 'calculateBAH':
+      return 'Calculating BAH…';
+    default:
+      if (SUBMIT_TOOL_NAMES.has(toolName)) return 'Sending your request…';
+      return 'Working on it…';
+  }
+}
+
+export default function MessageRenderer({ message, onSelectAgent, onApprove }: Props) {
+  const isAssistant = message.role === 'assistant';
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+      <div className={`flex flex-col gap-2 max-w-[85%] ${isUser ? 'items-end' : 'items-start'}`}>
+        {message.parts.map((part, idx) => {
+          const key = `${message.id}-${idx}`;
+
+          if (isTextUIPart(part)) {
+            const bubbleClass = isUser
+              ? 'rounded-lg bg-primary text-white px-3 py-2 text-sm whitespace-pre-wrap'
+              : 'rounded-lg bg-gray-100 text-gray-900 px-3 py-2 text-sm whitespace-pre-wrap';
+            return (
+              <div key={key} className={bubbleClass}>
+                {part.text}
+              </div>
+            );
+          }
+
+          if (!isAssistant || !isToolUIPart(part)) {
+            return null;
+          }
+
+          const toolName = getToolName(part);
+
+          switch (part.state) {
+            case 'input-streaming':
+            case 'input-available':
+              return <LoadingBubble key={key} label={loadingLabel(toolName)} />;
+
+            case 'approval-requested':
+              if (SUBMIT_TOOL_NAMES.has(toolName)) {
+                return (
+                  <ApprovalCard
+                    key={key}
+                    approvalId={part.approval.id}
+                    onApprove={onApprove}
+                  />
+                );
+              }
+              return <LoadingBubble key={key} label={loadingLabel(toolName)} />;
+
+            case 'approval-responded':
+              return <LoadingBubble key={key} label={loadingLabel(toolName)} />;
+
+            case 'output-denied':
+              if (SUBMIT_TOOL_NAMES.has(toolName)) {
+                return <DeniedBubble key={key} />;
+              }
+              return null;
+
+            case 'output-error':
+              return <ErrorBubble key={key} message={part.errorText} />;
+
+            case 'output-available': {
+              const envelope = asEnvelope<Record<string, unknown>>(part.output);
+              if (!envelope) {
+                return <ErrorBubble key={key} />;
+              }
+              if (envelope.ok === false) {
+                return <ErrorBubble key={key} message={envelope.error} />;
+              }
+              const data = envelope.data;
+
+              switch (toolName) {
+                case 'getAgentsForState': {
+                  const agents = (data && Array.isArray((data as { agents?: unknown }).agents)
+                    ? ((data as { agents: AgentListItem[] }).agents)
+                    : []) as AgentListItem[];
+                  return (
+                    <AgentCard
+                      key={key}
+                      list={agents}
+                      kind="agent"
+                      onSelect={onSelectAgent}
+                    />
+                  );
+                }
+                case 'getLendersForState': {
+                  const lenders = (data && Array.isArray((data as { lenders?: unknown }).lenders)
+                    ? ((data as { lenders: AgentListItem[] }).lenders)
+                    : []) as AgentListItem[];
+                  return (
+                    <AgentCard
+                      key={key}
+                      list={lenders}
+                      kind="lender"
+                      onSelect={onSelectAgent}
+                    />
+                  );
+                }
+                case 'getStateDetails': {
+                  const stateRecord = (data && (data as { state?: unknown }).state) as
+                    | { state_name?: string; short_name?: string; state_slug?: { current?: string } }
+                    | undefined;
+                  if (!stateRecord) {
+                    return <ErrorBubble key={key} />;
+                  }
+                  return <StateCard key={key} state={stateRecord} />;
+                }
+                case 'calculateBAH': {
+                  return (
+                    <BAHResult
+                      key={key}
+                      data={(data as Parameters<typeof BAHResult>[0]['data']) || {}}
+                    />
+                  );
+                }
+                case 'listStates': {
+                  return null;
+                }
+                default: {
+                  if (SUBMIT_TOOL_NAMES.has(toolName)) {
+                    const message = (data && typeof (data as { message?: unknown }).message === 'string')
+                      ? ((data as { message: string }).message)
+                      : undefined;
+                    return <ConfirmationBubble key={key} message={message} />;
+                  }
+                  return null;
+                }
+              }
+            }
+
+            default:
+              return null;
+          }
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/Concierge/StateCard.tsx
+++ b/components/Concierge/StateCard.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+interface Props {
+  state: {
+    state_name?: string;
+    short_name?: string;
+  };
+}
+
+export default function StateCard({ state }: Props) {
+  const stateName = state?.state_name || 'This state';
+  const shortName = state?.short_name;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 flex items-center justify-between gap-3">
+      <div className="flex flex-col">
+        <span className="text-xs uppercase tracking-wide text-gray-500">State</span>
+        <span className="text-sm font-semibold text-primary">{stateName}</span>
+      </div>
+      {shortName ? (
+        <span className="inline-flex items-center justify-center rounded-md bg-primary/10 text-primary text-sm font-semibold px-2 py-1">
+          {shortName}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/components/Concierge/index.ts
+++ b/components/Concierge/index.ts
@@ -1,0 +1,3 @@
+export { default as ConciergeProvider, useConcierge } from './ConciergeProvider';
+export type { ConciergeContextValue, ConciergeSeed } from './ConciergeProvider';
+export { default as ConciergeWidget } from './ConciergeWidget';

--- a/components/ContactAgents/ContactAgent.tsx
+++ b/components/ContactAgents/ContactAgent.tsx
@@ -6,6 +6,7 @@ import * as yup from "yup";
 import ReCAPTCHA from 'react-google-recaptcha';
 
 import { ContactAgentFormData } from '@/types';
+import { useConcierge } from '@/components/Concierge';
 
 interface ContactFormProps {
   onSubmit: (data: ContactAgentFormData) => Promise<{ success?: boolean; redirectUrl?: string; }>;
@@ -58,6 +59,16 @@ const ContactAgentForm = ({ onSubmit }: ContactFormProps) => {
   });
 
   const howDidYouHearValue = watch("howDidYouHear");
+  const destinationBaseValue = watch("destinationBase");
+  const { open: openConcierge } = useConcierge();
+
+  const handleConciergeCta = () => {
+    const destination = destinationBaseValue?.trim();
+    const openingMessage = destination
+      ? `I need help finding an agent in ${destination}.`
+      : 'I need help finding an agent.';
+    openConcierge({ topic: 'agent', openingMessage });
+  };
 
   const handleFormSubmit: SubmitHandler<ContactAgentFormData> = async (data) => {
     setIsSubmitting(true);
@@ -319,13 +330,20 @@ const ContactAgentForm = ({ onSubmit }: ContactFormProps) => {
               </div>
             </div>
             {/* Submit Button */}
-            <div className="flex md:justify-start justify-center">
+            <div className="flex md:justify-start justify-center flex-col md:items-start items-center gap-3">
               <button
                 type="submit"
                 disabled={isSubmitting}
                 className={`rounded-md border border-[#BBBFC1] ${isSubmitting ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#292F6C]'} px-8 py-2 text-center text-white font-medium flex items-center gap-2 shadow-lg`}
               >
                 {isSubmitting ? 'Submitting...' : 'Submit'}
+              </button>
+              <button
+                type="button"
+                onClick={handleConciergeCta}
+                className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
+              >
+                Or chat with our concierge instead.
               </button>
             </div>
           </div>

--- a/components/ContactAgents/ContactAgent.tsx
+++ b/components/ContactAgents/ContactAgent.tsx
@@ -7,6 +7,7 @@ import ReCAPTCHA from 'react-google-recaptcha';
 
 import { ContactAgentFormData } from '@/types';
 import { useConcierge } from '@/components/Concierge';
+import { featureFlags } from '@/lib/feature-flags';
 
 interface ContactFormProps {
   onSubmit: (data: ContactAgentFormData) => Promise<{ success?: boolean; redirectUrl?: string; }>;
@@ -338,13 +339,15 @@ const ContactAgentForm = ({ onSubmit }: ContactFormProps) => {
               >
                 {isSubmitting ? 'Submitting...' : 'Submit'}
               </button>
-              <button
-                type="button"
-                onClick={handleConciergeCta}
-                className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
-              >
-                Or chat with our concierge instead.
-              </button>
+              {featureFlags.conciergeEnabled && (
+                <button
+                  type="button"
+                  onClick={handleConciergeCta}
+                  className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
+                >
+                  Or chat with our concierge instead.
+                </button>
+              )}
             </div>
           </div>
         </form>

--- a/components/ContactLender/ContactLender.tsx
+++ b/components/ContactLender/ContactLender.tsx
@@ -8,6 +8,7 @@ import ReCAPTCHA from 'react-google-recaptcha';
 
 import { ContactLenderFormData, HowDidYouHearOptions } from '@/types';
 import { useConcierge } from '@/components/Concierge';
+import { featureFlags } from '@/lib/feature-flags';
 
 // Props type for ContactForm component
 interface ContactFormProps {
@@ -297,13 +298,15 @@ const ContactLenderForm: React.FC<ContactFormProps> = ({ onSubmit }) => {
               >
                 {isSubmitting ? 'Submitting...' : 'Submit'}
               </button>
-              <button
-                type="button"
-                onClick={handleConciergeCta}
-                className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
-              >
-                Or chat with our concierge instead.
-              </button>
+              {featureFlags.conciergeEnabled && (
+                <button
+                  type="button"
+                  onClick={handleConciergeCta}
+                  className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
+                >
+                  Or chat with our concierge instead.
+                </button>
+              )}
             </div>
           </div>
         </form>

--- a/components/ContactLender/ContactLender.tsx
+++ b/components/ContactLender/ContactLender.tsx
@@ -7,6 +7,7 @@ import * as yup from 'yup';
 import ReCAPTCHA from 'react-google-recaptcha';
 
 import { ContactLenderFormData, HowDidYouHearOptions } from '@/types';
+import { useConcierge } from '@/components/Concierge';
 
 // Props type for ContactForm component
 interface ContactFormProps {
@@ -59,6 +60,14 @@ const contactFormSchema = yup.object().shape({
 
 const ContactLenderForm: React.FC<ContactFormProps> = ({ onSubmit }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { open: openConcierge } = useConcierge();
+
+  const handleConciergeCta = () => {
+    openConcierge({
+      topic: 'lender',
+      openingMessage: 'I need help with a VA-friendly lender.',
+    });
+  };
 
   const {
     register,
@@ -280,13 +289,20 @@ const ContactLenderForm: React.FC<ContactFormProps> = ({ onSubmit }) => {
               </div>
             </div>
 
-            <div className="flex md:justify-start justify-center">
+            <div className="flex md:justify-start justify-center flex-col md:items-start items-center gap-3">
               <button
                 type="submit"
                 disabled={isSubmitting}
                 className={`rounded-md border border-[#BBBFC1] ${isSubmitting ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#292F6C]'} px-8 py-2 text-center text-white font-medium flex items-center gap-2 shadow-lg`}
               >
                 {isSubmitting ? 'Submitting...' : 'Submit'}
+              </button>
+              <button
+                type="button"
+                onClick={handleConciergeCta}
+                className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
+              >
+                Or chat with our concierge instead.
               </button>
             </div>
           </div>

--- a/components/contactpage/ContactForm/ContactForm.tsx
+++ b/components/contactpage/ContactForm/ContactForm.tsx
@@ -14,6 +14,7 @@ import { contactPostForm } from "@/services/salesForcePostFormsService";
 import { useRouter } from "next/navigation";
 import { sendGTMEvent } from "@next/third-parties/google";
 import { useConcierge } from "@/components/Concierge";
+import { featureFlags } from "@/lib/feature-flags";
 
 interface MediaAccountProps {
   _id: string;
@@ -296,13 +297,15 @@ const ContactForm = () => {
                       {isSubmitting ? 'Sending...' : 'Send Message'}
                     </span>
                   </button>
-                  <button
-                    type="button"
-                    onClick={handleConciergeCta}
-                    className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
-                  >
-                    Or chat with our concierge instead.
-                  </button>
+                  {featureFlags.conciergeEnabled && (
+                    <button
+                      type="button"
+                      onClick={handleConciergeCta}
+                      className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
+                    >
+                      Or chat with our concierge instead.
+                    </button>
+                  )}
                 </div>
               </div>
             </div>

--- a/components/contactpage/ContactForm/ContactForm.tsx
+++ b/components/contactpage/ContactForm/ContactForm.tsx
@@ -13,6 +13,7 @@ import ReCAPTCHA from 'react-google-recaptcha';
 import { contactPostForm } from "@/services/salesForcePostFormsService";
 import { useRouter } from "next/navigation";
 import { sendGTMEvent } from "@next/third-parties/google";
+import { useConcierge } from "@/components/Concierge";
 
 interface MediaAccountProps {
   _id: string;
@@ -46,6 +47,14 @@ const ContactForm = () => {
   const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { open: openConcierge } = useConcierge();
+
+  const handleConciergeCta = () => {
+    openConcierge({
+      topic: 'general',
+      openingMessage: 'I have a question.',
+    });
+  };
   const {
     register,
     handleSubmit,
@@ -274,18 +283,25 @@ const ContactForm = () => {
                   />
                   {renderError('captchaToken')}
                 </div>
-                <div className="flex justify-end lg:py-8 md:py-8 sm:py-2 py-2">
+                <div className="flex flex-col items-end lg:py-8 md:py-8 sm:py-2 py-2 gap-3">
                   <button
                     type="submit"
                     disabled={isSubmitting}
                     className={`items-center ${isSubmitting ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#A81F23]'} w-auto inline-flex xl:px-[30px] lg:px-[30px] sm:px-[20px] px-[20px] xl:py-[15px] lg:py-[15px] sm:py-[14px] py-[14px] rounded-[16px] text-center tracking-[1px] hover:tracking-[5px] duration-500 transition-all`}
                   >
                     <span
-                      className="xl:text-[18px] lg:text-[18px] md:text-[18px] sm:text-[14px] text-[14px] font-normal leading-6 bg-cover 
+                      className="xl:text-[18px] lg:text-[18px] md:text-[18px] sm:text-[14px] text-[14px] font-normal leading-6 bg-cover
                         text-white text-nowrap tahoma"
                     >
                       {isSubmitting ? 'Sending...' : 'Send Message'}
                     </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleConciergeCta}
+                    className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
+                  >
+                    Or chat with our concierge instead.
                   </button>
                 </div>
               </div>

--- a/components/homepage/VaLoanGuideDownload.tsx
+++ b/components/homepage/VaLoanGuideDownload.tsx
@@ -9,6 +9,7 @@ import { sendGTMEvent } from "@next/third-parties/google";
 import Image from "next/image";
 import Link from "next/link";
 import { useConcierge } from "@/components/Concierge";
+import { featureFlags } from "@/lib/feature-flags";
 
 // Form input types
 interface FormInputs {
@@ -158,15 +159,17 @@ const VaLoanGuideDownload = () => {
                         />
                     </div>
 
-                    <div className="w-full flex justify-center mb-2">
-                        <button
-                            type="button"
-                            onClick={handleConciergeCta}
-                            className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
-                        >
-                            Or chat with our concierge instead.
-                        </button>
-                    </div>
+                    {featureFlags.conciergeEnabled && (
+                        <div className="w-full flex justify-center mb-2">
+                            <button
+                                type="button"
+                                onClick={handleConciergeCta}
+                                className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
+                            >
+                                Or chat with our concierge instead.
+                            </button>
+                        </div>
+                    )}
                 </form>
 
                 <div className="w-full flex justify-center">

--- a/components/homepage/VaLoanGuideDownload.tsx
+++ b/components/homepage/VaLoanGuideDownload.tsx
@@ -8,6 +8,7 @@ import { vaLoanGuideForm } from "@/services/salesForcePostFormsService";
 import { sendGTMEvent } from "@next/third-parties/google";
 import Image from "next/image";
 import Link from "next/link";
+import { useConcierge } from "@/components/Concierge";
 
 // Form input types
 interface FormInputs {
@@ -22,6 +23,14 @@ const VaLoanGuideDownload = () => {
     const [submitting, setSubmitting] = useState(false);
     const [success, setSuccess] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const { open: openConcierge } = useConcierge();
+
+    const handleConciergeCta = () => {
+        openConcierge({
+            topic: 'va_loan_guide',
+            openingMessage: 'Can you walk me through the VA loan basics?',
+        });
+    };
 
     // Validation schema
     const validationSchema = Yup.object().shape({
@@ -147,6 +156,16 @@ const VaLoanGuideDownload = () => {
                             sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ''}
                             onChange={onCaptchaChange}
                         />
+                    </div>
+
+                    <div className="w-full flex justify-center mb-2">
+                        <button
+                            type="button"
+                            onClick={handleConciergeCta}
+                            className="text-sm text-primary hover:underline focus:outline-none focus-visible:underline min-h-[44px]"
+                        >
+                            Or chat with our concierge instead.
+                        </button>
                     </div>
                 </form>
 

--- a/lib/__tests__/bah-scraper.test.ts
+++ b/lib/__tests__/bah-scraper.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { extractBAHData, __testables, type PostData } from '@/lib/bah-scraper';
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+function loadFixture(name: string): string {
+  return fs.readFileSync(path.join(fixturesDir, name), 'utf8');
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('extractBAHData', () => {
+  it('parses a successful DTMO response (79918 / E-5 / 2025)', async () => {
+    const fixture = loadFixture('bah-79918-e5-2025.html');
+    const spy = vi
+      .spyOn(__testables, 'fetchPage')
+      .mockResolvedValue(fixture);
+
+    const result = await extractBAHData('2025', '79918', '5');
+
+    expect(spy).toHaveBeenCalledOnce();
+    const [, postData] = spy.mock.calls[0] as [string, PostData];
+    expect(postData.YEAR).toBe('25');
+    expect(postData.Zipcode).toBe('79918');
+    expect(postData.Rank).toBe('5');
+
+    expect(result.isValid).toBe(true);
+    expect(result.mha).toMatch(/EL PASO/);
+    expect(result.rank).toBe('E-5');
+    expect(result.year).toBe('2025');
+    expect(result.withDependents).toBeGreaterThan(0);
+    expect(result.withoutDependents).toBeGreaterThan(0);
+    expect(result.withDependents).toBeGreaterThan(result.withoutDependents);
+  });
+
+  it('sends YEAR=26 on the wire when given "2026" (4-digit → 2-digit)', async () => {
+    const fixture = loadFixture('bah-79918-e5-2025.html');
+    const spy = vi
+      .spyOn(__testables, 'fetchPage')
+      .mockResolvedValue(fixture);
+
+    await extractBAHData('2026', '79918', '5');
+
+    const [, postData] = spy.mock.calls[0] as [string, PostData];
+    expect(postData.YEAR).toBe('26');
+  });
+
+  it('passes through a 2-digit year unchanged ("25" → "25")', async () => {
+    const fixture = loadFixture('bah-79918-e5-2025.html');
+    const spy = vi
+      .spyOn(__testables, 'fetchPage')
+      .mockResolvedValue(fixture);
+
+    await extractBAHData('25', '79918', '5');
+
+    const [, postData] = spy.mock.calls[0] as [string, PostData];
+    expect(postData.YEAR).toBe('25');
+  });
+
+  it('throws when DTMO returns a not-found page (no #ImportDiv2)', async () => {
+    const fixture = loadFixture('bah-99999-notfound.html');
+    vi.spyOn(__testables, 'fetchPage').mockResolvedValue(fixture);
+
+    await expect(extractBAHData('2025', '99999', '5')).rejects.toThrow(
+      /Could not find BAH data container/,
+    );
+  });
+
+  it('rejects unknown rank ids before hitting the network', async () => {
+    const spy = vi.spyOn(__testables, 'fetchPage');
+    await expect(extractBAHData('2025', '79918', '999')).rejects.toThrow(
+      /Invalid rank ID/,
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/fixtures/bah-79918-e5-2025.html
+++ b/lib/__tests__/fixtures/bah-79918-e5-2025.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>Basic Allowance for Housing: Query Results</title>
+    <link rel="icon" type="image/x-icon" href="/neorates/assets/img/favicon.ico">
+    <link rel="stylesheet" href="/COMMON/assets/uswds-2.2.1/css/uswds.css">
+    <link rel="stylesheet" href="/COMMON/assets/style/mib-1.0.1.css?v=2025.1.0">
+    <link rel="stylesheet" href="/COMMON/assets/fontawesome/css/all.css">
+    <link rel="stylesheet" href="/COMMON/assets/jquery-ui-1.12.1.custom/jquery-ui.min.css">
+    <link rel="stylesheet" href="/COMMON/assets/jquery-ui-1.12.1.custom/jquery-ui.theme.css">
+    <link rel="stylesheet" href="/COMMON/assets/js/jquery.modal.css?v=2025.1.2">
+    <link rel="stylesheet" href="/COMMON/assets/style/passport.css?v=2024.1.0">
+    <link rel="stylesheet" href="/COMMON/assets/DataTables/datatables.css">
+    <link rel="stylesheet" href="/COMMON/assets/DataTables/Buttons-2.0.1/css/buttons.dataTables.min.css">
+    <link rel="stylesheet" href="/neorates/assets/css/style-report.css?v=2024.1.0">
+    <link rel="stylesheet" href="/neorates/assets/css/style-datatables.css">
+    <link rel="stylesheet" href="/neorates/assets/css/style.css?v=2024.1.1">
+
+        
+        
+</head>
+<body class="report-body">
+    <header class="header">
+                    <a href="https://www.travel.dod.mil/Allowances/Basic-Allowance-for-Housing/BAH-Rate-Lookup/" title="Defense Travel Management Office">
+                <div class="passport-application-rates-logo" style="background-image: url(/neorates/assets/img/DMA%20Header%20Image%20DHRA-DSSC%20Approved%20-%2020221003.png);" role="img" aria-label="Defense Travel Management Office" alt="Defense Travel Management Office"></div>
+            </a>
+                <div class="header-text">
+            <b class="f15x title-color"> BASIC ALLOWANCE FOR HOUSING (BAH)</b>
+        </div>
+        <div id='spacer'></div>
+    </header>
+<p></p>
+
+    <div class="text-center">
+            <div class="text-bold report-subtitle">Rate Lookup Results</div>
+    </div>
+    <p></p>
+            <p></p>
+        <hr>
+
+            <div id="ImportDiv2" class="padding-2 display-flex flex-column flex-align-center">
+            <div id="">
+                <br clear="left">
+                                <div>
+                    <div><b>CY:</b> 2 5 </div>
+                    <br clear="left">
+                    <div><b>ZIP CODE:</b> 7 9 9 1 8 </div>
+                    <br clear="left">
+                    <div><b>MILITARY HOUSING AREA:</b> EL PASO, TX (TX279) </div>
+                    <br clear="left">
+                </div>
+                <table border="1" class="import-table import-table-border" id="uTable-oconus-standard" align="left" data-sortable="" data-sortable-initialized="true" aria-label="BAH">
+                    <thead>
+                    <tr>
+                        <th class="tabTX02" colspan="2" role="img" aria-label="MONTHLY ALLOWANCE"><div class="table-header-col-bg-auto">MONTHLY ALLOWANCE:</div></th>
+                    </tr>
+                    </thead-auto
+                    <tbody>
+                        <tr>
+                            <td class="trn-cola text-center"><b>E 5</b> with DEPENDENTS:</td>
+                            <td class="trn-cola text-center"><b>E 5</b> without DEPENDENTS:</td>
+                        </tr>
+                        <tr>
+                            <td class="trn-cola text-center">$ 1773.00</td>
+                            <td class="trn-cola text-center">$ 1425.00</td>
+                        </tr>
+                        <tr>
+                            <td class="trn-cola" colspan="2">See <a href="https://www.travel.dod.mil/Support/ALL-FAQs/Article/2906543/bah-basics/">BAH Frequently Asked Questions</a> for more information. For other BAH concerns, contact your service's BAH POC.</td>
+                        </tr>
+                    </tbody>
+                </table>
+                                <br clear="all">
+            </div>
+        </div>
+        </div>
+
+                <hr>
+        <div  class="padding-2 display-flex flex-column flex-align-center">
+            <div>
+                <h3 style="text-align:center;"></h3><p style="text-align:center;"><span><a class="fui-Link ___1q1shib f2hkw1w f3rmtva f1ewtqcl fyind8e f1k6fduh f1w7gpdv fk6fouc fjoy568 figsok6 f1s184ao f1mk8lai fnbmjn9 f1o700av f13mvf36 f1cmlufx f9n3di6 f1ids18y f1tx3yz7 f1deo86v f1eh06m1 f1iescvh fhgqx19 f1olyrje f1p93eir f1nev41a f1h8hb77 f1lqvz6u f10aw75t fsle3fq f17ae5zn" title="https://dodcio.defense.gov/dodsection508/std_stmt.aspx" href="https://dodcio.defense.gov/DoDSection508/Std_Stmt.aspx">Section 508</a> | <a class="fui-Link ___1q1shib f2hkw1w f3rmtva f1ewtqcl fyind8e f1k6fduh f1w7gpdv fk6fouc fjoy568 figsok6 f1s184ao f1mk8lai fnbmjn9 f1o700av f13mvf36 f1cmlufx f9n3di6 f1ids18y f1tx3yz7 f1deo86v f1eh06m1 f1iescvh fhgqx19 f1olyrje f1p93eir f1nev41a f1h8hb77 f1lqvz6u f10aw75t fsle3fq f17ae5zn" title="https://touchpoints.app.cloud.gov/touchpoints/2f5b5cd8" href="https://touchpoints.app.cloud.gov/touchpoints/2f5b5cd8">Report Accessibility Issue</a></span></p>
+            </div>
+        </div>
+    
+    <script src="/COMMON/assets/js/utils.js"></script>
+    <script src="/COMMON/assets/uswds-2.2.1/js/uswds.js"></script>
+    <script src="/COMMON/assets/js/jquery-3.6.1.min.js"></script>
+    <script src="/COMMON/assets/jquery-ui-1.12.1.custom/jquery-ui.js"></script>
+    <script src="/COMMON/assets/js/jquery.cookie.js"></script>
+    <script src="/COMMON/assets/js/jquery.modal.js?v=2025.1.0"></script>
+    <script src="/COMMON/assets/js/purify.js"></script>
+    <script src="/COMMON/assets/js/passport.js?v=2026.1.0"></script>
+    <script src="/COMMON/assets/DataTables/datatables.js?v=2025.1.0"></script>
+    <script src="/COMMON/assets/DataTables/Buttons-2.0.1/js/dataTables.buttons.min.js"></script>
+    <script src="/COMMON/assets/DataTables/JSZip-2.5.0/jszip.min.js"></script>
+    <script src="/COMMON/assets/DataTables/pdfmake-0.1.36/pdfmake.min.js"></script>
+    <script src="/COMMON/assets/DataTables/pdfmake-0.1.36/vfs_fonts.js"></script>
+    <script src="/COMMON/assets/DataTables/Buttons-2.0.1/js/buttons.html5.min.js"></script>
+    <script src="/COMMON/assets/DataTables/Buttons-2.0.1/js/buttons.print.min.js"></script>
+    <script src="/neorates/assets/js/report.js?v=2024.1.0"></script>
+</body>
+</html>

--- a/lib/__tests__/fixtures/bah-99999-notfound.html
+++ b/lib/__tests__/fixtures/bah-99999-notfound.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>Basic Allowance for Housing: Query Results</title>
+    <link rel="icon" type="image/x-icon" href="/neorates/assets/img/favicon.ico">
+    <link rel="stylesheet" href="/COMMON/assets/uswds-2.2.1/css/uswds.css">
+    <link rel="stylesheet" href="/COMMON/assets/style/mib-1.0.1.css?v=2025.1.0">
+    <link rel="stylesheet" href="/COMMON/assets/fontawesome/css/all.css">
+    <link rel="stylesheet" href="/COMMON/assets/jquery-ui-1.12.1.custom/jquery-ui.min.css">
+    <link rel="stylesheet" href="/COMMON/assets/jquery-ui-1.12.1.custom/jquery-ui.theme.css">
+    <link rel="stylesheet" href="/COMMON/assets/js/jquery.modal.css?v=2025.1.2">
+    <link rel="stylesheet" href="/COMMON/assets/style/passport.css?v=2024.1.0">
+    <link rel="stylesheet" href="/COMMON/assets/DataTables/datatables.css">
+    <link rel="stylesheet" href="/COMMON/assets/DataTables/Buttons-2.0.1/css/buttons.dataTables.min.css">
+    <link rel="stylesheet" href="/neorates/assets/css/style-report.css?v=2024.1.0">
+    <link rel="stylesheet" href="/neorates/assets/css/style-datatables.css">
+    <link rel="stylesheet" href="/neorates/assets/css/style.css?v=2024.1.1">
+
+        
+        
+</head>
+<body class="report-body">
+    <header class="header">
+                    <a href="https://www.travel.dod.mil/Allowances/Basic-Allowance-for-Housing/BAH-Rate-Lookup/" title="Defense Travel Management Office">
+                <div class="passport-application-rates-logo" style="background-image: url(/neorates/assets/img/DMA%20Header%20Image%20DHRA-DSSC%20Approved%20-%2020221003.png);" role="img" aria-label="Defense Travel Management Office" alt="Defense Travel Management Office"></div>
+            </a>
+                <div class="header-text">
+            <b class="f15x title-color"> BASIC ALLOWANCE FOR HOUSING (BAH)</b>
+        </div>
+        <div id='spacer'></div>
+    </header>
+<p></p>
+
+    <hr/>
+    <div class="text-center warning-msg">
+        <div class="f11x">Sorry, zip code (9 9 9 9 9) was not found for Calendar Year 2 5.</div>
+        <p></p>
+        <div>Please try again.</div>
+        <p></p>
+        <div><a href="https://www.travel.dod.mil/Allowances/Basic-Allowance-for-Housing/BAH-Rate-Lookup/">Defense Travel Management Office</a></div>
+    </div>
+
+    <script src="/COMMON/assets/js/utils.js"></script>
+    <script src="/COMMON/assets/uswds-2.2.1/js/uswds.js"></script>
+    <script src="/COMMON/assets/js/jquery-3.6.1.min.js"></script>
+    <script src="/COMMON/assets/jquery-ui-1.12.1.custom/jquery-ui.js"></script>
+    <script src="/COMMON/assets/js/jquery.cookie.js"></script>
+    <script src="/COMMON/assets/js/jquery.modal.js?v=2025.1.0"></script>
+    <script src="/COMMON/assets/js/purify.js"></script>
+    <script src="/COMMON/assets/js/passport.js?v=2026.1.0"></script>
+    <script src="/COMMON/assets/DataTables/datatables.js?v=2025.1.0"></script>
+    <script src="/COMMON/assets/DataTables/Buttons-2.0.1/js/dataTables.buttons.min.js"></script>
+    <script src="/COMMON/assets/DataTables/JSZip-2.5.0/jszip.min.js"></script>
+    <script src="/COMMON/assets/DataTables/pdfmake-0.1.36/pdfmake.min.js"></script>
+    <script src="/COMMON/assets/DataTables/pdfmake-0.1.36/vfs_fonts.js"></script>
+    <script src="/COMMON/assets/DataTables/Buttons-2.0.1/js/buttons.html5.min.js"></script>
+    <script src="/COMMON/assets/DataTables/Buttons-2.0.1/js/buttons.print.min.js"></script>
+    <script src="/neorates/assets/js/report.js?v=2024.1.0"></script>
+</body>
+</html>

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,0 +1,5 @@
+export const MODELS = {
+  chat: 'anthropic/claude-sonnet-4-6',
+} as const;
+
+export type ModelKey = keyof typeof MODELS;

--- a/lib/ai/session.ts
+++ b/lib/ai/session.ts
@@ -1,0 +1,21 @@
+import { cookies } from 'next/headers';
+import { randomUUID } from 'node:crypto';
+
+const COOKIE_NAME = 'vpcs_concierge_sid';
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+export async function getOrCreateSessionId(): Promise<{ sessionId: string; isNew: boolean }> {
+  const jar = await cookies();
+  const existing = jar.get(COOKIE_NAME)?.value;
+  if (existing) return { sessionId: existing, isNew: false };
+
+  const sessionId = randomUUID();
+  jar.set(COOKIE_NAME, sessionId, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+  });
+  return { sessionId, isNew: true };
+}

--- a/lib/ai/system-prompt.ts
+++ b/lib/ai/system-prompt.ts
@@ -1,0 +1,61 @@
+export interface PageContext {
+  path?: string;
+  state?: string;
+  topic?: string;
+}
+
+const BASE_PROMPT = `You are the VeteranPCS Concierge — a calm, knowledgeable guide for active-duty service members, veterans, and military spouses navigating a PCS (Permanent Change of Station) move.
+
+# Mission
+Help the user find a vetted, military-experienced real estate agent or VA-loan lender in the state they're moving to. Answer questions about BAH (Basic Allowance for Housing), VA loans, base information, and the PCS process. When the user is ready, collect what's needed and connect them with a partner.
+
+# Brand voice (non-negotiable)
+- Three words: Trusted. Patriotic. Helpful.
+- Sound like a friend who's done this move four times — plain language, calm, direct.
+- Reading level: 5th to 7th grade.
+- No emoji. No excessive symbols. No exclamation-stacking. No "Sure!", no "Absolutely!", no hype.
+- Military terms are fine. Briefly explain on first use (e.g., "BAH — Basic Allowance for Housing").
+- Quiet patriotism. Built by veterans for veterans, not flag-waving.
+- Slogan, used sparingly: "Together, we'll make it home."
+
+# The network
+- 370+ vetted agents across all 50 states. Lenders cover every state.
+- Up to $4,000 cash back at closing through partner agents.
+- 80+ five-star reviews.
+- Salesforce is the source of truth for agent and lender data.
+
+# How you work
+- Use the available tools to look up real data. Never invent agents, lenders, states, BAH rates, or contact info.
+- Prefer one short paragraph over a long one. Bullets only when they genuinely help.
+- If the user asks for an agent or lender, use the lookup tools and present 1–3 matches with their name, brokerage/company, city, and a one-line reason they fit (e.g., "Army veteran, based near Fort Hood").
+- If you don't know something, say so. Offer to connect the user to a human partner.
+
+# Lead submission (critical)
+- The submitAgentRequest, submitLenderRequest, submitGeneralInquiry, and submitVALoanGuideRequest tools send the user's information to a real partner.
+- NEVER call any submit* tool without first confirming with the user in plain words: "I'll share your details with [name/team] now — sound good?" Wait for a yes.
+- Before confirming, make sure you have at minimum: first name, last name, email, phone, and (for agent/lender requests) destination state.
+- Required fields per tool are documented in the tool's input schema. If a required field is missing, ask for it conversationally — do not list a form.
+
+# Escalation
+- If the user is in distress, asks for a human, or the conversation has hit a hard problem twice, offer to text a human partner directly. Use submitGeneralInquiry with a clear "Requesting human follow-up" note.
+
+# Out of scope
+- You cannot quote interest rates, predict markets, give legal advice, or recommend a specific home. Redirect to a partner.
+- You cannot access user accounts or past conversations.
+`;
+
+export function buildSystemPrompt(ctx?: PageContext): string {
+  const lines: string[] = [BASE_PROMPT];
+
+  if (ctx && (ctx.path || ctx.state || ctx.topic)) {
+    lines.push('\n# Current page context');
+    if (ctx.path) lines.push(`- Path: ${ctx.path}`);
+    if (ctx.state) lines.push(`- State of interest: ${ctx.state}`);
+    if (ctx.topic) lines.push(`- Topic: ${ctx.topic}`);
+    lines.push('Use this context to personalize the first response, but do not bring it up if the user changes topics.');
+  }
+
+  return lines.join('\n');
+}
+
+export const SYSTEM_PROMPT_VERSION = 'v1';

--- a/lib/ai/tools/__tests__/data-tools.test.ts
+++ b/lib/ai/tools/__tests__/data-tools.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/stateService', () => {
+  const fetchStateList = vi.fn();
+  const fetchAgentsListByState = vi.fn();
+  const fetchLendersListByState = vi.fn();
+  const fetchStateDetails = vi.fn();
+  return {
+    default: {
+      fetchStateList,
+      fetchAgentsListByState,
+      fetchLendersListByState,
+      fetchStateDetails,
+    },
+  };
+});
+
+import stateService from '@/services/stateService';
+import { dataTools } from '@/lib/ai/tools/data-tools';
+
+// Tool `execute` is typed as `T | AsyncIterable<T>` in AI SDK 6 to allow
+// streaming-tool returns; ours are always plain promises, so narrow once.
+import type { ToolCallOptions } from 'ai';
+
+// AI SDK 6 tool `execute` is loosely typed as `T | AsyncIterable<T> | PromiseLike<T>`
+// to allow streaming-tool returns; ours are always plain promises, so narrow once.
+type ToolExec<TArgs, TOut> = (
+  args: TArgs,
+  opts: ToolCallOptions,
+) => TOut | AsyncIterable<TOut> | PromiseLike<TOut>;
+
+async function runTool<TArgs, TOut>(
+  fn: ToolExec<TArgs, TOut>,
+  args: TArgs,
+): Promise<TOut> {
+  const res = await fn(args, { toolCallId: 't', messages: [] });
+  if (res !== null && typeof res === 'object' && Symbol.asyncIterator in (res as object)) {
+    throw new Error('Tool returned an async iterable; expected a single result.');
+  }
+  return res as TOut;
+}
+
+const fakeStates = [
+  {
+    _id: 'tx',
+    short_name: 'TX',
+    state_name: 'Texas',
+    state_slug: { current: 'texas', _type: 'slug' as const },
+  },
+  {
+    _id: 'fl',
+    short_name: 'FL',
+    state_name: 'Florida',
+    state_slug: { current: 'florida', _type: 'slug' as const },
+  },
+];
+
+const fakeAgents = {
+  totalSize: 2,
+  done: true,
+  records: [
+    {
+      Name: 'Jane Doe',
+      AccountId_15__c: '001A',
+      FirstName: 'Jane',
+      LastName: 'Doe',
+      Agent_Bio__pc: '',
+      Military_Status__pc: 'Veteran',
+      Military_Service__pc: 'Army',
+      Brokerage_Name__pc: 'Acme Realty',
+      BillingAddress: { city: 'Austin', state: 'TX' },
+      BillingStateCode: 'TX',
+      State_s_Licensed_in__pc: 'TX',
+    },
+    {
+      Name: 'John Smith',
+      AccountId_15__c: '001B',
+      FirstName: 'John',
+      LastName: 'Smith',
+      Agent_Bio__pc: '',
+      Military_Status__pc: 'Spouse',
+      Military_Service__pc: 'Navy',
+      Brokerage_Name__pc: 'Hill Country Homes',
+      BillingAddress: { city: 'San Antonio', state: 'TX' },
+      BillingStateCode: 'TX',
+      State_s_Licensed_in__pc: 'TX',
+    },
+  ],
+};
+
+const fakeLenders = {
+  totalSize: 1,
+  done: true,
+  records: [
+    {
+      Name: 'Lender A',
+      AccountId_15__c: '002A',
+      FirstName: 'Pat',
+      Agent_Bio__pc: '',
+      Military_Status__pc: 'Veteran',
+      Military_Service__pc: 'Marines',
+      Brokerage_Name__pc: 'VetLend',
+      BillingCity: 'Houston',
+      BillingState: 'TX',
+      Individual_NMLS_ID__pc: '12345',
+      Company_NMLS_ID__pc: '67890',
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.mocked(stateService.fetchStateList).mockReset().mockResolvedValue(fakeStates as never);
+  vi.mocked(stateService.fetchAgentsListByState).mockReset().mockResolvedValue(fakeAgents as never);
+  vi.mocked(stateService.fetchLendersListByState).mockReset().mockResolvedValue(fakeLenders as never);
+});
+
+describe('getAgentsForState', () => {
+  it('returns agents for full state name "Texas"', async () => {
+    const res = await runTool(dataTools.getAgentsForState.execute!, { state: 'Texas' });
+    if (!res.ok) throw new Error(`expected ok, got error: ${res.error}`);
+    expect(res.data.stateName).toBe('Texas');
+    expect(res.data.stateSlug).toBe('texas');
+    expect(res.data.agents.length).toBe(2);
+    expect(res.data.agents[0].name).toBe('Jane Doe');
+  });
+
+  it('passes short_name (TX) to fetchAgentsListByState, not the full state name', async () => {
+    await runTool(dataTools.getAgentsForState.execute!, { state: 'Texas' });
+    expect(stateService.fetchAgentsListByState).toHaveBeenCalledWith(
+      'TX',
+      expect.objectContaining({ requireHeadshot: false }),
+    );
+  });
+
+  it('handles lowercase state input', async () => {
+    const res = await runTool(dataTools.getAgentsForState.execute!, { state: 'texas' });
+    if (!res.ok) throw new Error('expected ok');
+    expect(res.data.stateName).toBe('Texas');
+  });
+
+  it('handles short-code state input ("TX")', async () => {
+    const res = await runTool(dataTools.getAgentsForState.execute!, { state: 'TX' });
+    if (!res.ok) throw new Error('expected ok');
+    expect(res.data.stateSlug).toBe('texas');
+    expect(stateService.fetchAgentsListByState).toHaveBeenCalledWith(
+      'TX',
+      expect.objectContaining({ requireHeadshot: false }),
+    );
+  });
+
+  it('returns a clean error for unknown states', async () => {
+    const res = await runTool(dataTools.getAgentsForState.execute!, { state: 'Atlantis' });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('expected error');
+    expect(res.error).toMatch(/Atlantis/);
+  });
+});
+
+describe('getLendersForState', () => {
+  it('returns lenders and passes short_name to the SOQL call', async () => {
+    const res = await runTool(dataTools.getLendersForState.execute!, { state: 'Texas' });
+    if (!res.ok) throw new Error('expected ok');
+    expect(res.data.stateName).toBe('Texas');
+    expect(res.data.lenders.length).toBe(1);
+    expect(stateService.fetchLendersListByState).toHaveBeenCalledWith(
+      'TX',
+      expect.objectContaining({ requireHeadshot: false }),
+    );
+  });
+});
+
+describe('listStates', () => {
+  it('returns the full state list (state_name no longer dropped by projection bug)', async () => {
+    const res = await runTool(dataTools.listStates.execute!, {});
+    if (!res.ok) throw new Error('expected ok');
+    expect(res.data.states.map((s) => s.name).sort()).toEqual(['Florida', 'Texas']);
+  });
+});

--- a/lib/ai/tools/calc-tools.ts
+++ b/lib/ai/tools/calc-tools.ts
@@ -1,0 +1,73 @@
+import { tool } from 'ai';
+import {
+  extractBAHData,
+  RANK_MAPPING,
+  type BAHData,
+} from '@/lib/bah-scraper';
+import { logError, logInfo } from '@/services/loggingService';
+import { bahInputSchema, type ToolResult } from '@/lib/ai/tools/types';
+
+// Reverse map: RANK_MAPPING is { '5': 'E-5', ... }.
+// We want the model-friendly inputs ("E5", "E-5", "e5") to resolve to the numeric id "5".
+function normalizeRankKey(input: string): string {
+  return input.toUpperCase().replace(/[\s-]/g, '');
+}
+
+const RANK_NAME_TO_ID: Record<string, string> = (() => {
+  const out: Record<string, string> = {};
+  for (const [id, name] of Object.entries(RANK_MAPPING)) {
+    const key = normalizeRankKey(name);
+    out[key] = id;
+  }
+  // Common alias: the BAH source labels the highest officer bucket "O-7/O-7+";
+  // accept plain "O7" as a synonym so the model doesn't need to know that.
+  out['O7'] = out['O7'] ?? out['O7/O7+'];
+  return out;
+})();
+
+function resolveRankId(rank: string): string | null {
+  const key = normalizeRankKey(rank);
+  return RANK_NAME_TO_ID[key] ?? null;
+}
+
+const calculateBAHTool = tool({
+  description:
+    'Calculate the Basic Allowance for Housing (BAH) for a given year, ZIP code, and pay grade. Pay grade values like E1–E9, O1–O7, W1–W5. The BAH source caps officer rates at O-7+, so O-8 and above use the O-7+ rate. Returns monthly amounts for with-dependents and without-dependents, plus the Military Housing Area name.',
+  inputSchema: bahInputSchema,
+  execute: async ({
+    year,
+    zipCode,
+    rank,
+  }): Promise<ToolResult<BAHData>> => {
+    const rankId = resolveRankId(rank);
+    if (!rankId) {
+      logInfo('Concierge tool: calculateBAH invalid rank', { rank });
+      return {
+        ok: false,
+        error: `Unknown pay grade "${rank}". Use a value like E5, O3, W2.`,
+      };
+    }
+    try {
+      const data = await extractBAHData(year, zipCode, rankId);
+      logInfo('Concierge tool: calculateBAH', {
+        year,
+        zipCode,
+        rank: data.rank,
+      });
+      return { ok: true, data };
+    } catch (error) {
+      logError(
+        'Concierge tool: calculateBAH failed',
+        { year, zipCode, rank },
+        error,
+      );
+      const message =
+        error instanceof Error ? error.message : 'BAH lookup failed.';
+      return { ok: false, error: message };
+    }
+  },
+});
+
+export const calcTools = {
+  calculateBAH: calculateBAHTool,
+};

--- a/lib/ai/tools/calc-tools.ts
+++ b/lib/ai/tools/calc-tools.ts
@@ -22,6 +22,8 @@ const RANK_NAME_TO_ID: Record<string, string> = (() => {
   // Common alias: the BAH source labels the highest officer bucket "O-7/O-7+";
   // accept plain "O7" as a synonym so the model doesn't need to know that.
   out['O7'] = out['O7'] ?? out['O7/O7+'];
+  // DTMO caps officer rates at O-7+; route O-8/O-9/O-10 to the same bucket.
+  out['O8'] = out['O9'] = out['O10'] = out['O7'];
   return out;
 })();
 

--- a/lib/ai/tools/data-tools.ts
+++ b/lib/ai/tools/data-tools.ts
@@ -170,7 +170,15 @@ const getAgentsForStateTool = tool({
       if (!matched) {
         return { ok: false, error: `Could not find a state matching "${state}".` };
       }
-      const data = await stateService.fetchAgentsListByState(matched.state_name);
+      if (!matched.short_name) {
+        logError('Concierge tool: getAgentsForState matched state missing short_name', {
+          slug: matched.state_slug?.current,
+          input: state,
+        });
+      }
+      const data = await stateService.fetchAgentsListByState(matched.short_name, {
+        requireHeadshot: false,
+      });
       const agents = (data.records || [])
         .map(trimAgent)
         .filter((a) => a.id)
@@ -210,7 +218,15 @@ const getLendersForStateTool = tool({
       if (!matched) {
         return { ok: false, error: `Could not find a state matching "${state}".` };
       }
-      const data = await stateService.fetchLendersListByState(matched.state_name);
+      if (!matched.short_name) {
+        logError('Concierge tool: getLendersForState matched state missing short_name', {
+          slug: matched.state_slug?.current,
+          input: state,
+        });
+      }
+      const data = await stateService.fetchLendersListByState(matched.short_name, {
+        requireHeadshot: false,
+      });
       const lenders = (data.records || [])
         .map(trimLender)
         .filter((l) => l.id)

--- a/lib/ai/tools/data-tools.ts
+++ b/lib/ai/tools/data-tools.ts
@@ -1,0 +1,242 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import stateService, {
+  type Agent,
+  type Lenders,
+  type StateList,
+} from '@/services/stateService';
+import { logError, logInfo } from '@/services/loggingService';
+import { stateInputSchema, type ToolResult } from '@/lib/ai/tools/types';
+
+// --- Public-facing trimmed shapes (NO PII: no PhotoUrl, PersonEmail, PersonMobilePhone) ---
+
+export interface PublicState {
+  slug: string;
+  name: string;
+}
+
+export interface PublicAgent {
+  id: string;
+  name: string;
+  firstName: string;
+  lastName: string;
+  brokerage: string;
+  city: string;
+  militaryStatus: string;
+  militaryService: string;
+  statesLicensed: string;
+}
+
+export interface PublicLender {
+  id: string;
+  name: string;
+  firstName: string;
+  brokerage: string;
+  city: string;
+  militaryStatus: string;
+  militaryService: string;
+  individualNmlsId: string;
+  companyNmlsId: string;
+}
+
+// --- State normalization ---
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+async function normalizeStateInput(
+  raw: string,
+): Promise<{ state: StateList | null; allStates: StateList[] }> {
+  const allStates = await stateService.fetchStateList();
+  const target = slugify(raw);
+  const match =
+    allStates.find((s) => s.state_slug?.current === target) ??
+    allStates.find((s) => slugify(s.state_name || '') === target) ??
+    allStates.find((s) => slugify(s.short_name || '') === target) ??
+    null;
+  return { state: match, allStates };
+}
+
+// --- Tool: listStates ---
+
+const listStatesTool = tool({
+  description:
+    'List every US state where VeteranPCS has vetted partner agents and lenders. Returns slug and display name for each state.',
+  inputSchema: z.object({}),
+  execute: async (): Promise<
+    ToolResult<{ states: PublicState[] }>
+  > => {
+    try {
+      const raw = await stateService.fetchStateList();
+      const states: PublicState[] = raw
+        .filter((s) => s.state_slug?.current && s.state_name)
+        .map((s) => ({
+          slug: s.state_slug.current,
+          name: s.state_name,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      logInfo('Concierge tool: listStates', { count: states.length });
+      return { ok: true, data: { states } };
+    } catch (error) {
+      logError('Concierge tool: listStates failed', undefined, error);
+      return { ok: false, error: 'Could not load the list of states right now.' };
+    }
+  },
+});
+
+// --- Tool: getStateDetails ---
+
+const getStateDetailsTool = tool({
+  description:
+    'Get details for a single US state by slug ("texas") or name ("Texas"). Use this when the user names a state and you need its Sanity record (display name, image, etc.).',
+  inputSchema: stateInputSchema,
+  execute: async ({ state }): Promise<ToolResult<{ state: StateList }>> => {
+    try {
+      const { state: matched } = await normalizeStateInput(state);
+      if (!matched) {
+        logInfo('Concierge tool: getStateDetails unknown state', {
+          input: state,
+        });
+        return { ok: false, error: `Could not find a state matching "${state}".` };
+      }
+      const details = await stateService.fetchStateDetails(
+        matched.state_slug.current,
+      );
+      logInfo('Concierge tool: getStateDetails', {
+        slug: matched.state_slug.current,
+      });
+      return { ok: true, data: { state: details } };
+    } catch (error) {
+      logError('Concierge tool: getStateDetails failed', { state }, error);
+      return { ok: false, error: 'Could not load state details right now.' };
+    }
+  },
+});
+
+// --- Helpers for ranking / trimming ---
+
+function topAreaCity(record: Agent | Lenders): string {
+  const area = record.Area_Assignments__r?.records?.[0]?.Area__r?.Name;
+  return area ?? '';
+}
+
+function trimAgent(agent: Agent): PublicAgent {
+  const billingCity = agent.BillingAddress?.city ?? '';
+  return {
+    id: agent.AccountId_15__c ?? '',
+    name: agent.Name ?? '',
+    firstName: agent.FirstName ?? '',
+    lastName: agent.LastName ?? '',
+    brokerage: agent.Brokerage_Name__pc ?? '',
+    city: billingCity || topAreaCity(agent),
+    militaryStatus: agent.Military_Status__pc ?? '',
+    militaryService: agent.Military_Service__pc ?? '',
+    statesLicensed: agent.State_s_Licensed_in__pc ?? '',
+  };
+}
+
+function trimLender(lender: Lenders): PublicLender {
+  const billingCity = lender.BillingCity ?? '';
+  return {
+    id: lender.AccountId_15__c ?? '',
+    name: lender.Name ?? '',
+    firstName: lender.FirstName ?? '',
+    brokerage: lender.Brokerage_Name__pc ?? '',
+    city: billingCity || topAreaCity(lender),
+    militaryStatus: lender.Military_Status__pc ?? '',
+    militaryService: lender.Military_Service__pc ?? '',
+    individualNmlsId: lender.Individual_NMLS_ID__pc ?? '',
+    companyNmlsId: lender.Company_NMLS_ID__pc ?? '',
+  };
+}
+
+// --- Tool: getAgentsForState ---
+
+const getAgentsForStateTool = tool({
+  description:
+    'Get up to 5 vetted real estate agents who serve a given US state. Use this when the user wants help finding an agent. Returns trimmed, public-facing data only (no email or phone).',
+  inputSchema: stateInputSchema,
+  execute: async ({
+    state,
+  }): Promise<ToolResult<{ stateSlug: string; stateName: string; agents: PublicAgent[] }>> => {
+    try {
+      const { state: matched } = await normalizeStateInput(state);
+      if (!matched) {
+        return { ok: false, error: `Could not find a state matching "${state}".` };
+      }
+      const data = await stateService.fetchAgentsListByState(matched.state_name);
+      const agents = (data.records || [])
+        .map(trimAgent)
+        .filter((a) => a.id)
+        .slice(0, 5);
+      logInfo('Concierge tool: getAgentsForState', {
+        slug: matched.state_slug.current,
+        count: agents.length,
+      });
+      return {
+        ok: true,
+        data: {
+          stateSlug: matched.state_slug.current,
+          stateName: matched.state_name,
+          agents,
+        },
+      };
+    } catch (error) {
+      logError('Concierge tool: getAgentsForState failed', { state }, error);
+      return { ok: false, error: 'Could not load agents for that state right now.' };
+    }
+  },
+});
+
+// --- Tool: getLendersForState ---
+
+const getLendersForStateTool = tool({
+  description:
+    'Get up to 5 vetted VA-loan lenders who serve a given US state. Use this when the user wants help finding a lender. Returns trimmed, public-facing data only (no email or phone).',
+  inputSchema: stateInputSchema,
+  execute: async ({
+    state,
+  }): Promise<
+    ToolResult<{ stateSlug: string; stateName: string; lenders: PublicLender[] }>
+  > => {
+    try {
+      const { state: matched } = await normalizeStateInput(state);
+      if (!matched) {
+        return { ok: false, error: `Could not find a state matching "${state}".` };
+      }
+      const data = await stateService.fetchLendersListByState(matched.state_name);
+      const lenders = (data.records || [])
+        .map(trimLender)
+        .filter((l) => l.id)
+        .slice(0, 5);
+      logInfo('Concierge tool: getLendersForState', {
+        slug: matched.state_slug.current,
+        count: lenders.length,
+      });
+      return {
+        ok: true,
+        data: {
+          stateSlug: matched.state_slug.current,
+          stateName: matched.state_name,
+          lenders,
+        },
+      };
+    } catch (error) {
+      logError('Concierge tool: getLendersForState failed', { state }, error);
+      return { ok: false, error: 'Could not load lenders for that state right now.' };
+    }
+  },
+});
+
+export const dataTools = {
+  listStates: listStatesTool,
+  getStateDetails: getStateDetailsTool,
+  getAgentsForState: getAgentsForStateTool,
+  getLendersForState: getLendersForStateTool,
+};

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -1,0 +1,13 @@
+import { dataTools } from '@/lib/ai/tools/data-tools';
+import { calcTools } from '@/lib/ai/tools/calc-tools';
+import { leadTools } from '@/lib/ai/tools/lead-tools';
+
+export function buildTools() {
+  return {
+    ...dataTools,
+    ...calcTools,
+    ...leadTools,
+  };
+}
+
+export type ConciergeTools = ReturnType<typeof buildTools>;

--- a/lib/ai/tools/lead-tools.ts
+++ b/lib/ai/tools/lead-tools.ts
@@ -1,0 +1,208 @@
+import { tool } from 'ai';
+import {
+  contactAgentPostForm,
+  contactLenderPostForm,
+  contactPostForm,
+  vaLoanGuideForm,
+} from '@/services/salesForcePostFormsService';
+import { logError, logInfo } from '@/services/loggingService';
+import {
+  agentRequestSchema,
+  lenderRequestSchema,
+  generalInquirySchema,
+  vaLoanGuideSchema,
+  type ToolResult,
+} from '@/lib/ai/tools/types';
+
+interface LeadSuccess {
+  kind: 'agent' | 'lender' | 'general' | 'va_guide';
+  message: string;
+}
+
+export const SUCCESS_MESSAGE =
+  "We've shared your details. A team member will reach out shortly.";
+
+const SUBMIT_REQUIRED =
+  'Required: first name, last name, email, phone. The SDK-level approval gate handles confirmation — emit the call when the user has provided the required fields.';
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return 'Submission failed.';
+}
+
+// Overwrites SF additionalComments on each call — fine for single-submit flows;
+// a retry within one conversation will replace prior context.
+function composeAdditionalComments(parts: Array<[string, string | undefined]>): string {
+  const prefix = '[via Concierge]';
+  const filled = parts
+    .filter(([, v]) => typeof v === 'string' && v.trim().length > 0)
+    .map(([label, v]) => `${label}: ${(v as string).trim()}`);
+  return `${prefix} ${filled.join(' | ')}`.trim();
+}
+
+// --- Agent ---
+
+const submitAgentRequestTool = tool({
+  description: `Send the user's contact details to VeteranPCS so a vetted real estate agent can reach out. ${SUBMIT_REQUIRED} Also required: destinationState. The destinationCity, currentLocation, branch, rank, and message fields are optional context.`,
+  inputSchema: agentRequestSchema,
+  needsApproval: true,
+  execute: async (input): Promise<ToolResult<LeadSuccess>> => {
+    try {
+      const additionalComments = composeAdditionalComments([
+        ['Rank', input.rank],
+        ['Branch', input.branch],
+        ['Message', input.message],
+      ]);
+      const formData = {
+        firstName: input.firstName,
+        lastName: input.lastName,
+        email: input.email,
+        phone: input.phone,
+        state: input.destinationState,
+        destinationBase: input.destinationCity ?? '',
+        currentBase: input.currentLocation ?? '',
+        branch_select: input.branch ?? '',
+        additionalComments,
+      };
+      logInfo('Concierge tool: submitAgentRequest', {
+        destinationState: input.destinationState,
+        hasMessage: Boolean(input.message),
+      });
+      await contactAgentPostForm(formData, '');
+      return {
+        ok: true,
+        data: { kind: 'agent', message: SUCCESS_MESSAGE },
+      };
+    } catch (error) {
+      logError(
+        'Concierge tool: submitAgentRequest failed',
+        { destinationState: input.destinationState },
+        error,
+      );
+      return { ok: false, error: errorMessage(error) };
+    }
+  },
+});
+
+// --- Lender ---
+
+const submitLenderRequestTool = tool({
+  description: `Send the user's contact details to VeteranPCS so a vetted VA-loan lender can reach out. ${SUBMIT_REQUIRED} Also required: destinationState. The destinationCity, loanType, and message fields are optional context.`,
+  inputSchema: lenderRequestSchema,
+  needsApproval: true,
+  execute: async (input): Promise<ToolResult<LeadSuccess>> => {
+    try {
+      const additionalComments = composeAdditionalComments([
+        ['Destination state', input.destinationState],
+        ['Destination city', input.destinationCity],
+        ['Loan type', input.loanType],
+        ['Message', input.message],
+      ]);
+      const formData = {
+        firstName: input.firstName,
+        lastName: input.lastName,
+        email: input.email,
+        phone: input.phone,
+        currentBase: input.destinationCity ?? '',
+        additionalComments,
+      };
+      logInfo('Concierge tool: submitLenderRequest', {
+        destinationState: input.destinationState,
+        hasMessage: Boolean(input.message),
+      });
+      await contactLenderPostForm(formData, '');
+      return {
+        ok: true,
+        data: { kind: 'lender', message: SUCCESS_MESSAGE },
+      };
+    } catch (error) {
+      logError(
+        'Concierge tool: submitLenderRequest failed',
+        { destinationState: input.destinationState },
+        error,
+      );
+      return { ok: false, error: errorMessage(error) };
+    }
+  },
+});
+
+// --- General inquiry ---
+
+const submitGeneralInquiryTool = tool({
+  description: `Send a general question or request for a human follow-up to the VeteranPCS team. ${SUBMIT_REQUIRED} Also required: subject, message. Use this for escalations (e.g., "Requesting human follow-up").`,
+  inputSchema: generalInquirySchema,
+  needsApproval: true,
+  execute: async (input): Promise<ToolResult<LeadSuccess>> => {
+    try {
+      const additionalComments = composeAdditionalComments([
+        ['Subject', input.subject],
+        ['Phone', input.phone],
+        ['Message', input.message],
+      ]);
+      const formData = {
+        firstName: input.firstName,
+        lastName: input.lastName,
+        email: input.email,
+        phone: input.phone,
+        additionalComments,
+      };
+      logInfo('Concierge tool: submitGeneralInquiry', {
+        hasSubject: Boolean(input.subject),
+      });
+      await contactPostForm(formData);
+      return {
+        ok: true,
+        data: { kind: 'general', message: SUCCESS_MESSAGE },
+      };
+    } catch (error) {
+      logError('Concierge tool: submitGeneralInquiry failed', undefined, error);
+      return { ok: false, error: errorMessage(error) };
+    }
+  },
+});
+
+// --- VA loan guide ---
+
+const submitVALoanGuideRequestTool = tool({
+  description: `Send the user's contact details so VeteranPCS can email them the VA Loan Guide. ${SUBMIT_REQUIRED}`,
+  inputSchema: vaLoanGuideSchema,
+  needsApproval: true,
+  execute: async (input): Promise<ToolResult<LeadSuccess>> => {
+    try {
+      const additionalComments = composeAdditionalComments([
+        ['Destination state', input.destinationState],
+        ['Phone', input.phone],
+      ]);
+      const formData = {
+        firstName: input.firstName,
+        lastName: input.lastName,
+        email: input.email,
+        phone: input.phone,
+        state: input.destinationState ?? '',
+        additionalComments,
+      };
+      logInfo('Concierge tool: submitVALoanGuideRequest', {
+        hasState: Boolean(input.destinationState),
+      });
+      await vaLoanGuideForm(formData);
+      return {
+        ok: true,
+        data: { kind: 'va_guide', message: SUCCESS_MESSAGE },
+      };
+    } catch (error) {
+      logError(
+        'Concierge tool: submitVALoanGuideRequest failed',
+        undefined,
+        error,
+      );
+      return { ok: false, error: errorMessage(error) };
+    }
+  },
+});
+
+export const leadTools = {
+  submitAgentRequest: submitAgentRequestTool,
+  submitLenderRequest: submitLenderRequestTool,
+  submitGeneralInquiry: submitGeneralInquiryTool,
+  submitVALoanGuideRequest: submitVALoanGuideRequestTool,
+};

--- a/lib/ai/tools/types.ts
+++ b/lib/ai/tools/types.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+export const stateInputSchema = z.object({
+  state: z
+    .string()
+    .min(2)
+    .describe('US state name (e.g., "Texas") or slug (e.g., "texas"). The tool handles both.'),
+});
+
+export const bahInputSchema = z.object({
+  year: z
+    .string()
+    .regex(/^\d{4}$/)
+    .describe('4-digit BAH year (e.g., "2026"). Use the current year unless the user specifies otherwise.'),
+  zipCode: z
+    .string()
+    .regex(/^\d{5}$/)
+    .describe('5-digit US ZIP code for the duty station or destination.'),
+  rank: z
+    .string()
+    .min(2)
+    .describe('Military pay grade like "E5", "O3", "W2". Case-insensitive.'),
+});
+
+const contactBase = z.object({
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  email: z.string().email(),
+  phone: z.string().min(7),
+});
+
+export const agentRequestSchema = contactBase.extend({
+  destinationState: z.string().min(2).describe('Full US state name the user is moving to.'),
+  destinationCity: z.string().optional(),
+  currentLocation: z.string().optional(),
+  branch: z.string().optional().describe('Military branch (e.g., Army, Navy).'),
+  rank: z.string().optional(),
+  message: z.string().optional().describe('Any context the user wants to share with the agent.'),
+});
+
+export const lenderRequestSchema = contactBase.extend({
+  destinationState: z.string().min(2),
+  destinationCity: z.string().optional(),
+  loanType: z.string().optional().describe('e.g., "VA loan", "conventional", "refinance".'),
+  message: z.string().optional(),
+});
+
+export const generalInquirySchema = contactBase.extend({
+  subject: z.string().min(1).describe('Short subject line summarizing what the user needs.'),
+  message: z.string().min(1).describe('The user\'s question or request, in their words.'),
+});
+
+export const vaLoanGuideSchema = contactBase.extend({
+  destinationState: z.string().optional(),
+});
+
+export type AgentRequestInput = z.infer<typeof agentRequestSchema>;
+export type LenderRequestInput = z.infer<typeof lenderRequestSchema>;
+export type GeneralInquiryInput = z.infer<typeof generalInquirySchema>;
+export type VALoanGuideInput = z.infer<typeof vaLoanGuideSchema>;
+export type BAHInput = z.infer<typeof bahInputSchema>;
+
+export interface ToolErrorResult {
+  ok: false;
+  error: string;
+}
+
+export interface ToolSuccessResult<T> {
+  ok: true;
+  data: T;
+}
+
+export type ToolResult<T> = ToolSuccessResult<T> | ToolErrorResult;

--- a/lib/bah-scraper.ts
+++ b/lib/bah-scraper.ts
@@ -30,7 +30,8 @@ export const RANK_MAPPING: Record<string, string> = {
     '23': 'O-6', '24': 'O-7/O-7+'
 };
 
-// HTTPS request helper
+// HTTPS request helper. Exposed via `__testables` below so unit tests can stub
+// the network without monkey-patching node:https.
 function fetchPage(url: string, postData: PostData | null = null): Promise<string> {
     return new Promise((resolve, reject) => {
         const urlObj = new URL(url);
@@ -80,16 +81,23 @@ function fetchPage(url: string, postData: PostData | null = null): Promise<strin
     });
 }
 
+// DTMO expects a 2-digit year on the wire (e.g., "25"); the concierge tool sends
+// a 4-digit year (e.g., "2025") to keep the user-facing contract unambiguous.
+function toDtmoYear(year: string): string {
+    return year.length === 4 ? year.slice(-2) : year;
+}
+
+function toFourDigitYear(year: string): string {
+    return year.length === 2 ? `20${year}` : year;
+}
+
 // Data extraction from HTML document
 async function extractDataFromDocument(
-    $: cheerio.CheerioAPI, 
-    year: string, 
-    zipCode: string, 
-    rankId: string, 
-    rankName: string
+    $: cheerio.CheerioAPI,
+    rankName: string,
 ): Promise<BAHData> {
     const importDiv = $('#ImportDiv2');
-    
+
     if (importDiv.length === 0) {
         throw new Error('Could not find BAH data container');
     }
@@ -119,7 +127,7 @@ async function extractDataFromDocument(
     }
 
     const amountCells = table.find('td.trn-cola.text-center:contains("$")');
-    
+
     if (amountCells.length < 2) {
         throw new Error('Could not find BAH amount cells');
     }
@@ -137,7 +145,7 @@ async function extractDataFromDocument(
     }
 
     return {
-        year: extractedYear,
+        year: toFourDigitYear(extractedYear),
         zipCode: extractedZip,
         rank: rankName,
         mha,
@@ -151,25 +159,31 @@ async function extractDataFromDocument(
 // Main extraction function
 export async function extractBAHData(year: string, zipCode: string, rankId: string): Promise<BAHData> {
     const rankName = RANK_MAPPING[rankId];
-    
+
     if (!rankName) {
         throw new Error('Invalid rank ID');
     }
 
-    console.log(`Extracting BAH data: Year=${year}, ZIP=${zipCode}, Rank=${rankName} (ID=${rankId})`);
+    const dtmoYear = toDtmoYear(year);
+
+    console.log(`Extracting BAH data: Year=${year} (wire=${dtmoYear}), ZIP=${zipCode}, Rank=${rankName} (ID=${rankId})`);
 
     // CRITICAL: Direct POST data structure
     const postData: PostData = {
         report: 'bah',
-        YEAR: year,
+        YEAR: dtmoYear,
         Zipcode: zipCode,
         Rank: rankId.toString()
     };
 
     // CRITICAL: Direct POST URL
     const postUrl = 'https://www.defensetravel.dod.mil/neorates/report/index.php';
-    const html = await fetchPage(postUrl, postData);
+    const html = await __testables.fetchPage(postUrl, postData);
 
     const $ = cheerio.load(html);
-    return await extractDataFromDocument($, year, zipCode, rankId, rankName);
+    return await extractDataFromDocument($, rankName);
 }
+
+// Indirection object so tests can stub the network layer with vi.spyOn.
+// Not part of the public contract — do not import outside of tests.
+export const __testables = { fetchPage };

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,8 @@
+function readBoolEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  return value === '1' || value.toLowerCase() === 'true';
+}
+
+export const featureFlags = {
+  conciergeEnabled: readBoolEnv(process.env.NEXT_PUBLIC_CONCIERGE_ENABLED),
+};

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,42 @@
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+import { logInfo } from '@/services/loggingService';
+
+interface LimitResult {
+  success: boolean;
+  limit: number;
+  remaining: number;
+  reset: number;
+}
+
+interface Limiter {
+  limit(identifier: string): Promise<LimitResult>;
+}
+
+function buildLimiter(): Limiter {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) {
+    logInfo('Rate limit disabled — Upstash env vars missing');
+    const now = Date.now();
+    return {
+      limit: async () => ({
+        success: true,
+        limit: Infinity,
+        remaining: Infinity,
+        reset: now,
+      }),
+    };
+  }
+
+  const redis = new Redis({ url, token });
+  return new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(10, '60 s'),
+    analytics: false,
+    prefix: 'ratelimit:chat',
+  });
+}
+
+export const chatLimiter: Limiter = buildLimiter();

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import { withBotId } from 'botid/next/config';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async headers() {
@@ -119,4 +121,4 @@ const nextConfig = {
   }
 };
 
-export default nextConfig;
+export default withBotId(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,8 @@
         "lint-staged": "^15.2.10",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -7849,6 +7850,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -7857,6 +7869,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -8831,6 +8850,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xstate/react": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@xstate/react/-/react-6.1.0.tgz",
@@ -9356,6 +9490,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -9972,6 +10116,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -10143,6 +10297,23 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -10215,6 +10386,16 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -11479,6 +11660,16 @@
         "node": ">= 16"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -12035,6 +12226,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -12886,6 +13084,16 @@
       "resolved": "https://registry.npmjs.org/exif-component/-/exif-component-1.0.1.tgz",
       "integrity": "sha512-FXnmK9yJYTa3V3G7DE9BRjUJ0pwXMICAxfbsAuKPTuSlFzMZhQbcvvwx0I8ofNJHxz3tfjze+whxcGpfklAWOQ==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/express": {
       "version": "5.2.1",
@@ -17230,6 +17438,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -17237,6 +17452,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -20409,6 +20634,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/peek-stream": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -23119,6 +23361,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -23367,6 +23616,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -23375,6 +23631,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -23782,6 +24045,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stubs": {
       "version": "3.0.0",
@@ -24287,6 +24570,20 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -24313,6 +24610,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -25514,6 +25841,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-tsconfig-paths": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
@@ -25537,6 +25887,92 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -25751,6 +26187,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vpcs-nextjs-website",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/react": "^3.0.190",
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
         "@google-cloud/local-auth": "^3.0.1",
@@ -17,10 +18,14 @@
         "@next/third-parties": "16.2.4",
         "@sanity/image-url": "^1.0.2",
         "@sanity/vision": "^3.62.0",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "@vercel/og": "^0.6.4",
         "@vercel/speed-insights": "^1.2.0",
+        "ai": "^6.0.188",
         "aos": "^2.3.4",
         "axios": "^1.15.1",
+        "botid": "^1.5.11",
         "chart.js": "^4.4.8",
         "cheerio": "^1.1.0",
         "gray-matter": "^4.0.3",
@@ -146,6 +151,70 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "license": "MIT"
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.118",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.118.tgz",
+      "integrity": "sha512-XYPbVoDo1TDMVLe5Eg42gIjdOyxaizh9H0kiSSnTXr+AdrqZvutk/ypLOiqBXPV3D1K3+BSm/sbFeomZJlM64A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.190",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.190.tgz",
+      "integrity": "sha512-ee8bZ3ZCC/PZDfCIX0LNvoPezo1v+jHp85pW6ct6B3qddsSp4SoFvapGuhK1gHRMLR6rKq0D5Gjii/+rgLzb9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.27",
+        "ai": "6.0.188",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -5422,6 +5491,15 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -7637,6 +7715,12 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -8625,6 +8709,39 @@
         "win32"
       ]
     },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/@vercel/edge": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.2.tgz",
@@ -8643,6 +8760,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vercel/speed-insights": {
@@ -8823,6 +8949,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.188",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.188.tgz",
+      "integrity": "sha512-kNwIl1MM4ESzeOPDYuN+FidJ2QY5kGWHLtTMru6HHPW/JJ6nPuvHRhJ8tMX/Y2Tijx9DCiv2W7y5IBouuB712g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.118",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -9663,6 +9807,23 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/botid": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/botid/-/botid-1.5.11.tgz",
+      "integrity": "sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -16458,6 +16619,12 @@
       "resolved": "https://registry.npmjs.org/json-reduce/-/json-reduce-3.0.0.tgz",
       "integrity": "sha512-zvnhEvwhqTOxBIcXnxvHvhqtubdwFRp+FascmCaL56BT9jdttRU8IFc+Ilh2HPJ0AtioF8mFPxmReuJKLW0Iyw==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -23775,6 +23942,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -24041,6 +24221,18 @@
       "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
       "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
       "license": "ISC"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -24579,6 +24771,12 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.25.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.190",
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
     "@google-cloud/local-auth": "^3.0.1",
@@ -20,10 +21,14 @@
     "@next/third-parties": "16.2.4",
     "@sanity/image-url": "^1.0.2",
     "@sanity/vision": "^3.62.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "@vercel/og": "^0.6.4",
     "@vercel/speed-insights": "^1.2.0",
+    "ai": "^6.0.188",
     "aos": "^2.3.4",
     "axios": "^1.15.1",
+    "botid": "^1.5.11",
     "chart.js": "^4.4.8",
     "cheerio": "^1.1.0",
     "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -68,7 +70,8 @@
     "lint-staged": "^15.2.10",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   },
   "overrides": {
     "@types/react": "19.2.14",

--- a/services/stateService.tsx
+++ b/services/stateService.tsx
@@ -119,7 +119,7 @@ export interface LendersData {
 const stateService = {
   fetchStateList: async (): Promise<StateList[]> => {
     try {
-      const response = await client.fetch(`*[_type == "state_list"]{ state_slug, short_name }`)
+      const response = await client.fetch(`*[_type == "state_list"]{ state_slug, short_name, state_name }`)
       if (response) {
         const seen = new Set<string>();
         return (response as StateList[]).filter((state) => {
@@ -158,7 +158,11 @@ const stateService = {
       throw error;
     }
   },
-  fetchAgentsListByState: async (state: string): Promise<AgentsData> => {
+  fetchAgentsListByState: async (
+    state: string,
+    options: { requireHeadshot?: boolean } = {},
+  ): Promise<AgentsData> => {
+    const { requireHeadshot = true } = options;
     try {
       const query = `
         SELECT Name, AccountId_15__c, FirstName, Agent_Bio__pc, Military_Status__pc,
@@ -180,7 +184,8 @@ const stateService = {
         const resolved = await Promise.all(
           response.data.records.map(async (agent: Agent) => {
             const PhotoUrl = await resolveHeadshot('agents', agent.AccountId_15__c);
-            return PhotoUrl ? { ...agent, PhotoUrl } : null;
+            if (PhotoUrl) return { ...agent, PhotoUrl };
+            return requireHeadshot ? null : agent;
           }),
         );
         const records = resolved.filter((agent): agent is Agent => agent !== null);
@@ -190,7 +195,7 @@ const stateService = {
         // Token expired: Refresh and retry
         try {
           await getSalesforceToken(); // Refresh token
-          return await stateService.fetchAgentsListByState(state); // Retry the request
+          return await stateService.fetchAgentsListByState(state, options); // Retry the request
         } catch (tokenError) {
           console.error("Failed to refresh token:", tokenError);
           throw tokenError;
@@ -203,7 +208,11 @@ const stateService = {
       throw error;
     }
   },
-  fetchLendersListByState: async (state: string): Promise<LendersData> => {
+  fetchLendersListByState: async (
+    state: string,
+    options: { requireHeadshot?: boolean } = {},
+  ): Promise<LendersData> => {
+    const { requireHeadshot = true } = options;
     try {
       const query = `
       SELECT Name, AccountId_15__c, FirstName, Agent_Bio__pc, Military_Status__pc, Military_Service__pc, Brokerage_Name__pc, BillingCity, BillingState, Individual_NMLS_ID__pc, Company_NMLS_ID__pc,
@@ -223,7 +232,8 @@ const stateService = {
         const resolved = await Promise.all(
           response.data.records.map(async (lender: Lenders) => {
             const PhotoUrl = await resolveHeadshot('lenders', lender.AccountId_15__c);
-            return PhotoUrl ? { ...lender, PhotoUrl } : null;
+            if (PhotoUrl) return { ...lender, PhotoUrl };
+            return requireHeadshot ? null : lender;
           }),
         );
         const records = resolved.filter((lender): lender is Lenders => lender !== null);
@@ -233,7 +243,7 @@ const stateService = {
       } else if (response?.status === 401) {
         try {
           await getSalesforceToken();
-          return await stateService.fetchLendersListByState(state);
+          return await stateService.fetchLendersListByState(state, options);
         } catch (tokenError) {
           console.error('Failed to refresh token:', tokenError);
           throw tokenError;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,6 +45,7 @@ const config: Config = {
       zIndex: {
         'nav': '9999',
         'loader': '1000',
+        'concierge': '8000',
       },
       transitionProperty: {
         'visibility': 'visibility, opacity',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['**/__tests__/**/*.test.ts'],
+    exclude: ['node_modules', '.next', 'public'],
+  },
+});


### PR DESCRIPTION
## Summary

Lands the Phase 2 LLM concierge foundation on top of the existing marketing site. The full feature is **off by default** behind `NEXT_PUBLIC_CONCIERGE_ENABLED` — when the flag is unset or false, nothing concierge-related loads, renders, or fetches, and all existing Salesforce form submission paths are byte-identical to `main`.

- **Concierge AI foundation** — Vercel AI SDK v6 via AI Gateway (`anthropic/claude-sonnet-4-6`), system prompt, session cookie, tools (data, calc, lead).
- **`/api/chat` streaming route** — BotID + Upstash rate limit, returns `404` before any work when the flag is off.
- **Concierge UI** — `<ConciergeProvider>`, `<ConciergeWidget>`, `MessageRenderer`, `AgentCard`, `BAHResult`, `StateCard`.
- **Form CTAs** — `Or chat with our concierge instead.` button on contact / agent / lender / VA-loan-guide forms, each flag-gated.
- **Bug fixes** — Sanity `state_name` projection restored; BAH scraper 2-digit/4-digit year round-trip; concierge tools now pass `requireHeadshot: false` so the LLM gets matches when a headshot is missing.
- **`CLAUDE.md`** — operational guide for future Claude/AI sessions in this repo.
- **README** — documents the Google Search Console blog indexer utility.

## Kill-switch guarantees (flag off)

Verified by two parallel sub-agent audits (kill-switch + form-impact) and then enforced at the JSX layer:

- No `<BotIdClient>` rendered — no remote script injection, no `window.fetch` monkey-patching.
- No `<ConciergeWidget>` rendered — no `useChat` execution, no AI SDK runtime work.
- No `Or chat with our concierge instead.` CTA on any form.
- `/api/chat` returns `404` before any other work.
- No `vpcs_concierge_sid` cookie set on any page.
- Form submission services (`salesForcePostFormsService.tsx`, `salesForceTokenService.tsx`, `api.tsx`, `sendToSlack.ts`, `sendOpenPhoneMessage.ts`) are byte-identical to `main`.
- `services/stateService.tsx` change is additive (`requireHeadshot` defaults to existing behavior).

## Env vars required to activate (preview / production)

- `AI_GATEWAY_API_KEY` (Vercel AI Gateway)
- `NEXT_PUBLIC_CONCIERGE_ENABLED=1` (or `true`)
- `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
- BotID is auto-wired on Vercel; no key needed.

## Test plan

- [ ] **Flag off (production default)**: load homepage, `/contact`, `/contact-agents`, `/contact-lender`, a state page, and a blog post. Confirm no concierge bubble, no concierge CTA, no `vpcs_concierge_sid` cookie, and `curl -X POST /api/chat` returns 404.
- [ ] **Existing Salesforce forms still submit**: contact form, agent contact, lender contact, VA loan guide download. Confirm Salesforce record creation + Slack notification + OpenPhone SMS still fire.
- [ ] **Flag on (preview)**: widget mounts, opens, and streams a response from the AI Gateway.
- [ ] **Concierge tools — read-only**: state listing returns vetted agents/lenders; agent results include those without a headshot.
- [ ] **BAH tool**: officer rates above O-7 alias to O-7; 2025 / 2026 rates resolve.
- [ ] **Lead handoff**: concierge `submit_lead` tool writes the Customer Person Account and triggers Slack + OpenPhone.
- [ ] **Rate limit**: rapid repeated POSTs to `/api/chat` return 429 after the configured threshold.
- [ ] **Pre-commit hook**: `npm run lint`, `npm run type-check`, `npm run build` all green (already passing locally).
- [ ] **Vitest**: `npm test` — all 12 tests across `lib/__tests__/bah-scraper.test.ts` and `lib/ai/tools/__tests__/data-tools.test.ts` pass.

## Why merge now

`main` has 23 outstanding Dependabot vulnerabilities (10 high, 11 moderate, 2 low). Landing this branch behind the flag lets us patch those on `main` without losing Phase 2 progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)