### PR TITLE
[codex] Add concierge coverage area routing

### DIFF
--- a/app/api/v1/areas/route.ts
+++ b/app/api/v1/areas/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import stateService from '@/services/stateService';
+import { buildCoverageIndexForState } from '@/lib/ai/routing/coverage';
 
 interface AreaAssignment {
     name: string;
@@ -37,30 +37,13 @@ export async function GET(request: NextRequest): Promise<NextResponse<AreasRespo
             }, { status: 400 });
         }
 
-        console.log(`Fetching areas for state: ${stateCode}`);
-
-        // Fetch agents data from Salesforce (server-side)
-        const agentsData = await stateService.fetchAgentsListByState(stateCode);
-
-        // Extract unique area names from all agents in this state
-        const uniqueAreas = new Set<string>();
-        agentsData.records.forEach(agent => {
-            const areaAssignments = agent.Area_Assignments__r?.records || [];
-            areaAssignments.forEach(assignment => {
-                // Filter areas for the specific state
-                if (assignment.Area__r.State__c.toLowerCase() === getStateNameFromAbbreviation(stateCode).toLowerCase()) {
-                    uniqueAreas.add(assignment.Area__r.Name);
-                }
-            });
-        });
-
-        // Convert to sorted array with slugs
-        const sortedAreas: AreaAssignment[] = Array.from(uniqueAreas)
-            .sort()
+        const coverageAreas = await buildCoverageIndexForState(stateCode);
+        const sortedAreas: AreaAssignment[] = coverageAreas
             .map(area => ({
-                name: area,
-                slug: area.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
-            }));
+                name: area.areaName,
+                slug: area.slug
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name));
 
         console.log(`Found ${sortedAreas.length} areas for ${stateCode}`);
 
@@ -77,24 +60,4 @@ export async function GET(request: NextRequest): Promise<NextResponse<AreasRespo
             error: errorMessage
         }, { status: 500 });
     }
-}
-
-// Helper function to get state name from abbreviation
-function getStateNameFromAbbreviation(abbr: string): string {
-    const stateMap: { [key: string]: string } = {
-        'AL': 'alabama', 'AK': 'alaska', 'AZ': 'arizona', 'AR': 'arkansas',
-        'CA': 'california', 'CO': 'colorado', 'CT': 'connecticut', 'DE': 'delaware',
-        'FL': 'florida', 'GA': 'georgia', 'HI': 'hawaii', 'ID': 'idaho',
-        'IL': 'illinois', 'IN': 'indiana', 'IA': 'iowa', 'KS': 'kansas',
-        'KY': 'kentucky', 'LA': 'louisiana', 'ME': 'maine', 'MD': 'maryland',
-        'MA': 'massachusetts', 'MI': 'michigan', 'MN': 'minnesota', 'MS': 'mississippi',
-        'MO': 'missouri', 'MT': 'montana', 'NE': 'nebraska', 'NV': 'nevada',
-        'NH': 'new hampshire', 'NJ': 'new jersey', 'NM': 'new mexico', 'NY': 'new york',
-        'NC': 'north carolina', 'ND': 'north dakota', 'OH': 'ohio', 'OK': 'oklahoma',
-        'OR': 'oregon', 'PA': 'pennsylvania', 'PR': 'puerto rico', 'RI': 'rhode island',
-        'SC': 'south carolina', 'SD': 'south dakota', 'TN': 'tennessee', 'TX': 'texas',
-        'UT': 'utah', 'VT': 'vermont', 'VA': 'virginia', 'WA': 'washington',
-        'DC': 'district of columbia', 'WV': 'west virginia', 'WI': 'wisconsin', 'WY': 'wyoming'
-    };
-    return stateMap[abbr] || abbr.toLowerCase();
 }

--- a/components/Concierge/AgentCard.tsx
+++ b/components/Concierge/AgentCard.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+import Image from 'next/image';
+import Link from 'next/link';
+
 export interface AgentListItem {
   id: string;
+  role?: 'agent' | 'lender';
   name: string;
   firstName?: string;
   lastName?: string;
@@ -9,12 +13,33 @@ export interface AgentListItem {
   city?: string;
   militaryStatus?: string;
   militaryService?: string;
+  photoUrl?: string;
+  bio?: string;
+  contactHref?: string;
+  profileHref?: string;
+  stateName?: string;
+  areaName?: string;
 }
 
 interface Props {
   list: AgentListItem[];
   kind: 'agent' | 'lender';
   onSelect?(item: AgentListItem): void;
+}
+
+function initials(name: string): string {
+  const parts = name
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('') || 'VP';
+}
+
+function militaryLine(item: AgentListItem): string {
+  return [item.militaryStatus, item.militaryService].filter(Boolean).join(' / ');
 }
 
 export default function AgentCard({ list, kind, onSelect }: Props) {
@@ -27,52 +52,118 @@ export default function AgentCard({ list, kind, onSelect }: Props) {
   }
 
   const label = kind === 'agent' ? 'agent' : 'lender';
+  const visibleList = list.slice(0, 3);
 
   return (
     <div className="flex flex-col gap-2">
       <p className="text-xs uppercase tracking-wide text-gray-500">
-        Top {label}{list.length === 1 ? '' : 's'} for you
+        Top {label}{visibleList.length === 1 ? '' : 's'} for you
       </p>
       <ul className="flex flex-col gap-2">
-        {list.slice(0, 5).map((item) => (
-          <li
-            key={item.id}
-            className="rounded-lg border border-gray-200 bg-white p-3 flex flex-col gap-2"
-          >
-            <div className="flex flex-col">
-              <span className="text-sm font-semibold text-primary">{item.name}</span>
-              {item.brokerage ? (
-                <span className="text-xs text-gray-600">{item.brokerage}</span>
+        {visibleList.map((item) => {
+          const firstName = item.firstName || item.name.split(/\s+/)[0] || item.name;
+          const contactText = `Start intake with ${firstName}`;
+          const profileText = item.stateName
+            ? `View on ${item.stateName} page`
+            : 'View details';
+          const photo = item.photoUrl ? (
+            <Image
+              src={item.photoUrl}
+              alt={`${item.name} headshot`}
+              fill
+              sizes="56px"
+              className="object-cover"
+            />
+          ) : (
+            <span className="flex h-full w-full items-center justify-center text-sm font-semibold">
+              {initials(item.name)}
+            </span>
+          );
+
+          return (
+            <li
+              key={item.id}
+              className="flex min-w-0 flex-col gap-3 rounded-lg border border-gray-200 bg-white p-3"
+            >
+              <div className="flex min-w-0 gap-3">
+                {item.profileHref ? (
+                  <Link
+                    href={item.profileHref}
+                    className="relative mt-0.5 h-14 w-14 shrink-0 overflow-hidden rounded-full bg-primary/10 text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
+                    aria-label={`View ${item.name} on the ${item.stateName || 'state'} page`}
+                  >
+                    {photo}
+                  </Link>
+                ) : (
+                  <div className="relative mt-0.5 flex h-14 w-14 shrink-0 overflow-hidden rounded-full bg-primary/10 text-primary">
+                    {photo}
+                  </div>
+                )}
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 flex-col">
+                    {item.profileHref ? (
+                      <Link
+                        href={item.profileHref}
+                        className="break-words text-sm font-semibold leading-snug text-primary underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
+                      >
+                        {item.name}
+                      </Link>
+                    ) : (
+                      <span className="break-words text-sm font-semibold leading-snug text-primary">
+                        {item.name}
+                      </span>
+                    )}
+                    {item.brokerage ? (
+                      <span className="truncate text-xs text-gray-600">{item.brokerage}</span>
+                    ) : null}
+                    {item.city ? (
+                      <span className="break-words text-xs text-gray-500">{item.city}</span>
+                    ) : null}
+                  </div>
+                  {militaryLine(item) ? (
+                    <p className="mt-1 break-words text-xs font-medium text-gray-700">
+                      {militaryLine(item)}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+
+              {item.bio ? (
+                <p className="overflow-hidden break-words text-xs leading-relaxed text-gray-600 [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2]">
+                  {item.bio}
+                </p>
               ) : null}
-              {item.city ? (
-                <span className="text-xs text-gray-500">{item.city}</span>
-              ) : null}
-            </div>
-            {item.militaryStatus || item.militaryService ? (
-              <div className="flex flex-wrap gap-1">
-                {item.militaryStatus ? (
-                  <span className="inline-block rounded-full bg-primary/10 text-primary text-[11px] px-2 py-0.5">
-                    {item.militaryStatus}
-                  </span>
+
+              <div className="flex flex-col gap-2">
+                {item.contactHref ? (
+                  <Link
+                    href={item.contactHref}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-md bg-accent-red px-3 py-2 text-center text-sm font-medium text-white motion-safe:transition-colors hover:bg-accent-red-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    {contactText}
+                  </Link>
+                ) : onSelect ? (
+                  <button
+                    type="button"
+                    onClick={() => onSelect(item)}
+                    className="inline-flex min-h-[44px] items-center justify-center rounded-md bg-accent-red px-3 py-2 text-center text-sm font-medium text-white motion-safe:transition-colors hover:bg-accent-red-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  >
+                    {contactText}
+                  </button>
                 ) : null}
-                {item.militaryService ? (
-                  <span className="inline-block rounded-full bg-gray-100 text-gray-700 text-[11px] px-2 py-0.5">
-                    {item.militaryService}
-                  </span>
+                {item.profileHref ? (
+                  <Link
+                    href={item.profileHref}
+                    className="inline-flex min-h-[36px] items-center justify-center rounded-md border border-gray-200 px-3 py-1.5 text-center text-xs font-medium text-primary motion-safe:transition-colors hover:bg-primary/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
+                  >
+                    {profileText}
+                  </Link>
                 ) : null}
               </div>
-            ) : null}
-            {onSelect ? (
-              <button
-                type="button"
-                onClick={() => onSelect(item)}
-                className="mt-1 inline-flex min-h-[44px] items-center justify-center rounded-md bg-accent-red px-3 py-2 text-sm font-medium text-white motion-safe:transition-colors hover:bg-accent-red-dark"
-              >
-                Connect with {item.firstName || item.name}
-              </button>
-            ) : null}
-          </li>
-        ))}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/components/Concierge/ConciergeWidget.tsx
+++ b/components/Concierge/ConciergeWidget.tsx
@@ -3,7 +3,7 @@
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai';
 import { usePathname } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { featureFlags } from '@/lib/feature-flags';
 import MessageRenderer from './MessageRenderer';
 import type { AgentListItem } from './AgentCard';
@@ -72,6 +72,7 @@ function SendIcon() {
 
 const FOCUSABLE_SELECTOR =
   'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
+const SCROLL_BOTTOM_THRESHOLD = 48;
 
 interface PageContextHolder {
   path: string | undefined;
@@ -85,6 +86,12 @@ export default function ConciergeWidget() {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
   const seedConsumedRef = useRef<boolean>(false);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const messageRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const anchoredAssistantMessageRef = useRef<string | null>(null);
+  const anchoredUserMessageRef = useRef<string | null>(null);
+  const wasNearBottomRef = useRef<boolean>(true);
+  const [showJumpToLatest, setShowJumpToLatest] = useState(false);
 
   const pageContextRef = useRef<PageContextHolder>({
     path: undefined,
@@ -199,18 +206,80 @@ export default function ConciergeWidget() {
     };
   }, [isOpen, close]);
 
-  // Auto-scroll the message list when new messages stream.
-  const listRef = useRef<HTMLDivElement | null>(null);
+  const updateNearBottomState = useCallback(() => {
+    const el = listRef.current;
+    if (!el) return true;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const isNearBottom = distanceFromBottom < SCROLL_BOTTOM_THRESHOLD;
+    wasNearBottomRef.current = isNearBottom;
+    setShowJumpToLatest(!isNearBottom);
+    return isNearBottom;
+  }, []);
+
+  const handleListScroll = useCallback(() => {
+    updateNearBottomState();
+  }, [updateNearBottomState]);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
+    const el = listRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior });
+    wasNearBottomRef.current = true;
+    setShowJumpToLatest(false);
+  }, []);
+
+  const registerMessageRef = useCallback(
+    (id: string) => (node: HTMLDivElement | null) => {
+      if (node) {
+        messageRefs.current.set(id, node);
+      } else {
+        messageRefs.current.delete(id);
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!isOpen) return;
     const el = listRef.current;
     if (!el) return;
-    el.scrollTop = el.scrollHeight;
-  }, [isOpen, messages]);
+    const latest = messages[messages.length - 1];
+    if (!latest) {
+      updateNearBottomState();
+      return;
+    }
+
+    if (latest.role === 'user' && anchoredUserMessageRef.current !== latest.id) {
+      anchoredUserMessageRef.current = latest.id;
+      window.requestAnimationFrame(() => scrollToBottom());
+      return;
+    }
+
+    if (
+      latest.role === 'assistant' &&
+      anchoredAssistantMessageRef.current !== latest.id
+    ) {
+      anchoredAssistantMessageRef.current = latest.id;
+      window.requestAnimationFrame(() => {
+        const node = messageRefs.current.get(latest.id);
+        if (node) {
+          node.scrollIntoView({ block: 'start' });
+          updateNearBottomState();
+        }
+      });
+      return;
+    }
+
+    if (wasNearBottomRef.current && latest.role !== 'assistant') {
+      window.requestAnimationFrame(() => scrollToBottom());
+    }
+  }, [isOpen, messages, scrollToBottom, updateNearBottomState]);
 
   const handleSelectAgent = (item: AgentListItem) => {
     if (isStreaming) return;
-    void sendMessage({ text: `I'd like to connect with ${item.name}.` });
+    void sendMessage({
+      text: `I want VeteranPCS to help me start intake with ${item.name} for my PCS move. Please collect any missing contact details before sending anything.`,
+    });
   };
 
   const handleApprove = useCallback(
@@ -274,6 +343,7 @@ export default function ConciergeWidget() {
           {/* Message list */}
           <div
             ref={listRef}
+            onScroll={handleListScroll}
             className="flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-3 bg-gray-50"
           >
             {messages.length === 0 ? (
@@ -283,18 +353,29 @@ export default function ConciergeWidget() {
             ) : null}
 
             {messages.map((message) => (
-              <MessageRenderer
-                key={message.id}
-                message={message}
-                onSelectAgent={handleSelectAgent}
-                onApprove={handleApprove}
-              />
+              <div key={message.id} ref={registerMessageRef(message.id)}>
+                <MessageRenderer
+                  message={message}
+                  onSelectAgent={handleSelectAgent}
+                  onApprove={handleApprove}
+                />
+              </div>
             ))}
 
             {error ? (
               <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-600">
                 Something went wrong — try again or reach us at support@veteranpcs.com
               </div>
+            ) : null}
+
+            {showJumpToLatest ? (
+              <button
+                type="button"
+                onClick={() => scrollToBottom('smooth')}
+                className="sticky bottom-0 self-center rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-primary shadow-sm motion-safe:transition-colors hover:bg-primary/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
+              >
+                Jump to latest
+              </button>
             ) : null}
           </div>
 

--- a/components/Concierge/MessageRenderer.tsx
+++ b/components/Concierge/MessageRenderer.tsx
@@ -106,6 +106,12 @@ const SUBMIT_TOOL_NAMES = new Set<string>([
 
 function loadingLabel(toolName: string): string {
   switch (toolName) {
+    case 'resolveDestinationLocation':
+      return 'Resolving destination…';
+    case 'findCoverageAreas':
+      return 'Checking coverage areas…';
+    case 'getPartnersForCoverageArea':
+      return 'Looking up partners…';
     case 'getAgentsForState':
       return 'Looking up agents…';
     case 'getLendersForState':
@@ -215,6 +221,22 @@ export default function MessageRenderer({ message, onSelectAgent, onApprove }: P
                     />
                   );
                 }
+                case 'getPartnersForCoverageArea': {
+                  const partners = (data && Array.isArray((data as { partners?: unknown }).partners)
+                    ? ((data as { partners: AgentListItem[] }).partners)
+                    : []) as AgentListItem[];
+                  const role = data && (data as { role?: unknown }).role === 'lender'
+                    ? 'lender'
+                    : 'agent';
+                  return (
+                    <AgentCard
+                      key={key}
+                      list={partners}
+                      kind={role}
+                      onSelect={onSelectAgent}
+                    />
+                  );
+                }
                 case 'getStateDetails': {
                   const stateRecord = (data && (data as { state?: unknown }).state) as
                     | { state_name?: string; short_name?: string; state_slug?: { current?: string } }
@@ -233,6 +255,10 @@ export default function MessageRenderer({ message, onSelectAgent, onApprove }: P
                   );
                 }
                 case 'listStates': {
+                  return null;
+                }
+                case 'resolveDestinationLocation':
+                case 'findCoverageAreas': {
                   return null;
                 }
                 default: {

--- a/components/Concierge/__tests__/AgentCard.test.ts
+++ b/components/Concierge/__tests__/AgentCard.test.ts
@@ -1,0 +1,71 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import AgentCard, { type AgentListItem } from '@/components/Concierge/AgentCard';
+
+const basePartner = {
+  brokerage: 'A very long brokerage name that should not be allowed to break the card layout',
+  city: 'Colorado Springs',
+  militaryStatus: 'Veteran',
+  militaryService: 'Army',
+  bio: 'This partner has a long relocation bio that should be clamped in the card instead of expanding forever on a small phone screen.',
+  stateName: 'Colorado',
+  profileHref: '/colorado#colorado-springs',
+};
+
+describe('AgentCard', () => {
+  it('renders at most three actionable cards with fallback initials and safe links', () => {
+    const list: AgentListItem[] = [
+      {
+        ...basePartner,
+        id: '1',
+        name: 'Alex Agent',
+        firstName: 'Alex',
+        contactHref: '/contact-agent?form=agent&fn=Alex&id=1&state=colorado',
+      },
+      {
+        ...basePartner,
+        id: '2',
+        name: 'Bailey Broker',
+        firstName: 'Bailey',
+        contactHref: '/contact-agent?form=agent&fn=Bailey&id=2&state=colorado',
+      },
+      {
+        ...basePartner,
+        id: '3',
+        name: 'Casey Closer',
+        firstName: 'Casey',
+        contactHref: '/contact-agent?form=agent&fn=Casey&id=3&state=colorado',
+      },
+      {
+        ...basePartner,
+        id: '4',
+        name: 'Fourth Partner',
+        firstName: 'Fourth',
+        contactHref: '/contact-agent?form=agent&fn=Fourth&id=4&state=colorado',
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      React.createElement(AgentCard, { list, kind: 'agent' }),
+    );
+
+    expect(html).toContain('Top agents for you');
+    expect(html).toContain('Alex Agent');
+    expect(html).toContain('AA');
+    expect(html).toContain('Start intake with Alex');
+    expect(html).toContain('/contact-agent?form=agent&amp;fn=Alex&amp;id=1&amp;state=colorado');
+    expect(html).toContain('/colorado#colorado-springs');
+    expect(html).toContain('[-webkit-line-clamp:2]');
+    expect(html).not.toContain('Fourth Partner');
+    expect(html).not.toContain('**');
+  });
+
+  it('renders a useful empty state', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(AgentCard, { list: [], kind: 'lender' }),
+    );
+
+    expect(html).toContain('No matches available right now');
+  });
+});

--- a/docs/concierge-area-routing-release-notes.md
+++ b/docs/concierge-area-routing-release-notes.md
@@ -1,0 +1,23 @@
+# Concierge Area Routing Release Notes
+
+## Behavior
+
+- Destination routing is deterministic for military bases, ZIP codes, `city, state`, and state-only requests.
+- The concierge resolves a destination, routes it to active VeteranPCS coverage areas, then fetches top partners for the selected area.
+- Military aliases now cover Fort Carson, Peterson SFB, USAFA, Naval Station Norfolk, Fort Cavazos/Fort Hood, JBLM, MacDill AFB, and Fort Liberty/Fort Bragg.
+- If exact city coverage is missing, the concierge says so and shows the closest active same-state VeteranPCS coverage area.
+- Partner cards are capped at 3 and include contact-form hrefs plus state/profile hrefs. Tool outputs do not expose partner email or phone.
+
+## Limitations
+
+- ZIP and city routing uses local ZIP centroids and straight-line distance, not drive time or MLS boundaries.
+- Coverage-area coordinates are curated for known military/compound markets and otherwise inferred from local ZIP city lookup.
+- City-only inputs without a state are treated as ambiguous. The concierge should ask for the state instead of guessing.
+- Lenders route by selected area when lender area assignments exist; otherwise they fall back to top state lenders with a caveat.
+
+## Follow-Up Data Needs
+
+- Move canonical coverage-area coordinates and aliases into Salesforce or Sanity.
+- Add a scheduled coverage-index export/cache once routing traffic grows.
+- Expand military installation aliases as real concierge transcripts reveal new base nicknames and misspellings.
+- Add drive-time or service-radius data if the business wants tighter local-fit claims.

--- a/evals/README.md
+++ b/evals/README.md
@@ -18,6 +18,7 @@ Requires `AI_GATEWAY_API_KEY` in `.env.local` (Salesforce/Sanity creds only need
 | `safety.eval.ts` | LLM01 / abuse | `evaluateInput` blocks the jailbreak corpus; allows a normal question |
 | `faithfulness.eval.ts` | LLM09 | Answer names only tool-returned agents; no invented BAH figure |
 | `tool-selection.eval.ts` | LLM06 / correctness | Right tool for intent; no premature submit |
+| `routing.eval.ts` | correctness / faithfulness | Destination routing uses deterministic tools; no invented coverage |
 | `brand-voice.eval.ts` | quality | Calm, plain, emoji-free |
 
 Mock tools (`evals/lib/mock-tools.ts`) keep the inner loop deterministic and free. Swap in real tools only for a final confidence gate. Each suite logs its token spend in an `afterAll` hook.

--- a/evals/lib/mock-tools.ts
+++ b/evals/lib/mock-tools.ts
@@ -1,21 +1,138 @@
 import { tool, type ToolSet } from 'ai';
 import { z } from 'zod';
+import { resolveDestinationLocation } from '@/lib/ai/routing/destination';
+import type { CoverageRoutingResult, PublicPartner } from '@/lib/ai/routing/types';
 
 const TX_AGENTS = [
   {
     id: '1', name: 'Jane Carter', firstName: 'Jane', lastName: 'Carter',
     brokerage: 'Lone Star Realty', city: 'Austin',
     militaryStatus: 'Veteran', militaryService: 'Army', statesLicensed: 'TX',
+    role: 'agent', photoUrl: '', bio: 'Army veteran serving Austin-area military buyers.',
+    contactHref: '/contact-agent?form=agent&fn=Jane&id=1&state=texas',
+    profileHref: '/texas#austin', stateName: 'Texas', stateSlug: 'texas',
   },
   {
     id: '2', name: 'Marcus Webb', firstName: 'Marcus', lastName: 'Webb',
     brokerage: 'Hill Country Homes', city: 'San Antonio',
     militaryStatus: 'Military Spouse', militaryService: 'Navy', statesLicensed: 'TX',
+    role: 'agent', photoUrl: '', bio: 'Military spouse helping San Antonio families.',
+    contactHref: '/contact-agent?form=agent&fn=Marcus&id=2&state=texas',
+    profileHref: '/texas#san-antonio', stateName: 'Texas', stateSlug: 'texas',
   },
 ];
 
 /** The only agent names a faithful answer may present for Texas. */
 export const MOCK_TX_AGENT_NAMES = TX_AGENTS.map((a) => a.name);
+
+const MOCK_PARTNERS: PublicPartner[] = [
+  partner('1', 'Jason Anderson', 'Jason', 'agent', 'Colorado Springs', 'Colorado', 'colorado'),
+  partner('2', 'Ciarra Borucki', 'Ciarra', 'agent', 'Colorado Springs', 'Colorado', 'colorado'),
+  partner('3', 'Anthony Gracia', 'Anthony', 'agent', 'Colorado Springs', 'Colorado', 'colorado'),
+  partner('4', 'Denver Partner', 'Denver', 'agent', 'Denver', 'Colorado', 'colorado'),
+  partner('5', 'Norfolk Partner', 'Norfolk', 'agent', 'Norfolk', 'Virginia', 'virginia'),
+  partner('6', 'Killeen Partner', 'Killeen', 'agent', 'Killeen - Fort Hood', 'Texas', 'texas'),
+];
+
+function partner(
+  id: string,
+  name: string,
+  firstName: string,
+  role: 'agent' | 'lender',
+  areaName: string,
+  stateName: string,
+  stateSlug: string,
+): PublicPartner {
+  return {
+    id,
+    role,
+    name,
+    firstName,
+    brokerage: `${areaName} Realty`,
+    city: areaName,
+    militaryStatus: 'Veteran',
+    militaryService: 'Army',
+    photoUrl: '',
+    bio: `Serves military families in ${areaName}.`,
+    contactHref: role === 'agent'
+      ? `/contact-agent?form=agent&fn=${firstName}&id=${id}&state=${stateSlug}`
+      : `/contact-lender?form=lender&fn=${firstName}&id=${id}&state=${stateSlug}`,
+    profileHref: `/${stateSlug}`,
+    stateName,
+    stateSlug,
+    areaName,
+    aaScore: 90 - Number(id),
+  };
+}
+
+function routeFixture(destination: string, stateHint?: string): CoverageRoutingResult {
+  const resolved = resolveDestinationLocation(destination, stateHint);
+  if (resolved.type === 'ambiguous') {
+    return {
+      destination: resolved,
+      coverageAreas: [],
+      needsClarification: true,
+      caveat: resolved.caveat,
+    };
+  }
+
+  const input = `${destination} ${stateHint ?? ''}`.toLowerCase();
+  const selected =
+    input.includes('boulder') || input.includes('80301')
+      ? coverageArea('Denver', 'Colorado', 'CO', 'colorado', 25, false, 'high')
+      : input.includes('norfolk')
+        ? coverageArea('Norfolk', 'Virginia', 'VA', 'virginia', 0, true, 'high')
+        : input.includes('cavazos') || input.includes('hood')
+          ? coverageArea('Killeen - Fort Hood', 'Texas', 'TX', 'texas', 0, true, 'high')
+          : input.includes('colorado') && resolved.type === 'state'
+            ? coverageArea('Colorado Springs', 'Colorado', 'CO', 'colorado', undefined, false, 'medium')
+            : coverageArea('Colorado Springs', 'Colorado', 'CO', 'colorado', 0, true, 'high');
+
+  const caveat = resolved.type === 'state'
+    ? resolved.caveat
+    : selected.exactMatch
+      ? undefined
+      : `I do not see a ${resolved.normalizedName}-specific VeteranPCS coverage area right now. The closest active VeteranPCS coverage area I found is ${selected.areaName}.`;
+
+  return {
+    destination: resolved,
+    coverageAreas: [selected],
+    selectedCoverageArea: selected,
+    needsClarification: false,
+    caveat,
+  };
+}
+
+function coverageArea(
+  areaName: string,
+  stateName: string,
+  stateCode: string,
+  stateSlug: string,
+  distanceMiles: number | undefined,
+  exactMatch: boolean,
+  confidence: 'high' | 'medium' | 'low',
+) {
+  return {
+    areaName,
+    slug: areaName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''),
+    stateName,
+    stateCode,
+    stateSlug,
+    latitude: 0,
+    longitude: 0,
+    agentCount: 3,
+    lenderAvailable: true,
+    topAgentScore: 90,
+    topLenderScore: 80,
+    aliases: [],
+    distanceMiles,
+    confidence,
+    reason: exactMatch
+      ? `${areaName} matches this active VeteranPCS coverage area.`
+      : `Closest active VeteranPCS coverage area found in ${stateName}.`,
+    exactMatch,
+  };
+}
 
 /**
  * Mock versions of the real concierge tools (same names + shapes) returning
@@ -27,10 +144,61 @@ export function mockTools(): ToolSet {
     listStates: tool({
       description: 'List US states with VeteranPCS partners.',
       inputSchema: z.object({}),
-      execute: async () => ({ ok: true, data: { states: [{ slug: 'texas', name: 'Texas' }] } }),
+      execute: async () => ({ ok: true, data: { states: [{ slug: 'texas', name: 'Texas' }, { slug: 'colorado', name: 'Colorado' }] } }),
+    }),
+    resolveDestinationLocation: tool({
+      description:
+        'Resolve a user-named destination to deterministic geography. Use before partner lookup for bases, cities, ZIPs, and states.',
+      inputSchema: z.object({ destination: z.string(), stateHint: z.string().optional() }),
+      execute: async ({ destination, stateHint }) => ({
+        ok: true,
+        data: { destination: resolveDestinationLocation(destination, stateHint) },
+      }),
+    }),
+    findCoverageAreas: tool({
+      description:
+        'Route a resolved destination to active VeteranPCS coverage areas and return caveats when exact coverage is missing.',
+      inputSchema: z.object({ destination: z.string(), stateHint: z.string().optional() }),
+      execute: async ({ destination, stateHint }) => ({
+        ok: true,
+        data: routeFixture(destination, stateHint),
+      }),
+    }),
+    getPartnersForCoverageArea: tool({
+      description:
+        'Get the top 3 actionable VeteranPCS partners for a selected coverage area. Call after findCoverageAreas.',
+      inputSchema: z.object({
+        state: z.string(),
+        areaName: z.string().optional(),
+        role: z.enum(['agent', 'lender']),
+      }),
+      execute: async ({ state, areaName, role }) => {
+        const normalizedState = state.toLowerCase().includes('virginia')
+          ? 'Virginia'
+          : state.toLowerCase().includes('texas') || state.toUpperCase() === 'TX'
+            ? 'Texas'
+            : 'Colorado';
+        const partners = MOCK_PARTNERS
+          .filter((item) => item.role === role)
+          .filter((item) => item.stateName === normalizedState)
+          .filter((item) => !areaName || item.areaName === areaName)
+          .slice(0, 3);
+        return {
+          ok: true,
+          data: {
+            role,
+            stateName: normalizedState,
+            stateCode: normalizedState === 'Colorado' ? 'CO' : normalizedState === 'Virginia' ? 'VA' : 'TX',
+            stateSlug: normalizedState.toLowerCase().replace(/\s+/g, '-'),
+            areaName,
+            matchedArea: Boolean(areaName),
+            partners,
+          },
+        };
+      },
     }),
     getAgentsForState: tool({
-      description: 'Get up to 5 vetted real estate agents who serve a given US state.',
+      description: 'Get up to 3 vetted real estate agents who serve a given US state.',
       inputSchema: z.object({ state: z.string() }),
       execute: async () => ({
         ok: true,
@@ -38,7 +206,7 @@ export function mockTools(): ToolSet {
       }),
     }),
     getLendersForState: tool({
-      description: 'Get up to 5 vetted VA-loan lenders who serve a given US state.',
+      description: 'Get up to 3 vetted VA-loan lenders who serve a given US state.',
       inputSchema: z.object({ state: z.string() }),
       execute: async () => ({
         ok: true,

--- a/evals/lib/run.ts
+++ b/evals/lib/run.ts
@@ -17,6 +17,10 @@ export interface RunResult {
   text: string;
   /** Names of every tool the model called across all steps. */
   toolNames: string[];
+  /** Every tool call with the model-provided input. */
+  toolCalls: Array<{ toolName: string; input: unknown }>;
+  /** Every tool result with the tool output. */
+  toolResults: Array<{ toolName: string; output: unknown }>;
   usage: { totalTokens?: number } | undefined;
 }
 
@@ -37,5 +41,14 @@ export async function runConcierge(userText: string, opts: RunOptions = {}): Pro
   });
 
   const toolNames = result.steps.flatMap((step) => step.toolCalls.map((c) => c.toolName));
-  return { text: result.text, toolNames, usage: result.usage };
+  const toolCalls = result.steps.flatMap((step) =>
+    step.toolCalls.map((call) => ({ toolName: call.toolName, input: call.input })),
+  );
+  const toolResults = result.steps.flatMap((step) =>
+    step.toolResults.map((toolResult) => ({
+      toolName: toolResult.toolName,
+      output: toolResult.output,
+    })),
+  );
+  return { text: result.text, toolNames, toolCalls, toolResults, usage: result.usage };
 }

--- a/evals/routing.eval.ts
+++ b/evals/routing.eval.ts
@@ -1,0 +1,131 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { runConcierge, type RunResult } from './lib/run';
+import { mockTools } from './lib/mock-tools';
+import { recordSpend, spendSoFar } from './lib/report';
+
+afterAll(() => console.log(`[routing] token spend: ${spendSoFar()}`));
+
+const refusalPattern = /I can only help with PCS moves/i;
+
+describe('routing', () => {
+  it.each([
+    ['Fort Carson', 'Colorado Springs', 'CO'],
+    ['Peterson SFB', 'Colorado Springs', 'CO'],
+    ['USAFA', 'Colorado Springs', 'CO'],
+    ['Naval Station Norfolk', 'Norfolk', 'VA'],
+    ['Fort Cavazos', 'Killeen - Fort Hood', 'TX'],
+    ['Fort Hood', 'Killeen - Fort Hood', 'TX'],
+  ])('routes base alias %s to %s', async (destination, expectedArea, expectedState) => {
+    const res = await runConcierge(`I need a VeteranPCS agent near ${destination}.`, {
+      tools: mockTools(),
+    });
+    recordSpend(res.usage);
+
+    expectNoRefusal(res);
+    expect(res.toolNames, res.text).toContain('resolveDestinationLocation');
+    expect(res.toolNames, res.text).toContain('findCoverageAreas');
+    expect(res.toolNames, res.text).toContain('getPartnersForCoverageArea');
+    expectSelectedCoverage(res, expectedArea, expectedState, 'high');
+    expectPartnerCall(res, expectedArea, 'agent');
+    expectPartnerPayloadMax(res, 3);
+  });
+
+  it.each([
+    ['Boulder, CO'],
+    ['80301'],
+  ])('routes %s to nearest active area with a caveat', async (destination) => {
+    const res = await runConcierge(`Can you find me an agent in ${destination}?`, {
+      tools: mockTools(),
+    });
+    recordSpend(res.usage);
+
+    expectNoRefusal(res);
+    expectSelectedCoverage(res, 'Denver', 'CO', 'high');
+    expectPartnerCall(res, 'Denver', 'agent');
+    expect(routeCaveat(res)).toMatch(/do not see .*specific VeteranPCS coverage area/i);
+    expect(res.text).toMatch(/closest|do not see|don't see|don't have .*specific|don't have an exact|no .*specific|not .*exact/i);
+    expectPartnerPayloadMax(res, 3);
+  });
+
+  it('asks for state when the destination is ambiguous', async () => {
+    const res = await runConcierge('I need an agent in Springfield.', {
+      tools: mockTools(),
+    });
+    recordSpend(res.usage);
+
+    expectNoRefusal(res);
+    expect(res.toolNames).not.toContain('getPartnersForCoverageArea');
+    expect(res.text).toMatch(/which|what|state/i);
+  });
+
+  it('handles state-only routing without inventing city coverage', async () => {
+    const res = await runConcierge('I am moving to Colorado and need an agent.', {
+      tools: mockTools(),
+    });
+    recordSpend(res.usage);
+
+    expectNoRefusal(res);
+    expect(res.toolNames, res.text).toContain('findCoverageAreas');
+    expectSelectedCoverage(res, 'Colorado Springs', 'CO', 'medium');
+    expect(routeCaveat(res)).toMatch(/State-only routing is broad/i);
+  });
+});
+
+function expectNoRefusal(res: RunResult): void {
+  expect(res.text).not.toMatch(refusalPattern);
+}
+
+function expectSelectedCoverage(
+  res: RunResult,
+  expectedArea: string,
+  expectedState: string,
+  expectedConfidence: string,
+): void {
+  const selected = selectedCoverage(res);
+  expect(selected?.areaName).toBe(expectedArea);
+  expect(selected?.stateCode).toBe(expectedState);
+  expect(selected?.confidence).toBe(expectedConfidence);
+}
+
+function expectPartnerCall(
+  res: RunResult,
+  expectedArea: string,
+  expectedRole: string,
+): void {
+  const call = res.toolCalls.find((item) => item.toolName === 'getPartnersForCoverageArea');
+  expect(call, res.text).toBeTruthy();
+  const input = asRecord(call?.input);
+  expect(input.areaName).toBe(expectedArea);
+  expect(input.role).toBe(expectedRole);
+}
+
+function expectPartnerPayloadMax(res: RunResult, max: number): void {
+  const result = res.toolResults.find((item) => item.toolName === 'getPartnersForCoverageArea');
+  expect(result, res.text).toBeTruthy();
+  const envelope = asRecord(result?.output);
+  const data = asRecord(envelope.data);
+  const partners = Array.isArray(data.partners) ? data.partners : [];
+  expect(partners.length).toBeLessThanOrEqual(max);
+}
+
+function selectedCoverage(res: RunResult): Record<string, unknown> | undefined {
+  const result = res.toolResults.find((item) => item.toolName === 'findCoverageAreas');
+  const envelope = asRecord(result?.output);
+  const data = asRecord(envelope.data);
+  return asOptionalRecord(data.selectedCoverageArea);
+}
+
+function routeCaveat(res: RunResult): string {
+  const result = res.toolResults.find((item) => item.toolName === 'findCoverageAreas');
+  const envelope = asRecord(result?.output);
+  const data = asRecord(envelope.data);
+  return typeof data.caveat === 'string' ? data.caveat : '';
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function asOptionalRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
+}

--- a/lib/ai/routing/__tests__/coverage.test.ts
+++ b/lib/ai/routing/__tests__/coverage.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/stateService', () => ({
+  default: {
+    fetchAgentsListByState: vi.fn(),
+    fetchLendersListByState: vi.fn(),
+  },
+}));
+
+import { resolveDestinationLocation } from '@/lib/ai/routing/destination';
+import { routeResolvedDestination } from '@/lib/ai/routing/coverage';
+import type { CoverageArea } from '@/lib/ai/routing/types';
+
+function area(input: Partial<CoverageArea> & Pick<CoverageArea, 'areaName'>): CoverageArea {
+  return {
+    areaName: input.areaName,
+    slug: input.slug ?? input.areaName.toLowerCase().replace(/\s+/g, '-'),
+    stateName: input.stateName ?? 'Colorado',
+    stateCode: input.stateCode ?? 'CO',
+    stateSlug: input.stateSlug ?? 'colorado',
+    latitude: input.latitude,
+    longitude: input.longitude,
+    agentCount: input.agentCount ?? 1,
+    lenderAvailable: input.lenderAvailable ?? true,
+    topAgentScore: input.topAgentScore ?? 50,
+    topLenderScore: input.topLenderScore ?? 0,
+    aliases: input.aliases ?? [],
+  };
+}
+
+describe('routeResolvedDestination', () => {
+  const coloradoAreas = [
+    area({
+      areaName: 'Colorado Springs',
+      latitude: 38.8339,
+      longitude: -104.8214,
+      agentCount: 3,
+      aliases: ['Fort Carson', 'Peterson SFB', 'USAFA'],
+    }),
+    area({
+      areaName: 'Denver',
+      latitude: 39.7392,
+      longitude: -104.9903,
+      agentCount: 1,
+      topAgentScore: 20,
+    }),
+  ];
+
+  it('uses military-base coverage override before distance', () => {
+    const res = routeResolvedDestination(
+      resolveDestinationLocation('Fort Carson'),
+      coloradoAreas,
+    );
+
+    expect(res.needsClarification).toBe(false);
+    expect(res.selectedCoverageArea?.areaName).toBe('Colorado Springs');
+    expect(res.selectedCoverageArea?.confidence).toBe('high');
+    expect(res.caveat).toBeUndefined();
+  });
+
+  it('prefers exact active coverage-area match', () => {
+    const res = routeResolvedDestination(resolveDestinationLocation('Denver, CO'), coloradoAreas);
+
+    expect(res.selectedCoverageArea?.areaName).toBe('Denver');
+    expect(res.selectedCoverageArea?.exactMatch).toBe(true);
+  });
+
+  it('routes Boulder to nearest active Colorado area when no exact area exists', () => {
+    const res = routeResolvedDestination(resolveDestinationLocation('Boulder, CO'), coloradoAreas);
+
+    expect(res.selectedCoverageArea?.areaName).toBe('Denver');
+    expect(res.selectedCoverageArea?.exactMatch).toBe(false);
+    expect(res.caveat).toMatch(/Boulder, CO-specific/);
+    expect(res.caveat).toMatch(/closest active VeteranPCS coverage area/i);
+  });
+
+  it('adds a human-confirmation caveat when nearest active coverage is far away', () => {
+    const res = routeResolvedDestination(resolveDestinationLocation('Boulder, CO'), [
+      coloradoAreas[0],
+    ]);
+
+    expect(res.selectedCoverageArea?.areaName).toBe('Colorado Springs');
+    expect(res.selectedCoverageArea?.confidence).toBe('low');
+    expect(res.caveat).toMatch(/human partner should confirm/i);
+  });
+
+  it('returns top active state areas for state-only input', () => {
+    const res = routeResolvedDestination(resolveDestinationLocation('Colorado'), coloradoAreas);
+
+    expect(res.selectedCoverageArea?.areaName).toBe('Colorado Springs');
+    expect(res.coverageAreas).toHaveLength(2);
+    expect(res.caveat).toMatch(/State-only routing is broad/);
+  });
+
+  it('returns a clear caveat when no active areas exist', () => {
+    const res = routeResolvedDestination(resolveDestinationLocation('Colorado'), []);
+
+    expect(res.selectedCoverageArea).toBeUndefined();
+    expect(res.coverageAreas).toEqual([]);
+    expect(res.caveat).toMatch(/do not see an active VeteranPCS coverage area/);
+  });
+
+  it('does not route ambiguous city-only input', () => {
+    const res = routeResolvedDestination(resolveDestinationLocation('Springfield'), coloradoAreas);
+
+    expect(res.needsClarification).toBe(true);
+    expect(res.selectedCoverageArea).toBeUndefined();
+    expect(res.caveat).toMatch(/need the state/i);
+  });
+});

--- a/lib/ai/routing/__tests__/destination.test.ts
+++ b/lib/ai/routing/__tests__/destination.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDestinationLocation } from '@/lib/ai/routing/destination';
+
+describe('resolveDestinationLocation', () => {
+  it.each([
+    ['Fort Carson', 'Colorado Springs'],
+    ['Peterson SFB', 'Colorado Springs'],
+    ['USAFA', 'Colorado Springs'],
+  ])('resolves Colorado base alias %s', (input, coverageAreaOverride) => {
+    const res = resolveDestinationLocation(input);
+
+    expect(res).toMatchObject({
+      type: 'military_base',
+      stateName: 'Colorado',
+      stateCode: 'CO',
+      coverageAreaOverride,
+      confidence: 'high',
+    });
+  });
+
+  it('resolves a ZIP code to Boulder, CO', () => {
+    const res = resolveDestinationLocation('80301');
+
+    expect(res).toMatchObject({
+      type: 'zip',
+      normalizedName: 'Boulder, CO',
+      stateName: 'Colorado',
+      stateCode: 'CO',
+      confidence: 'high',
+    });
+    expect(res.latitude).toBeCloseTo(40.0497, 3);
+  });
+
+  it('resolves city and state input', () => {
+    const res = resolveDestinationLocation('Boulder, CO');
+
+    expect(res).toMatchObject({
+      type: 'city',
+      normalizedName: 'Boulder, CO',
+      stateName: 'Colorado',
+      stateCode: 'CO',
+      confidence: 'high',
+    });
+  });
+
+  it('resolves state-only input', () => {
+    const res = resolveDestinationLocation('Colorado');
+
+    expect(res).toMatchObject({
+      type: 'state',
+      normalizedName: 'Colorado',
+      stateCode: 'CO',
+      confidence: 'high',
+    });
+    expect(res.caveat).toMatch(/State-only routing is broad/);
+  });
+
+  it('asks for clarification on Springfield without a state', () => {
+    const res = resolveDestinationLocation('Springfield');
+
+    expect(res.type).toBe('ambiguous');
+    expect(res.candidates?.map((candidate) => candidate.stateCode)).toEqual(
+      expect.arrayContaining(['MO', 'IL', 'MA', 'VA']),
+    );
+    expect(res.caveat).toMatch(/need the state/i);
+  });
+
+  it('does not guess for a city-only destination without a state', () => {
+    const res = resolveDestinationLocation('Boulder');
+
+    expect(res.type).toBe('ambiguous');
+    expect(res.stateCode).toBeUndefined();
+    expect(res.caveat).toMatch(/need the state/i);
+  });
+});

--- a/lib/ai/routing/__tests__/partners.test.ts
+++ b/lib/ai/routing/__tests__/partners.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/stateService', () => {
+  const fetchAgentsListByState = vi.fn();
+  const fetchLendersListByState = vi.fn();
+  return {
+    default: {
+      fetchAgentsListByState,
+      fetchLendersListByState,
+    },
+  };
+});
+
+import stateService from '@/services/stateService';
+import { getPartnersForCoverageArea } from '@/lib/ai/routing/partners';
+
+function assignment(areaName: string, stateName: string, score: number) {
+  return {
+    Id: `${areaName}-${score}`,
+    Name: `${areaName} assignment`,
+    AA_Score__c: score,
+    Area__r: { Name: areaName, State__c: stateName },
+  };
+}
+
+function agent(name: string, id: string, score: number) {
+  const [firstName, lastName] = name.split(' ');
+  return {
+    Name: name,
+    AccountId_15__c: id,
+    FirstName: firstName,
+    LastName: lastName ?? '',
+    Agent_Bio__pc: `${name} has a long but useful military relocation bio for families moving with orders.`,
+    Military_Status__pc: 'Veteran',
+    Military_Service__pc: 'Army',
+    Brokerage_Name__pc: `${firstName} Realty`,
+    BillingAddress: { city: 'Round Rock', state: 'TX' },
+    BillingStateCode: 'TX',
+    State_s_Licensed_in__pc: 'TX',
+    PhotoUrl: `/images/agents/${id}.webp`,
+    PersonEmail: `${firstName}@example.com`,
+    PersonMobilePhone: '555-555-5555',
+    Area_Assignments__r: {
+      records: [assignment('Austin', 'Texas', score)],
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(stateService.fetchAgentsListByState).mockReset();
+  vi.mocked(stateService.fetchLendersListByState).mockReset();
+});
+
+describe('getPartnersForCoverageArea', () => {
+  it('returns top 3 agents by AA_Score for the selected area with public card metadata only', async () => {
+    vi.mocked(stateService.fetchAgentsListByState).mockResolvedValue({
+      totalSize: 4,
+      done: true,
+      records: [
+        agent('Low Agent', '001LOW', 10),
+        agent('Top Agent', '001TOP', 90),
+        agent('Mid Agent', '001MID', 70),
+        agent('Third Agent', '001THIRD', 40),
+      ],
+    } as never);
+
+    const res = await getPartnersForCoverageArea('TX', 'Austin', 'agent');
+
+    expect(res?.matchedArea).toBe(true);
+    expect(res?.partners.map((partner) => partner.name)).toEqual([
+      'Top Agent',
+      'Mid Agent',
+      'Third Agent',
+    ]);
+    expect(res?.partners[0]).toMatchObject({
+      role: 'agent',
+      city: 'Austin',
+      stateName: 'Texas',
+      photoUrl: '/images/agents/001TOP.webp',
+      contactHref: '/contact-agent?form=agent&fn=Top&id=001TOP&state=texas',
+      profileHref: '/texas#austin',
+      aaScore: 90,
+    });
+    expect(JSON.stringify(res?.partners)).not.toContain('PersonEmail');
+    expect(JSON.stringify(res?.partners)).not.toContain('PersonMobilePhone');
+  });
+
+  it('falls back to top state lenders when no lender is ranked in the selected area', async () => {
+    vi.mocked(stateService.fetchLendersListByState).mockResolvedValue({
+      totalSize: 1,
+      done: true,
+      records: [
+        {
+          Name: 'Pat Lender',
+          AccountId_15__c: '002PAT',
+          FirstName: 'Pat',
+          Agent_Bio__pc: 'VA loan specialist.',
+          Military_Status__pc: 'Veteran',
+          Military_Service__pc: 'Navy',
+          Brokerage_Name__pc: 'VetLend',
+          BillingCity: 'San Antonio',
+          BillingState: 'TX',
+          Individual_NMLS_ID__pc: '12345',
+          Company_NMLS_ID__pc: '67890',
+          PhotoUrl: '/images/lenders/002PAT.webp',
+          Area_Assignments__r: {
+            records: [assignment('San Antonio', 'Texas', 75)],
+          },
+        },
+      ],
+    } as never);
+
+    const res = await getPartnersForCoverageArea('Texas', 'Austin', 'lender');
+
+    expect(res?.matchedArea).toBe(false);
+    expect(res?.caveat).toMatch(/top active lenders in Texas/);
+    expect(res?.partners).toHaveLength(1);
+    expect(res?.partners[0]).toMatchObject({
+      role: 'lender',
+      name: 'Pat Lender',
+      contactHref: '/contact-lender?form=lender&fn=Pat&id=002PAT&state=texas',
+      profileHref: '/texas',
+    });
+  });
+});

--- a/lib/ai/routing/coverage.ts
+++ b/lib/ai/routing/coverage.ts
@@ -1,0 +1,344 @@
+import stateService, { type Agent, type Lenders } from '@/services/stateService';
+import { logInfo } from '@/services/loggingService';
+import { sanitizeCityName } from '@/utils/sanitizeCityName';
+import { resolveDestinationLocation } from '@/lib/ai/routing/destination';
+import {
+  areaAliases,
+  coordinatesForCoverageArea,
+  distanceMiles,
+} from '@/lib/ai/routing/geo';
+import {
+  findRoutingState,
+  normalizeCompactText,
+  stateMatches,
+} from '@/lib/ai/routing/states';
+import type {
+  Coordinates,
+  CoverageArea,
+  CoverageRoutingResult,
+  DestinationResolution,
+  RoutedCoverageArea,
+  RoutingConfidence,
+  RoutingState,
+} from '@/lib/ai/routing/types';
+
+const COVERAGE_LIMIT = 3;
+const FAR_DISTANCE_MILES = 75;
+
+interface MutableCoverageArea extends CoverageArea {
+  agentIds: Set<string>;
+  lenderIds: Set<string>;
+}
+
+export async function buildCoverageIndexForState(stateInput: string): Promise<CoverageArea[]> {
+  const state = findRoutingState(stateInput);
+  if (!state) return [];
+
+  const [agentsData, lendersData] = await Promise.all([
+    stateService.fetchAgentsListByState(state.code, { requireHeadshot: false }),
+    stateService.fetchLendersListByState(state.code, { requireHeadshot: false }),
+  ]);
+
+  const areas = new Map<string, MutableCoverageArea>();
+  for (const agent of agentsData.records ?? []) {
+    addRecordAssignments(areas, agent, state, 'agent');
+  }
+  for (const lender of lendersData.records ?? []) {
+    addRecordAssignments(areas, lender, state, 'lender');
+  }
+
+  const result = [...areas.values()]
+    .map(({ agentIds, lenderIds, ...area }) => ({
+      ...area,
+      agentCount: agentIds.size,
+      lenderAvailable: lenderIds.size > 0,
+    }))
+    .filter((area) => area.agentCount > 0 || area.lenderAvailable)
+    .sort(
+      (a, b) =>
+        b.agentCount - a.agentCount ||
+        Number(b.lenderAvailable) - Number(a.lenderAvailable) ||
+        b.topAgentScore - a.topAgentScore ||
+        a.areaName.localeCompare(b.areaName),
+    );
+
+  logInfo('Concierge routing: built coverage index', {
+    state: state.code,
+    areas: result.length,
+  });
+  return result;
+}
+
+export async function findCoverageAreasForDestination(
+  destination: string,
+  stateHint?: string,
+): Promise<CoverageRoutingResult> {
+  const resolved = resolveDestinationLocation(destination, stateHint);
+  if (!resolved.stateCode) {
+    return routeResolvedDestination(resolved, []);
+  }
+  const areas = await buildCoverageIndexForState(resolved.stateCode);
+  return routeResolvedDestination(resolved, areas);
+}
+
+export function routeResolvedDestination(
+  destination: DestinationResolution,
+  areas: CoverageArea[],
+): CoverageRoutingResult {
+  if (destination.type === 'ambiguous') {
+    return {
+      destination,
+      coverageAreas: [],
+      needsClarification: true,
+      caveat: destination.caveat,
+    };
+  }
+
+  if (destination.type === 'unknown' || !destination.stateCode) {
+    return {
+      destination,
+      coverageAreas: [],
+      needsClarification: false,
+      caveat: destination.caveat ?? 'I could not resolve that destination to a supported US state.',
+    };
+  }
+
+  const activeAreas = areas.filter((area) => area.agentCount > 0 || area.lenderAvailable);
+  if (activeAreas.length === 0) {
+    return {
+      destination,
+      coverageAreas: [],
+      needsClarification: false,
+      caveat: `I do not see an active VeteranPCS coverage area in ${destination.stateName} right now.`,
+    };
+  }
+
+  if (destination.type === 'state') {
+    const coverageAreas = activeAreas.slice(0, COVERAGE_LIMIT).map((area) =>
+      decorateArea(area, {
+        confidence: 'medium',
+        reason: 'Top active VeteranPCS coverage area in this state.',
+        exactMatch: false,
+      }),
+    );
+    return {
+      destination,
+      coverageAreas,
+      selectedCoverageArea: coverageAreas[0],
+      needsClarification: false,
+      caveat: destination.caveat,
+    };
+  }
+
+  const explicit = findExplicitCoverageArea(destination, activeAreas);
+  if (explicit) {
+    const selected = decorateArea(explicit, {
+      confidence: 'high',
+      reason: destination.coverageAreaOverride
+        ? `${destination.normalizedName} routes to the ${explicit.areaName} coverage area.`
+        : `${destination.normalizedName} matches this active VeteranPCS coverage area.`,
+      exactMatch: true,
+    });
+    return {
+      destination,
+      coverageAreas: [selected, ...rankOtherAreas(activeAreas, selected).slice(0, COVERAGE_LIMIT - 1)],
+      selectedCoverageArea: selected,
+      needsClarification: false,
+    };
+  }
+
+  const routed = routeByDistance(destination, activeAreas);
+  if (routed.length === 0) {
+    const coverageAreas = activeAreas.slice(0, COVERAGE_LIMIT).map((area) =>
+      decorateArea(area, {
+        confidence: 'low',
+        reason: 'Active VeteranPCS coverage area in the same state; distance could not be calculated.',
+        exactMatch: false,
+      }),
+    );
+    return {
+      destination,
+      coverageAreas,
+      selectedCoverageArea: coverageAreas[0],
+      needsClarification: false,
+      caveat: `I do not see a ${destination.normalizedName}-specific VeteranPCS coverage area, and I could not calculate an exact nearest area.`,
+    };
+  }
+
+  const selected = routed[0];
+  const caveat = buildCoverageCaveat(destination, selected);
+  return {
+    destination,
+    coverageAreas: routed.slice(0, COVERAGE_LIMIT),
+    selectedCoverageArea: selected,
+    needsClarification: false,
+    caveat,
+  };
+}
+
+function addRecordAssignments(
+  areas: Map<string, MutableCoverageArea>,
+  record: Agent | Lenders,
+  state: RoutingState,
+  role: 'agent' | 'lender',
+): void {
+  const assignments = record.Area_Assignments__r?.records ?? [];
+  for (const assignment of assignments) {
+    const areaName = assignment.Area__r?.Name;
+    if (!areaName || !stateMatches(assignment.Area__r?.State__c, state)) continue;
+    const area = ensureArea(areas, areaName, state);
+    const score = assignment.AA_Score__c ?? 0;
+    if (role === 'agent') {
+      area.agentIds.add(record.AccountId_15__c);
+      area.topAgentScore = Math.max(area.topAgentScore, score);
+    } else {
+      area.lenderIds.add(record.AccountId_15__c);
+      area.topLenderScore = Math.max(area.topLenderScore, score);
+    }
+  }
+}
+
+function ensureArea(
+  areas: Map<string, MutableCoverageArea>,
+  areaName: string,
+  state: RoutingState,
+): MutableCoverageArea {
+  const key = areaKey(areaName, state.code);
+  const existing = areas.get(key);
+  if (existing) return existing;
+
+  const coordinates = coordinatesForCoverageArea(areaName, state);
+  const area: MutableCoverageArea = {
+    areaName,
+    slug: sanitizeCityName(areaName),
+    stateName: state.name,
+    stateCode: state.code,
+    stateSlug: state.slug,
+    latitude: coordinates?.latitude,
+    longitude: coordinates?.longitude,
+    agentCount: 0,
+    lenderAvailable: false,
+    topAgentScore: 0,
+    topLenderScore: 0,
+    aliases: coordinates?.aliases ?? areaAliases(areaName, state.code),
+    agentIds: new Set<string>(),
+    lenderIds: new Set<string>(),
+  };
+  areas.set(key, area);
+  return area;
+}
+
+function findExplicitCoverageArea(
+  destination: DestinationResolution,
+  areas: CoverageArea[],
+): CoverageArea | null {
+  const override = destination.coverageAreaOverride;
+  if (override) {
+    const overrideMatch = areas.find((area) => areaNameMatches(area, override));
+    if (overrideMatch) return overrideMatch;
+  }
+
+  return areas.find((area) => areaNameMatches(area, destination.normalizedName)) ?? null;
+}
+
+function areaNameMatches(area: CoverageArea, input: string): boolean {
+  const target = normalizeCompactText(input.replace(/,\s*[A-Z]{2}$/i, ''));
+  const names = [area.areaName, ...area.aliases];
+  return names.some((name) => {
+    const normalizedName = normalizeCompactText(name);
+    return normalizedName === target || target.includes(normalizedName) || normalizedName.includes(target);
+  });
+}
+
+function routeByDistance(
+  destination: DestinationResolution,
+  areas: CoverageArea[],
+): RoutedCoverageArea[] {
+  const destinationCoordinates = coordinatesFromDestination(destination);
+  if (!destinationCoordinates) return [];
+
+  return areas
+    .filter((area) => area.latitude !== undefined && area.longitude !== undefined)
+    .map((area) => {
+      const distance = distanceMiles(destinationCoordinates, {
+        latitude: area.latitude as number,
+        longitude: area.longitude as number,
+      });
+      const rounded = Math.round(distance);
+      return decorateArea(area, {
+        distanceMiles: rounded,
+        confidence: confidenceForDistance(rounded),
+        reason: `Closest active VeteranPCS coverage area found in ${area.stateName}.`,
+        exactMatch: false,
+      });
+    })
+    .sort(
+      (a, b) =>
+        (a.distanceMiles ?? Number.POSITIVE_INFINITY) -
+          (b.distanceMiles ?? Number.POSITIVE_INFINITY) ||
+        b.agentCount - a.agentCount ||
+        b.topAgentScore - a.topAgentScore,
+    );
+}
+
+function rankOtherAreas(areas: CoverageArea[], selected: CoverageArea): RoutedCoverageArea[] {
+  return areas
+    .filter((area) => areaKey(area.areaName, area.stateCode) !== areaKey(selected.areaName, selected.stateCode))
+    .sort(
+      (a, b) =>
+        b.agentCount - a.agentCount ||
+        b.topAgentScore - a.topAgentScore ||
+        a.areaName.localeCompare(b.areaName),
+    )
+    .map((area) =>
+      decorateArea(area, {
+        confidence: 'medium',
+        reason: 'Other active VeteranPCS coverage area in the same state.',
+        exactMatch: false,
+      }),
+    );
+}
+
+function decorateArea(
+  area: CoverageArea,
+  options: {
+    distanceMiles?: number;
+    confidence: RoutingConfidence;
+    reason: string;
+    exactMatch: boolean;
+  },
+): RoutedCoverageArea {
+  return {
+    ...area,
+    distanceMiles: options.distanceMiles,
+    confidence: options.confidence,
+    reason: options.reason,
+    exactMatch: options.exactMatch,
+  };
+}
+
+function buildCoverageCaveat(destination: DestinationResolution, selected: RoutedCoverageArea): string {
+  const distance = selected.distanceMiles;
+  const distancePhrase =
+    distance !== undefined ? ` It is about ${distance} straight-line miles away.` : '';
+  const farPhrase =
+    distance !== undefined && distance > FAR_DISTANCE_MILES
+      ? ' A human partner should confirm the best local fit before you move forward.'
+      : '';
+  return `I do not see a ${destination.normalizedName}-specific VeteranPCS coverage area right now. The closest active VeteranPCS coverage area I found is ${selected.areaName}.${distancePhrase}${farPhrase}`;
+}
+
+function confidenceForDistance(distance: number): RoutingConfidence {
+  if (distance <= 35) return 'high';
+  if (distance <= FAR_DISTANCE_MILES) return 'medium';
+  return 'low';
+}
+
+function coordinatesFromDestination(destination: DestinationResolution): Coordinates | null {
+  if (destination.latitude === undefined || destination.longitude === undefined) return null;
+  return { latitude: destination.latitude, longitude: destination.longitude };
+}
+
+function areaKey(areaName: string, stateCode: string): string {
+  return `${stateCode}:${normalizeCompactText(areaName)}`;
+}

--- a/lib/ai/routing/data.ts
+++ b/lib/ai/routing/data.ts
@@ -1,0 +1,167 @@
+import type {
+  ClarificationCandidate,
+  Coordinates,
+  RoutingState,
+} from '@/lib/ai/routing/types';
+
+export interface InstallationAlias {
+  canonicalName: string;
+  aliases: string[];
+  stateCode: string;
+  stateName: string;
+  stateSlug: string;
+  latitude: number;
+  longitude: number;
+  nearestCoverageAreaOverride: string;
+}
+
+export interface CoverageAreaMetadata {
+  areaName: string;
+  stateCode: string;
+  latitude: number;
+  longitude: number;
+  aliases?: string[];
+  lookupNames?: string[];
+}
+
+export const INSTALLATION_ALIASES: readonly InstallationAlias[] = [
+  {
+    canonicalName: 'Fort Carson',
+    aliases: ['Fort Carson', 'Ft Carson', 'Carson', 'Fort Carson Army Base'],
+    stateCode: 'CO',
+    stateName: 'Colorado',
+    stateSlug: 'colorado',
+    latitude: 38.7375,
+    longitude: -104.7889,
+    nearestCoverageAreaOverride: 'Colorado Springs',
+  },
+  {
+    canonicalName: 'Peterson Space Force Base',
+    aliases: ['Peterson SFB', 'Peterson Space Force Base', 'Peterson AFB', 'Peterson Air Force Base'],
+    stateCode: 'CO',
+    stateName: 'Colorado',
+    stateSlug: 'colorado',
+    latitude: 38.8236,
+    longitude: -104.7009,
+    nearestCoverageAreaOverride: 'Colorado Springs',
+  },
+  {
+    canonicalName: 'United States Air Force Academy',
+    aliases: ['USAFA', 'US Air Force Academy', 'Air Force Academy', 'United States Air Force Academy'],
+    stateCode: 'CO',
+    stateName: 'Colorado',
+    stateSlug: 'colorado',
+    latitude: 38.9987,
+    longitude: -104.8617,
+    nearestCoverageAreaOverride: 'Colorado Springs',
+  },
+  {
+    canonicalName: 'Naval Station Norfolk',
+    aliases: ['Naval Station Norfolk', 'Norfolk Naval Station', 'NS Norfolk', 'Naval Base Norfolk'],
+    stateCode: 'VA',
+    stateName: 'Virginia',
+    stateSlug: 'virginia',
+    latitude: 36.9467,
+    longitude: -76.3133,
+    nearestCoverageAreaOverride: 'Norfolk',
+  },
+  {
+    canonicalName: 'Fort Cavazos',
+    aliases: ['Fort Cavazos', 'Ft Cavazos', 'Fort Hood', 'Ft Hood', 'Cavazos', 'Hood'],
+    stateCode: 'TX',
+    stateName: 'Texas',
+    stateSlug: 'texas',
+    latitude: 31.1349,
+    longitude: -97.7797,
+    nearestCoverageAreaOverride: 'Killeen - Fort Hood',
+  },
+  {
+    canonicalName: 'Joint Base Lewis-McChord',
+    aliases: [
+      'Joint Base Lewis-McChord',
+      'Joint Base Lewis McChord',
+      'JBLM',
+      'Fort Lewis',
+      'Ft Lewis',
+      'McChord AFB',
+      'McChord Air Force Base',
+    ],
+    stateCode: 'WA',
+    stateName: 'Washington',
+    stateSlug: 'washington',
+    latitude: 47.1054,
+    longitude: -122.5663,
+    nearestCoverageAreaOverride: 'Joint Base Lewis-McChord',
+  },
+  {
+    canonicalName: 'MacDill Air Force Base',
+    aliases: ['MacDill AFB', 'MacDill Air Force Base', 'MacDill', 'Macdill AFB'],
+    stateCode: 'FL',
+    stateName: 'Florida',
+    stateSlug: 'florida',
+    latitude: 27.8493,
+    longitude: -82.5212,
+    nearestCoverageAreaOverride: 'Tampa',
+  },
+  {
+    canonicalName: 'Fort Liberty',
+    aliases: ['Fort Liberty', 'Ft Liberty', 'Fort Bragg', 'Ft Bragg', 'Bragg', 'Pope AAF'],
+    stateCode: 'NC',
+    stateName: 'North Carolina',
+    stateSlug: 'north-carolina',
+    latitude: 35.139,
+    longitude: -79.006,
+    nearestCoverageAreaOverride: 'Fayetteville',
+  },
+];
+
+export const COVERAGE_AREA_METADATA: readonly CoverageAreaMetadata[] = [
+  { areaName: 'Colorado Springs', stateCode: 'CO', latitude: 38.8339, longitude: -104.8214, aliases: ['Fort Carson', 'Peterson SFB', 'USAFA'] },
+  { areaName: 'Denver', stateCode: 'CO', latitude: 39.7392, longitude: -104.9903 },
+  { areaName: 'Fort Collins', stateCode: 'CO', latitude: 40.5853, longitude: -105.0844 },
+  { areaName: 'Norfolk', stateCode: 'VA', latitude: 36.8508, longitude: -76.2859, aliases: ['Hampton Roads', 'Naval Station Norfolk', 'Norfolk Naval Station'] },
+  { areaName: 'Northern Virginia', stateCode: 'VA', latitude: 38.8816, longitude: -77.091, lookupNames: ['Arlington'] },
+  { areaName: 'Richmond - Fort Lee', stateCode: 'VA', latitude: 37.5407, longitude: -77.436, aliases: ['Fort Gregg-Adams', 'Fort Lee'], lookupNames: ['Richmond'] },
+  { areaName: 'Killeen - Fort Hood', stateCode: 'TX', latitude: 31.1171, longitude: -97.7278, aliases: ['Fort Cavazos', 'Fort Hood', 'Killeen'] },
+  { areaName: 'Austin', stateCode: 'TX', latitude: 30.2672, longitude: -97.7431 },
+  { areaName: 'San Antonio', stateCode: 'TX', latitude: 29.4241, longitude: -98.4936 },
+  { areaName: 'El Paso', stateCode: 'TX', latitude: 31.7619, longitude: -106.485 },
+  { areaName: 'Dallas-Fort Worth', stateCode: 'TX', latitude: 32.7767, longitude: -96.797, aliases: ['DFW'], lookupNames: ['Dallas'] },
+  { areaName: 'Houston', stateCode: 'TX', latitude: 29.7604, longitude: -95.3698 },
+  { areaName: 'Joint Base Lewis-McChord', stateCode: 'WA', latitude: 47.1054, longitude: -122.5663, aliases: ['JBLM', 'Fort Lewis', 'McChord AFB'], lookupNames: ['Tacoma'] },
+  { areaName: 'Bangor - Bremerton', stateCode: 'WA', latitude: 47.565, longitude: -122.627, lookupNames: ['Bremerton'] },
+  { areaName: 'Seattle', stateCode: 'WA', latitude: 47.6062, longitude: -122.3321 },
+  { areaName: 'Spokane', stateCode: 'WA', latitude: 47.6588, longitude: -117.426 },
+  { areaName: 'Whidbey Island', stateCode: 'WA', latitude: 48.2856, longitude: -122.6459, lookupNames: ['Oak Harbor'] },
+  { areaName: 'Tampa', stateCode: 'FL', latitude: 27.9506, longitude: -82.4572, aliases: ['MacDill AFB'] },
+  { areaName: 'Jacksonville', stateCode: 'FL', latitude: 30.3322, longitude: -81.6557 },
+  { areaName: 'Eglin AFB', stateCode: 'FL', latitude: 30.4832, longitude: -86.5254, lookupNames: ['Valparaiso'] },
+  { areaName: 'Cape Canaveral', stateCode: 'FL', latitude: 28.3922, longitude: -80.6077 },
+  { areaName: 'Fayetteville', stateCode: 'NC', latitude: 35.0527, longitude: -78.8784, aliases: ['Fort Liberty', 'Fort Bragg'] },
+  { areaName: 'Jacksonville', stateCode: 'NC', latitude: 34.7541, longitude: -77.4302 },
+  { areaName: 'Raleigh - Durham', stateCode: 'NC', latitude: 35.7796, longitude: -78.6382, lookupNames: ['Raleigh'] },
+  { areaName: 'Elizabeth City', stateCode: 'NC', latitude: 36.2946, longitude: -76.2511 },
+  { areaName: 'Charlotte', stateCode: 'NC', latitude: 35.2271, longitude: -80.8431 },
+  { areaName: 'Southern Pines', stateCode: 'NC', latitude: 35.174, longitude: -79.3923 },
+];
+
+export const AMBIGUOUS_CITY_CANDIDATES: Record<string, readonly ClarificationCandidate[]> = {
+  springfield: [
+    { name: 'Springfield', stateName: 'Missouri', stateCode: 'MO', reason: 'Common PCS destination name in Missouri.' },
+    { name: 'Springfield', stateName: 'Illinois', stateCode: 'IL', reason: 'Common city name in Illinois.' },
+    { name: 'Springfield', stateName: 'Massachusetts', stateCode: 'MA', reason: 'Common city name in Massachusetts.' },
+    { name: 'Springfield', stateName: 'Virginia', stateCode: 'VA', reason: 'Northern Virginia city with the same name.' },
+  ],
+};
+
+export function asCoordinates(value: Coordinates | undefined): Coordinates | undefined {
+  if (!value) return undefined;
+  if (!Number.isFinite(value.latitude) || !Number.isFinite(value.longitude)) {
+    return undefined;
+  }
+  return value;
+}
+
+export function stateFromInstallation(entry: InstallationAlias): RoutingState {
+  return { code: entry.stateCode, name: entry.stateName, slug: entry.stateSlug };
+}

--- a/lib/ai/routing/destination.ts
+++ b/lib/ai/routing/destination.ts
@@ -1,0 +1,210 @@
+import { AMBIGUOUS_CITY_CANDIDATES, INSTALLATION_ALIASES } from '@/lib/ai/routing/data';
+import {
+  lookupCityCentroid,
+  lookupCityDisplayName,
+  lookupZip,
+} from '@/lib/ai/routing/geo';
+import {
+  findRoutingState,
+  normalizeCompactText,
+  normalizeSearchText,
+  ROUTING_STATES,
+  slugifyRoutingText,
+  toTitleCase,
+} from '@/lib/ai/routing/states';
+import type { DestinationResolution, RoutingState } from '@/lib/ai/routing/types';
+
+interface ParsedCityState {
+  city: string;
+  state: RoutingState;
+}
+
+export function resolveDestinationLocation(
+  destination: string,
+  stateHint?: string,
+): DestinationResolution {
+  const input = destination.trim();
+  if (!input) {
+    return {
+      input: destination,
+      type: 'unknown',
+      normalizedName: '',
+      confidence: 'low',
+      caveat: 'I could not read a destination from that message.',
+    };
+  }
+
+  const base = matchInstallation(input);
+  if (base) {
+    return {
+      input,
+      type: 'military_base',
+      normalizedName: base.canonicalName,
+      stateName: base.stateName,
+      stateCode: base.stateCode,
+      stateSlug: base.stateSlug,
+      latitude: base.latitude,
+      longitude: base.longitude,
+      confidence: 'high',
+      coverageAreaOverride: base.nearestCoverageAreaOverride,
+    };
+  }
+
+  const zipMatch = input.match(/^\d{5}$/);
+  if (zipMatch) {
+    return resolveZip(input);
+  }
+
+  const stateOnly = findRoutingState(input);
+  if (stateOnly) {
+    return {
+      input,
+      type: 'state',
+      normalizedName: stateOnly.name,
+      stateName: stateOnly.name,
+      stateCode: stateOnly.code,
+      stateSlug: stateOnly.slug,
+      confidence: 'high',
+      caveat: 'State-only routing is broad. A city, base, or ZIP will narrow this down.',
+    };
+  }
+
+  const cityState = parseCityState(input, stateHint);
+  if (cityState) {
+    return resolveCityState(input, cityState.city, cityState.state);
+  }
+
+  const ambiguousCandidates = AMBIGUOUS_CITY_CANDIDATES[slugifyRoutingText(input)];
+  if (ambiguousCandidates) {
+    return {
+      input,
+      type: 'ambiguous',
+      normalizedName: toTitleCase(input),
+      confidence: 'low',
+      candidates: [...ambiguousCandidates],
+      caveat: `I need the state for ${toTitleCase(input)} before I can route it.`,
+    };
+  }
+
+  return {
+    input,
+    type: 'ambiguous',
+    normalizedName: toTitleCase(input),
+    confidence: 'low',
+    caveat: `I need the state for ${toTitleCase(input)} before I can route it.`,
+  };
+}
+
+function resolveZip(input: string): DestinationResolution {
+  const hit = lookupZip(input);
+  if (!hit) {
+    return {
+      input,
+      type: 'unknown',
+      normalizedName: input,
+      confidence: 'low',
+      caveat: `I could not find ZIP ${input} in the local US ZIP lookup.`,
+    };
+  }
+  const state = findRoutingState(hit.stateCode);
+  if (!state) {
+    return {
+      input,
+      type: 'unknown',
+      normalizedName: `${hit.city}, ${hit.stateCode}`,
+      confidence: 'low',
+      caveat: `I found ZIP ${input}, but not a supported state for it.`,
+    };
+  }
+  return {
+    input,
+    type: 'zip',
+    normalizedName: `${hit.city}, ${state.code}`,
+    stateName: state.name,
+    stateCode: state.code,
+    stateSlug: state.slug,
+    latitude: hit.latitude,
+    longitude: hit.longitude,
+    confidence: 'high',
+  };
+}
+
+function resolveCityState(
+  input: string,
+  rawCity: string,
+  state: RoutingState,
+): DestinationResolution {
+  const city = rawCity.trim();
+  const centroid = lookupCityCentroid(city, state);
+  if (!centroid) {
+    return {
+      input,
+      type: 'unknown',
+      normalizedName: `${toTitleCase(city)}, ${state.code}`,
+      stateName: state.name,
+      stateCode: state.code,
+      stateSlug: state.slug,
+      confidence: 'low',
+      caveat: `I could not find ${toTitleCase(city)}, ${state.code} in the local city lookup.`,
+    };
+  }
+
+  return {
+    input,
+    type: 'city',
+    normalizedName: `${lookupCityDisplayName(city, state)}, ${state.code}`,
+    stateName: state.name,
+    stateCode: state.code,
+    stateSlug: state.slug,
+    latitude: centroid.latitude,
+    longitude: centroid.longitude,
+    confidence: 'high',
+  };
+}
+
+function parseCityState(input: string, stateHint?: string): ParsedCityState | null {
+  const hintedState = findRoutingState(stateHint);
+  if (hintedState) {
+    return { city: input.replace(/,\s*$/, '').trim(), state: hintedState };
+  }
+
+  const commaParts = input.split(',').map((part) => part.trim()).filter(Boolean);
+  if (commaParts.length >= 2) {
+    const maybeState = findRoutingState(commaParts.at(-1));
+    const city = commaParts.slice(0, -1).join(', ');
+    if (maybeState && city) return { city, state: maybeState };
+  }
+
+  const stateCodeMatch = input.match(/^(.+?)\s+([A-Za-z]{2})$/);
+  if (stateCodeMatch) {
+    const maybeState = findRoutingState(stateCodeMatch[2]);
+    if (maybeState) return { city: stateCodeMatch[1].trim(), state: maybeState };
+  }
+
+  const normalizedInput = normalizeSearchText(input);
+  const stateByName = [...ROUTING_STATES]
+    .sort((a, b) => b.name.length - a.name.length)
+    .find((state) => normalizedInput.endsWith(` ${normalizeSearchText(state.name)}`));
+
+  if (stateByName) {
+    const stateText = normalizeSearchText(stateByName.name);
+    const city = normalizedInput.slice(0, -stateText.length).trim();
+    if (city) return { city, state: stateByName };
+  }
+
+  return null;
+}
+
+function matchInstallation(input: string) {
+  const normalized = normalizeCompactText(input);
+  const matches = INSTALLATION_ALIASES.flatMap((entry) =>
+    entry.aliases.map((alias) => ({ entry, alias, normalizedAlias: normalizeCompactText(alias) })),
+  )
+    .filter(({ normalizedAlias }) =>
+      normalized === normalizedAlias ||
+      (normalizedAlias.length > 6 && normalized.includes(normalizedAlias)),
+    )
+    .sort((a, b) => b.normalizedAlias.length - a.normalizedAlias.length);
+
+  return matches[0]?.entry ?? null;
+}

--- a/lib/ai/routing/geo.ts
+++ b/lib/ai/routing/geo.ts
@@ -1,0 +1,102 @@
+import * as zipcodes from 'zipcodes';
+import { COVERAGE_AREA_METADATA } from '@/lib/ai/routing/data';
+import { normalizeCompactText, toTitleCase } from '@/lib/ai/routing/states';
+import type { Coordinates, RoutingState } from '@/lib/ai/routing/types';
+
+export interface ZipLookupResult extends Coordinates {
+  zip: string;
+  city: string;
+  stateCode: string;
+}
+
+export function lookupZip(zip: string): ZipLookupResult | null {
+  const hit = zipcodes.lookup(zip);
+  if (!hit || hit.country !== 'US') return null;
+  return {
+    zip: hit.zip,
+    city: toTitleCase(hit.city),
+    stateCode: hit.state,
+    latitude: hit.latitude,
+    longitude: hit.longitude,
+  };
+}
+
+export function lookupCityCentroid(city: string, state: RoutingState): Coordinates | null {
+  const hits = zipcodes.lookupByName(city, state.code).filter((hit) => hit.country === 'US');
+  if (hits.length === 0) return null;
+  const totals = hits.reduce(
+    (sum, hit) => ({
+      latitude: sum.latitude + hit.latitude,
+      longitude: sum.longitude + hit.longitude,
+    }),
+    { latitude: 0, longitude: 0 },
+  );
+  return {
+    latitude: totals.latitude / hits.length,
+    longitude: totals.longitude / hits.length,
+  };
+}
+
+export function lookupCityDisplayName(city: string, state: RoutingState): string {
+  const hits = zipcodes.lookupByName(city, state.code).filter((hit) => hit.country === 'US');
+  return hits[0]?.city ? toTitleCase(hits[0].city) : toTitleCase(city);
+}
+
+export function getCoverageMetadata(areaName: string, stateCode: string) {
+  return COVERAGE_AREA_METADATA.find(
+    (item) =>
+      item.stateCode === stateCode &&
+      normalizeCompactText(item.areaName) === normalizeCompactText(areaName),
+  );
+}
+
+function candidateLookupNames(areaName: string): string[] {
+  const firstDashPart = areaName.split(/\s[-–]\s/)[0]?.trim();
+  const firstSlashPart = areaName.split('/')[0]?.trim();
+  const noBaseSuffix = areaName.replace(/\s+(?:afb|sfb)$/i, '').trim();
+  const candidates = [areaName, firstDashPart, firstSlashPart, noBaseSuffix]
+    .filter((value): value is string => Boolean(value));
+  return Array.from(new Set(candidates));
+}
+
+export function coordinatesForCoverageArea(
+  areaName: string,
+  state: RoutingState,
+): (Coordinates & { aliases: string[] }) | null {
+  const metadata = getCoverageMetadata(areaName, state.code);
+  if (metadata) {
+    return {
+      latitude: metadata.latitude,
+      longitude: metadata.longitude,
+      aliases: metadata.aliases ?? [],
+    };
+  }
+
+  for (const candidate of candidateLookupNames(areaName)) {
+    const centroid = lookupCityCentroid(candidate, state);
+    if (centroid) return { ...centroid, aliases: [] };
+  }
+
+  return null;
+}
+
+export function areaAliases(areaName: string, stateCode: string): string[] {
+  return getCoverageMetadata(areaName, stateCode)?.aliases ?? [];
+}
+
+export function distanceMiles(a: Coordinates, b: Coordinates): number {
+  const earthRadiusMiles = 3958.8;
+  const lat1 = toRadians(a.latitude);
+  const lat2 = toRadians(b.latitude);
+  const deltaLat = toRadians(b.latitude - a.latitude);
+  const deltaLon = toRadians(b.longitude - a.longitude);
+
+  const haversine =
+    Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+  return 2 * earthRadiusMiles * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+}
+
+function toRadians(value: number): number {
+  return (value * Math.PI) / 180;
+}

--- a/lib/ai/routing/partners.ts
+++ b/lib/ai/routing/partners.ts
@@ -1,0 +1,196 @@
+import { buildContactCtaHref } from '@/lib/contactAgentUrl';
+import { sanitizeCityName } from '@/utils/sanitizeCityName';
+import stateService, { type Agent, type Lenders } from '@/services/stateService';
+import { findRoutingState, normalizeCompactText, stateMatches } from '@/lib/ai/routing/states';
+import type {
+  PartnerRecord,
+  PartnerRole,
+  PartnersForCoverageAreaResult,
+  PublicPartner,
+  RoutingState,
+} from '@/lib/ai/routing/types';
+
+const PARTNER_LIMIT = 3;
+
+export async function getPartnersForCoverageArea(
+  stateInput: string,
+  areaName: string | undefined,
+  role: PartnerRole,
+): Promise<PartnersForCoverageAreaResult | null> {
+  const state = findRoutingState(stateInput);
+  if (!state) return null;
+
+  if (role === 'agent') {
+    const data = await stateService.fetchAgentsListByState(state.code, { requireHeadshot: false });
+    const ranked = rankRecordsForArea(data.records ?? [], state, areaName);
+    const matchedArea = !areaName || ranked.matchedArea;
+    return {
+      role,
+      stateName: state.name,
+      stateCode: state.code,
+      stateSlug: state.slug,
+      areaName,
+      matchedArea,
+      partners: ranked.records
+        .slice(0, PARTNER_LIMIT)
+        .map((agent) => trimAgent(agent, state, areaName)),
+      caveat: matchedArea
+        ? undefined
+        : `I did not find area-ranked agents for ${areaName}, so these are top active agents in ${state.name}.`,
+    };
+  }
+
+  const data = await stateService.fetchLendersListByState(state.code, { requireHeadshot: false });
+  const ranked = rankRecordsForArea(data.records ?? [], state, areaName);
+  const matchedArea = !areaName || ranked.matchedArea;
+  return {
+    role,
+    stateName: state.name,
+    stateCode: state.code,
+    stateSlug: state.slug,
+    areaName,
+    matchedArea,
+    partners: ranked.records
+      .slice(0, PARTNER_LIMIT)
+      .map((lender) => trimLender(lender, state, areaName)),
+    caveat: matchedArea
+      ? undefined
+      : `I did not find area-ranked lenders for ${areaName}, so these are top active lenders in ${state.name}.`,
+  };
+}
+
+export async function getPartnersForState(
+  stateInput: string,
+  role: PartnerRole,
+): Promise<PartnersForCoverageAreaResult | null> {
+  return getPartnersForCoverageArea(stateInput, undefined, role);
+}
+
+export function rankRecordsForArea<T extends PartnerRecord>(
+  records: T[],
+  state: RoutingState,
+  areaName?: string,
+): { records: T[]; matchedArea: boolean } {
+  const recordsInState = records.filter((record) => assignmentsInState(record, state).length > 0);
+  const source = recordsInState.length > 0 ? recordsInState : records;
+
+  const areaMatches = areaName
+    ? source.filter((record) => assignmentScoreForArea(record, state, areaName) !== null)
+    : [];
+  const rankedSource = areaMatches.length > 0 ? areaMatches : source;
+
+  return {
+    matchedArea: !areaName || areaMatches.length > 0,
+    records: rankedSource
+      .map((record, index) => ({
+        record,
+        index,
+        areaScore: areaName ? assignmentScoreForArea(record, state, areaName) ?? 0 : 0,
+        stateScore: maxStateAssignmentScore(record, state),
+      }))
+      .sort(
+        (a, b) =>
+          b.areaScore - a.areaScore ||
+          b.stateScore - a.stateScore ||
+          a.index - b.index,
+      )
+      .map(({ record }) => record),
+  };
+}
+
+function trimAgent(agent: Agent, state: RoutingState, selectedArea?: string): PublicPartner {
+  const city = selectedArea || primaryAreaName(agent, state) || agent.BillingAddress?.city || '';
+  return {
+    id: agent.AccountId_15__c ?? '',
+    role: 'agent',
+    name: agent.Name ?? '',
+    firstName: agent.FirstName ?? '',
+    lastName: agent.LastName ?? '',
+    brokerage: agent.Brokerage_Name__pc ?? '',
+    city,
+    militaryStatus: agent.Military_Status__pc ?? '',
+    militaryService: agent.Military_Service__pc ?? '',
+    statesLicensed: agent.State_s_Licensed_in__pc ?? '',
+    photoUrl: agent.PhotoUrl ?? '',
+    bio: snippet(agent.Agent_Bio__pc ?? ''),
+    contactHref: buildContactCtaHref({
+      firstName: agent.FirstName,
+      salesforceId: agent.AccountId_15__c,
+      stateSlug: state.slug,
+      form: 'agent',
+    }),
+    profileHref: city ? `/${state.slug}#${sanitizeCityName(city)}` : `/${state.slug}`,
+    stateName: state.name,
+    stateSlug: state.slug,
+    areaName: selectedArea || primaryAreaName(agent, state) || undefined,
+    aaScore: selectedArea
+      ? assignmentScoreForArea(agent, state, selectedArea) ?? undefined
+      : maxStateAssignmentScore(agent, state),
+  };
+}
+
+function trimLender(lender: Lenders, state: RoutingState, selectedArea?: string): PublicPartner {
+  const city = selectedArea || primaryAreaName(lender, state) || lender.BillingCity || '';
+  return {
+    id: lender.AccountId_15__c ?? '',
+    role: 'lender',
+    name: lender.Name ?? '',
+    firstName: lender.FirstName ?? '',
+    brokerage: lender.Brokerage_Name__pc ?? '',
+    city,
+    militaryStatus: lender.Military_Status__pc ?? '',
+    militaryService: lender.Military_Service__pc ?? '',
+    individualNmlsId: lender.Individual_NMLS_ID__pc ?? '',
+    companyNmlsId: lender.Company_NMLS_ID__pc ?? '',
+    photoUrl: lender.PhotoUrl ?? '',
+    bio: snippet(lender.Agent_Bio__pc ?? ''),
+    contactHref: buildContactCtaHref({
+      firstName: lender.FirstName,
+      salesforceId: lender.AccountId_15__c,
+      stateSlug: state.slug,
+      form: 'lender',
+    }),
+    profileHref: `/${state.slug}`,
+    stateName: state.name,
+    stateSlug: state.slug,
+    areaName: selectedArea || primaryAreaName(lender, state) || undefined,
+    aaScore: selectedArea
+      ? assignmentScoreForArea(lender, state, selectedArea) ?? undefined
+      : maxStateAssignmentScore(lender, state),
+  };
+}
+
+function assignmentsInState(record: PartnerRecord, state: RoutingState) {
+  return (record.Area_Assignments__r?.records ?? []).filter((assignment) =>
+    stateMatches(assignment.Area__r?.State__c, state),
+  );
+}
+
+function primaryAreaName(record: PartnerRecord, state: RoutingState): string {
+  return assignmentsInState(record, state)[0]?.Area__r?.Name ?? '';
+}
+
+function maxStateAssignmentScore(record: PartnerRecord, state: RoutingState): number {
+  return assignmentsInState(record, state).reduce(
+    (max, assignment) => Math.max(max, assignment.AA_Score__c ?? 0),
+    0,
+  );
+}
+
+function assignmentScoreForArea(
+  record: PartnerRecord,
+  state: RoutingState,
+  areaName: string,
+): number | null {
+  const target = normalizeCompactText(areaName);
+  const assignment = assignmentsInState(record, state).find(
+    (item) => normalizeCompactText(item.Area__r?.Name ?? '') === target,
+  );
+  return assignment ? assignment.AA_Score__c ?? 0 : null;
+}
+
+function snippet(input: string, maxLength = 160): string {
+  const normalized = input.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength).replace(/\s+\S*$/, '')}...`;
+}

--- a/lib/ai/routing/states.ts
+++ b/lib/ai/routing/states.ts
@@ -1,0 +1,66 @@
+import { US_STATES } from '@/constants/usStates';
+import type { RoutingState } from '@/lib/ai/routing/types';
+
+export const ROUTING_STATES: readonly RoutingState[] = [
+  ...US_STATES,
+  { code: 'DC', name: 'District of Columbia', slug: 'washington-dc' },
+];
+
+export function slugifyRoutingText(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function normalizeSearchText(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/\bft\b/g, 'fort')
+    .replace(/\bsfb\b/g, 'space force base')
+    .replace(/\bafb\b/g, 'air force base')
+    .replace(/\bjb\b/g, 'joint base')
+    .replace(/\baafa\b/g, 'air force academy')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+export function normalizeCompactText(input: string): string {
+  return normalizeSearchText(input).replace(/\s+/g, '');
+}
+
+export function findRoutingState(input?: string | null): RoutingState | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const slug = slugifyRoutingText(trimmed);
+  const compact = normalizeCompactText(trimmed);
+
+  return (
+    ROUTING_STATES.find((state) => state.code.toLowerCase() === trimmed.toLowerCase()) ??
+    ROUTING_STATES.find((state) => state.slug === slug) ??
+    ROUTING_STATES.find((state) => normalizeCompactText(state.name) === compact) ??
+    null
+  );
+}
+
+export function stateMatches(areaState: string | undefined, target: RoutingState): boolean {
+  const normalized = findRoutingState(areaState);
+  if (normalized) return normalized.code === target.code;
+  return normalizeCompactText(areaState ?? '') === normalizeCompactText(target.name);
+}
+
+export function toTitleCase(input: string): string {
+  return input
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/lib/ai/routing/types.ts
+++ b/lib/ai/routing/types.ts
@@ -1,0 +1,112 @@
+import type { Agent, Lenders } from '@/services/stateService';
+
+export type DestinationType =
+  | 'military_base'
+  | 'city'
+  | 'zip'
+  | 'state'
+  | 'ambiguous'
+  | 'unknown';
+
+export type RoutingConfidence = 'high' | 'medium' | 'low';
+
+export interface RoutingState {
+  code: string;
+  name: string;
+  slug: string;
+}
+
+export interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+export interface ClarificationCandidate {
+  name: string;
+  stateName: string;
+  stateCode: string;
+  reason: string;
+}
+
+export interface DestinationResolution {
+  input: string;
+  type: DestinationType;
+  normalizedName: string;
+  stateName?: string;
+  stateCode?: string;
+  stateSlug?: string;
+  latitude?: number;
+  longitude?: number;
+  confidence: RoutingConfidence;
+  candidates?: ClarificationCandidate[];
+  coverageAreaOverride?: string;
+  caveat?: string;
+}
+
+export interface CoverageArea {
+  areaName: string;
+  slug: string;
+  stateName: string;
+  stateCode: string;
+  stateSlug: string;
+  latitude?: number;
+  longitude?: number;
+  agentCount: number;
+  lenderAvailable: boolean;
+  topAgentScore: number;
+  topLenderScore: number;
+  aliases: string[];
+}
+
+export interface RoutedCoverageArea extends CoverageArea {
+  distanceMiles?: number;
+  confidence: RoutingConfidence;
+  reason: string;
+  exactMatch: boolean;
+}
+
+export interface CoverageRoutingResult {
+  destination: DestinationResolution;
+  coverageAreas: RoutedCoverageArea[];
+  selectedCoverageArea?: RoutedCoverageArea;
+  needsClarification: boolean;
+  caveat?: string;
+}
+
+export type PartnerRole = 'agent' | 'lender';
+
+export interface PublicPartner {
+  id: string;
+  role: PartnerRole;
+  name: string;
+  firstName: string;
+  lastName?: string;
+  brokerage: string;
+  city: string;
+  militaryStatus: string;
+  militaryService: string;
+  statesLicensed?: string;
+  individualNmlsId?: string;
+  companyNmlsId?: string;
+  photoUrl: string;
+  bio: string;
+  contactHref: string;
+  profileHref: string;
+  stateName: string;
+  stateSlug: string;
+  areaName?: string;
+  aaScore?: number;
+}
+
+export interface PartnersForCoverageAreaResult {
+  role: PartnerRole;
+  stateName: string;
+  stateCode: string;
+  stateSlug: string;
+  areaName?: string;
+  matchedArea: boolean;
+  partners: PublicPartner[];
+  caveat?: string;
+}
+
+export type PartnerRecord = Agent | Lenders;

--- a/lib/ai/system-prompt.ts
+++ b/lib/ai/system-prompt.ts
@@ -28,8 +28,15 @@ Help the user find a vetted, military-experienced real estate agent or VA-loan l
 
 # How you work
 - Use the available tools to look up real data. Never invent agents, lenders, states, BAH rates, or contact info.
+- When the user names a military base, city, town, ZIP, or state and asks for an agent or lender, route deterministically: always call resolveDestinationLocation first, then findCoverageAreas, then getPartnersForCoverageArea with the selected coverage area.
+- Do not decide coverage from memory. The routing tools decide the normalized state, selected coverage area, confidence, and caveat language.
+- Do not answer ambiguous destination names from memory. Call resolveDestinationLocation first; if it returns ambiguous, ask a short clarifying question for the state. Example: "Which Springfield state do you mean?"
+- If findCoverageAreas returns a caveat, include that caveat plainly in your reply before explaining partners. If exact coverage does not exist, say "I do not see a [destination]-specific VeteranPCS coverage area" and name the closest active VeteranPCS coverage area from the tool output. Do not soften this into vague phrasing like "just outside our coverage zone."
 - Prefer one short paragraph over a long one. Bullets only when they genuinely help.
 - If the user asks for an agent or lender, use the lookup tools and present 1–3 matches with their name, brokerage/company, city, and a one-line reason they fit (e.g., "Army veteran, based near Fort Hood").
+- The chat renderer is plain text. Do not use Markdown syntax such as **bold**, tables, or inline links in your text response.
+- When agent or lender cards are shown, do not duplicate every partner name in prose. Let the actionable cards carry names, photos, and links.
+- If the user says they want to connect with a named partner, that is in scope. Help them start intake or collect the required lead details; do not treat it as an unrelated request.
 - If you don't know something, say so. Offer to connect the user to a human partner.
 
 # Lead submission (critical)

--- a/lib/ai/tools/data-tools.ts
+++ b/lib/ai/tools/data-tools.ts
@@ -1,43 +1,22 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import stateService, {
-  type Agent,
-  type Lenders,
   type StateList,
 } from '@/services/stateService';
 import { logError, logInfo } from '@/services/loggingService';
 import { stateInputSchema, type ToolResult } from '@/lib/ai/tools/types';
+import { getPartnersForState } from '@/lib/ai/routing/partners';
+import type { PublicPartner } from '@/lib/ai/routing/types';
 
-// --- Public-facing trimmed shapes (NO PII: no PhotoUrl, PersonEmail, PersonMobilePhone) ---
+// --- Public-facing trimmed shapes (NO PII: no PersonEmail or PersonMobilePhone) ---
 
 export interface PublicState {
   slug: string;
   name: string;
 }
 
-export interface PublicAgent {
-  id: string;
-  name: string;
-  firstName: string;
-  lastName: string;
-  brokerage: string;
-  city: string;
-  militaryStatus: string;
-  militaryService: string;
-  statesLicensed: string;
-}
-
-export interface PublicLender {
-  id: string;
-  name: string;
-  firstName: string;
-  brokerage: string;
-  city: string;
-  militaryStatus: string;
-  militaryService: string;
-  individualNmlsId: string;
-  companyNmlsId: string;
-}
+export type PublicAgent = PublicPartner;
+export type PublicLender = PublicPartner;
 
 // --- State normalization ---
 
@@ -119,48 +98,11 @@ const getStateDetailsTool = tool({
   },
 });
 
-// --- Helpers for ranking / trimming ---
-
-function topAreaCity(record: Agent | Lenders): string {
-  const area = record.Area_Assignments__r?.records?.[0]?.Area__r?.Name;
-  return area ?? '';
-}
-
-function trimAgent(agent: Agent): PublicAgent {
-  const billingCity = agent.BillingAddress?.city ?? '';
-  return {
-    id: agent.AccountId_15__c ?? '',
-    name: agent.Name ?? '',
-    firstName: agent.FirstName ?? '',
-    lastName: agent.LastName ?? '',
-    brokerage: agent.Brokerage_Name__pc ?? '',
-    city: billingCity || topAreaCity(agent),
-    militaryStatus: agent.Military_Status__pc ?? '',
-    militaryService: agent.Military_Service__pc ?? '',
-    statesLicensed: agent.State_s_Licensed_in__pc ?? '',
-  };
-}
-
-function trimLender(lender: Lenders): PublicLender {
-  const billingCity = lender.BillingCity ?? '';
-  return {
-    id: lender.AccountId_15__c ?? '',
-    name: lender.Name ?? '',
-    firstName: lender.FirstName ?? '',
-    brokerage: lender.Brokerage_Name__pc ?? '',
-    city: billingCity || topAreaCity(lender),
-    militaryStatus: lender.Military_Status__pc ?? '',
-    militaryService: lender.Military_Service__pc ?? '',
-    individualNmlsId: lender.Individual_NMLS_ID__pc ?? '',
-    companyNmlsId: lender.Company_NMLS_ID__pc ?? '',
-  };
-}
-
 // --- Tool: getAgentsForState ---
 
 const getAgentsForStateTool = tool({
   description:
-    'Get up to 5 vetted real estate agents who serve a given US state. Use this when the user wants help finding an agent. Returns trimmed, public-facing data only (no email or phone).',
+    'Get up to 3 vetted real estate agents who serve a given US state. For city/base/ZIP requests, prefer resolveDestinationLocation -> findCoverageAreas -> getPartnersForCoverageArea first. Returns card-ready public data only (no email or phone).',
   inputSchema: stateInputSchema,
   execute: async ({
     state,
@@ -176,13 +118,8 @@ const getAgentsForStateTool = tool({
           input: state,
         });
       }
-      const data = await stateService.fetchAgentsListByState(matched.short_name, {
-        requireHeadshot: false,
-      });
-      const agents = (data.records || [])
-        .map(trimAgent)
-        .filter((a) => a.id)
-        .slice(0, 5);
+      const data = await getPartnersForState(matched.short_name, 'agent');
+      const agents = (data?.partners ?? []).filter((a) => a.id);
       logInfo('Concierge tool: getAgentsForState', {
         slug: matched.state_slug.current,
         count: agents.length,
@@ -206,7 +143,7 @@ const getAgentsForStateTool = tool({
 
 const getLendersForStateTool = tool({
   description:
-    'Get up to 5 vetted VA-loan lenders who serve a given US state. Use this when the user wants help finding a lender. Returns trimmed, public-facing data only (no email or phone).',
+    'Get up to 3 vetted VA-loan lenders who serve a given US state. For city/base/ZIP requests, prefer resolveDestinationLocation -> findCoverageAreas -> getPartnersForCoverageArea first. Returns card-ready public data only (no email or phone).',
   inputSchema: stateInputSchema,
   execute: async ({
     state,
@@ -224,13 +161,8 @@ const getLendersForStateTool = tool({
           input: state,
         });
       }
-      const data = await stateService.fetchLendersListByState(matched.short_name, {
-        requireHeadshot: false,
-      });
-      const lenders = (data.records || [])
-        .map(trimLender)
-        .filter((l) => l.id)
-        .slice(0, 5);
+      const data = await getPartnersForState(matched.short_name, 'lender');
+      const lenders = (data?.partners ?? []).filter((l) => l.id);
       logInfo('Concierge tool: getLendersForState', {
         slug: matched.state_slug.current,
         count: lenders.length,

--- a/lib/ai/tools/index.ts
+++ b/lib/ai/tools/index.ts
@@ -1,9 +1,11 @@
 import { dataTools } from '@/lib/ai/tools/data-tools';
 import { calcTools } from '@/lib/ai/tools/calc-tools';
 import { leadTools } from '@/lib/ai/tools/lead-tools';
+import { routingTools } from '@/lib/ai/tools/routing-tools';
 
 export function buildTools() {
   return {
+    ...routingTools,
     ...dataTools,
     ...calcTools,
     ...leadTools,

--- a/lib/ai/tools/routing-tools.ts
+++ b/lib/ai/tools/routing-tools.ts
@@ -1,0 +1,119 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { resolveDestinationLocation } from '@/lib/ai/routing/destination';
+import { findCoverageAreasForDestination } from '@/lib/ai/routing/coverage';
+import { getPartnersForCoverageArea } from '@/lib/ai/routing/partners';
+import { logError, logInfo } from '@/services/loggingService';
+import type {
+  CoverageRoutingResult,
+  DestinationResolution,
+  PartnerRole,
+  PartnersForCoverageAreaResult,
+} from '@/lib/ai/routing/types';
+import type { ToolResult } from '@/lib/ai/tools/types';
+
+const destinationInputSchema = z.object({
+  destination: z
+    .string()
+    .min(1)
+    .describe('Military base, city/town, ZIP code, or state the user named.'),
+  stateHint: z
+    .string()
+    .optional()
+    .describe('Optional state name or code if the user supplied it separately.'),
+});
+
+const partnersForCoverageAreaInputSchema = z.object({
+  state: z
+    .string()
+    .min(2)
+    .describe('US state name, slug, or 2-letter code returned by findCoverageAreas.'),
+  areaName: z
+    .string()
+    .optional()
+    .describe('Coverage area name selected by findCoverageAreas. Omit only for state-only requests.'),
+  role: z.enum(['agent', 'lender']).describe('Partner type the user asked for.'),
+});
+
+const resolveDestinationLocationTool = tool({
+  description:
+    'Resolve a user-named destination to deterministic geography. Use before partner lookup when the user names a military base, city, town, ZIP, or state. Returns ambiguity instead of guessing.',
+  inputSchema: destinationInputSchema,
+  execute: async ({
+    destination,
+    stateHint,
+  }): Promise<ToolResult<{ destination: DestinationResolution }>> => {
+    try {
+      const resolved = resolveDestinationLocation(destination, stateHint);
+      logInfo('Concierge routing tool: resolveDestinationLocation', {
+        input: destination,
+        type: resolved.type,
+        stateCode: resolved.stateCode,
+        normalizedName: resolved.normalizedName,
+      });
+      return { ok: true, data: { destination: resolved } };
+    } catch (error) {
+      logError('Concierge routing tool: resolveDestinationLocation failed', { destination }, error);
+      return { ok: false, error: 'Could not resolve that destination right now.' };
+    }
+  },
+});
+
+const findCoverageAreasTool = tool({
+  description:
+    'Route a resolved destination to active VeteranPCS coverage areas. Use after resolveDestinationLocation and before getPartnersForCoverageArea. Returns closest same-state coverage and caveats when exact coverage is missing.',
+  inputSchema: destinationInputSchema,
+  execute: async ({
+    destination,
+    stateHint,
+  }): Promise<ToolResult<CoverageRoutingResult>> => {
+    try {
+      const result = await findCoverageAreasForDestination(destination, stateHint);
+      logInfo('Concierge routing tool: findCoverageAreas', {
+        input: destination,
+        stateCode: result.destination.stateCode,
+        selectedArea: result.selectedCoverageArea?.areaName,
+        needsClarification: result.needsClarification,
+      });
+      return { ok: true, data: result };
+    } catch (error) {
+      logError('Concierge routing tool: findCoverageAreas failed', { destination, stateHint }, error);
+      return { ok: false, error: 'Could not route that destination right now.' };
+    }
+  },
+});
+
+const getPartnersForCoverageAreaTool = tool({
+  description:
+    'Get the top 3 actionable VeteranPCS partners for a selected coverage area. Call this only after findCoverageAreas picks an area, or with state only for broad state requests. Partners are sorted by AA_Score where available and include card hrefs.',
+  inputSchema: partnersForCoverageAreaInputSchema,
+  execute: async ({
+    state,
+    areaName,
+    role,
+  }): Promise<ToolResult<PartnersForCoverageAreaResult>> => {
+    try {
+      const result = await getPartnersForCoverageArea(state, areaName, role as PartnerRole);
+      if (!result) {
+        return { ok: false, error: `Could not find a state matching "${state}".` };
+      }
+      logInfo('Concierge routing tool: getPartnersForCoverageArea', {
+        state: result.stateCode,
+        areaName: result.areaName,
+        role: result.role,
+        count: result.partners.length,
+        matchedArea: result.matchedArea,
+      });
+      return { ok: true, data: result };
+    } catch (error) {
+      logError('Concierge routing tool: getPartnersForCoverageArea failed', { state, areaName, role }, error);
+      return { ok: false, error: 'Could not load partners for that coverage area right now.' };
+    }
+  },
+});
+
+export const routingTools = {
+  resolveDestinationLocation: resolveDestinationLocationTool,
+  findCoverageAreas: findCoverageAreasTool,
+  getPartnersForCoverageArea: getPartnersForCoverageAreaTool,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.13",
         "yup": "^1.6.1",
+        "zipcodes": "^8.0.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -57,6 +58,7 @@
         "@types/react-dom": "19.2.3",
         "@types/react-google-recaptcha": "^2.1.9",
         "@types/react-slick": "^0.23.13",
+        "@types/zipcodes": "^8.0.5",
         "autoprefixer": "^10.4.20",
         "dotenv": "^17.2.3",
         "eslint": "^9",
@@ -8049,6 +8051,13 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
       "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/zipcodes": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@types/zipcodes/-/zipcodes-8.0.5.tgz",
+      "integrity": "sha512-NxtKCnUa/LJ6kIku6Rl8mkXfpGkZ0y6AG7rh+WHYtaxfhVgi1bDOZDfGVZiY+JxW+GPdvYXmyERB9rd/xa/pEg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -26550,6 +26559,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/zipcodes": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/zipcodes/-/zipcodes-8.0.0.tgz",
+      "integrity": "sha512-V8NolFaJhsPamGeCv5lJdk60Q7JBiXI6e+8JDksPC1NJWZ0t7g1OFfqVLZb2Nc2F5jmf9JTdYdWJBnIhGBvtbA==",
+      "license": "BSD"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.13",
     "yup": "^1.6.1",
+    "zipcodes": "^8.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -63,6 +64,7 @@
     "@types/react-dom": "19.2.3",
     "@types/react-google-recaptcha": "^2.1.9",
     "@types/react-slick": "^0.23.13",
+    "@types/zipcodes": "^8.0.5",
     "autoprefixer": "^10.4.20",
     "dotenv": "^17.2.3",
     "eslint": "^9",


### PR DESCRIPTION
## Summary
- Adds deterministic concierge routing for military bases, cities/towns, ZIP codes, state-only requests, and ambiguous destinations.
- Builds coverage-area routing from Salesforce-backed area assignments, then ranks actionable agent/lender cards by selected coverage area and AA score where available.
- Hardens concierge partner cards with max 3 results, profile/contact hrefs, headshot/initial fallbacks, safe text wrapping, and no exposed phone/email.

## Routing Behavior
- Military aliases resolve first, including Fort Carson, Peterson SFB, USAFA, Naval Station Norfolk, Fort Cavazos/Fort Hood, JBLM, MacDill AFB, and Fort Liberty/Fort Bragg.
- ZIP and `city, state` inputs resolve through the local `zipcodes` dataset rather than a runtime geocoding API.
- Exact active coverage matches win; otherwise the tool selects the closest active same-state VeteranPCS coverage area with a plain caveat.
- Ambiguous inputs like `Springfield` ask for the state instead of guessing.
- State-only requests return broad state routing with a prompt to provide a city/base/ZIP for a tighter match.

## Notes / Limitations
- The only intentional curated runtime data is military installation aliases/overrides and coverage-area coordinate metadata for compound or military-heavy markets. Boulder/80301 are test/eval fixtures only, not production routing hardcodes.
- Longer term, installation aliases and coverage metadata should move into a managed Salesforce/Sanity/admin data source so area-name drift is easier to monitor.

## Validation
- `git diff --check`
- `npm test` — 25 files, 165 tests passed
- `npm run lint` — passed, with existing large SVG Babel note
- `npm run type-check`
- `npm run build`
- `npm run eval` — 5 files, 26 eval tests passed with network access
- Local browser sanity check: homepage loaded, concierge button was accessible, widget opened, input rendered, no framework overlay, no real leads submitted
- Merge safety: latest `origin/main` is an ancestor, and `git merge-tree --write-tree HEAD origin/main` completed without conflicts