### PR TITLE
fix(blog): route lender authors' byline CTA to the lender contact form

### DIFF
--- a/components/Blog/AuthorByline.tsx
+++ b/components/Blog/AuthorByline.tsx
@@ -95,6 +95,7 @@ export default async function AuthorByline({
     firstName: author.firstName,
     salesforceId: author.salesforceId,
     stateSlug: author.stateSlug,
+    form: author.isLender ? 'lender' : 'agent',
   });
 
   return (

--- a/lib/contactAgentUrl.ts
+++ b/lib/contactAgentUrl.ts
@@ -1,8 +1,10 @@
+type ContactForm = 'agent' | 'lender';
+
 type Args = {
   firstName?: string | null;
   salesforceId?: string | null;
   stateSlug?: string | null;
-  form?: string;
+  form?: ContactForm;
 };
 
 export function buildContactCtaHref({
@@ -11,10 +13,13 @@ export function buildContactCtaHref({
   stateSlug,
   form = 'agent',
 }: Args): string {
+  // Keep the route and the form param in lock-step so a lender is never sent to
+  // the agent contact flow (which would record an agent lead in Salesforce).
+  const route = form === 'lender' ? '/contact-lender' : '/contact-agent';
   const params = new URLSearchParams();
   params.set('form', form);
   if (firstName) params.set('fn', firstName);
   if (salesforceId) params.set('id', salesforceId);
   if (stateSlug) params.set('state', stateSlug);
-  return `/contact-agent?${params.toString()}`;
+  return `${route}?${params.toString()}`;
 }


### PR DESCRIPTION
## What
Lender blog authors' "Get in Touch" byline button routed to the **agent** contact form, creating agent leads in Salesforce for lender contacts.

## Root cause
`components/Blog/AuthorByline.tsx` called `buildContactCtaHref` without the author's role, so `lib/contactAgentUrl.ts` used its silent `form='agent'` default and hardcoded `/contact-agent` route. The resolver already exposes `author.isLender`; the byline just dropped it. Surfaced when a Hawaii lender (Larry Gonzalez, Account `001Rg000006QuG4`, Lead `00QRg00000tYPTNMA4`) was contacted via his blog byline and routed as an agent.

## Fix
- `lib/contactAgentUrl.ts`: derive route from role (`/contact-lender` vs `/contact-agent`) so route + `form` param stay in lock-step; type `form` as `'agent' | 'lender'`.
- `components/Blog/AuthorByline.tsx`: pass `form: author.isLender ? 'lender' : 'agent'`.

## Verification
- `npm run type-check`, `npm run lint`, `npm run build` all pass.
- Rendered HTML on `/blog/should-active-duty-military-buy-a-home-in-hawaii`: byline now emits `/contact-lender?form=lender&fn=Larry&id=001Rg000006QuG4&state=hawaii`; no agent-routed Larry link remains. Agents unaffected (`isLender === false` → `/contact-agent`).

## Out of scope (follow-up)
Both web-to-lead POSTs send the same Salesforce `recordType` (`0124x000000Z5yD`); role is distinguished only by which custom field is populated (`Lsn28` agent vs `QPJUT` lender). If SF classifies by `recordType`, that's a separate latent risk to confirm with the Salesforce developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)