### PR TITLE
[codex] Add Salesforce lead owner routing

### DIFF
--- a/services/__tests__/salesForcePostFormsService.test.ts
+++ b/services/__tests__/salesForcePostFormsService.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import sendToSlack from '@/actions/sendToSlack';
 import { sendOpenPhoneMessage } from '@/actions/sendOpenPhoneMessage';
+import { routeSalesforceLeadOwner } from '@/services/salesforceLeadOwnerService';
 import { contactAgentPostForm, contactLenderPostForm } from '@/services/salesForcePostFormsService';
 import { logError } from '@/services/loggingService';
+
+vi.mock('server-only', () => ({}));
 
 vi.mock('@/actions/sendToSlack', () => ({
   default: vi.fn(async () => ({ ok: true })),
@@ -10,6 +13,19 @@ vi.mock('@/actions/sendToSlack', () => ({
 
 vi.mock('@/actions/sendOpenPhoneMessage', () => ({
   sendOpenPhoneMessage: vi.fn(async () => ({ id: 'openphone-test-message' })),
+}));
+
+vi.mock('@/services/salesforceLeadOwnerService', () => ({
+  appendLeadOwnerSubmissionMarker: vi.fn((url: string, submissionId: string) => {
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}sid=${encodeURIComponent(submissionId)}`;
+  }),
+  routeSalesforceLeadOwner: vi.fn(async () => ({
+    leadId: '00QTEST',
+    ownerId: '005TEST',
+    ownerName: 'Test Owner',
+    adminName: 'Test Admin',
+  })),
 }));
 
 vi.mock('@/services/loggingService', () => ({
@@ -105,7 +121,23 @@ describe('contactAgentPostForm Salesforce Web-to-Lead behavior', () => {
 
     expect(result).toEqual({ redirectUrl: 'https://www.veteranpcs.com/thank-you' });
     expect(salesforceBody().get('00N4x00000LspV2')).toBe('CO');
+    expect(salesforceBody().get('00N4x00000QQ1LB')).toContain('sid=submission-test-id');
     expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(routeSalesforceLeadOwner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        submissionId: 'submission-test-id',
+        submissionStartedAt: expect.any(Date),
+        leadSource: 'Contact Agent',
+        destinationStateCode: 'CO',
+        destinationStateSlug: 'colorado',
+        email: 'tech+qa@veteranpcs.com',
+        selectedAgentId: '0014x00000HWTqI',
+        owner: expect.objectContaining({
+          adminName: 'Beth',
+          ownerId: '0054x000005GsUvAAK',
+        }),
+      }),
+    );
     expect(sendToSlack).toHaveBeenCalledTimes(1);
     expect(sendToSlack).toHaveBeenCalledWith(expect.objectContaining({ state: 'Colorado' }));
     expect(sendOpenPhoneMessage).toHaveBeenCalledTimes(1);
@@ -117,7 +149,7 @@ describe('contactAgentPostForm Salesforce Web-to-Lead behavior', () => {
     });
 
     const result = await contactAgentPostForm(
-      { ...qaPayload(), state: 'TX' },
+      { ...qaPayload(), state: 'TX', destinationBase: 'Austin QA Test' },
       '?form=agent&fn=Jason&id=0014x00000HWTqI',
     );
 
@@ -141,6 +173,13 @@ describe('contactAgentPostForm Salesforce Web-to-Lead behavior', () => {
     await contactAgentPostForm({ ...qaPayload(), state: 'TX' }, queryString);
 
     expect(salesforceBody().get('00N4x00000LspV2')).toBe('CO');
+    expect(routeSalesforceLeadOwner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationStateCode: 'CO',
+        destinationStateSlug: 'colorado',
+        owner: expect.objectContaining({ adminName: 'Beth' }),
+      }),
+    );
     expect(sendToSlack).toHaveBeenCalledWith(expect.objectContaining({ state: 'Colorado' }));
   });
 
@@ -170,6 +209,18 @@ describe('contactAgentPostForm Salesforce Web-to-Lead behavior', () => {
 
     expect(result).toEqual({ message: 'Form submitted successfully!' });
     expect(salesforceBody().get('00N4x00000LspV2')).toBe('TX');
+    expect(routeSalesforceLeadOwner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leadSource: 'Contact Lender',
+        destinationStateCode: 'TX',
+        destinationStateSlug: 'texas',
+        selectedLenderId: '0014x00000Lender',
+        owner: expect.objectContaining({
+          adminName: 'Tara',
+          ownerId: '005Rg00000BAN0DIAX',
+        }),
+      }),
+    );
     expect(sendToSlack).toHaveBeenCalledWith(expect.objectContaining({ state: 'Texas' }));
     expect(sendOpenPhoneMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -189,6 +240,30 @@ describe('contactAgentPostForm Salesforce Web-to-Lead behavior', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(sendToSlack).toHaveBeenCalledTimes(1);
     expect(sendOpenPhoneMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the visitor success path when post-Web-to-Lead owner routing fails', async () => {
+    vi.mocked(routeSalesforceLeadOwner).mockRejectedValueOnce(new Error('ambiguous lead'));
+    mockSalesforceResponse('<html><body>Thank you for your submission.</body></html>', {
+      status: 200,
+    });
+
+    const result = await contactAgentPostForm(qaPayload(), queryString);
+
+    expect(result).toEqual({ message: 'Form submitted successfully!' });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(sendToSlack).toHaveBeenCalledTimes(1);
+    expect(sendOpenPhoneMessage).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith(
+      'Salesforce Lead owner routing failed after Web-to-Lead acceptance',
+      expect.objectContaining({
+        submissionId: 'submission-test-id',
+        leadSource: 'Contact Agent',
+        destinationStateCode: 'CO',
+        destinationStateSlug: 'colorado',
+      }),
+      expect.any(Error),
+    );
   });
 
   it('does not retry Salesforce when Slack returns a failed result after Salesforce accepts', async () => {

--- a/services/__tests__/salesforceLeadOwnerRouting.test.ts
+++ b/services/__tests__/salesforceLeadOwnerRouting.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import { getLeadOwnerForState } from '@/services/salesforceLeadOwnerRouting';
+
+describe('salesforceLeadOwnerRouting', () => {
+  it.each([
+    ['colorado', 'BETH', 'Beth', '0054x000005GsUvAAK', 'Beth Soldner'],
+    ['texas', 'TARA', 'Tara', '005Rg00000BAN0DIAX', 'Tara Gould'],
+    ['florida', 'JESSICA', 'Jessica', '005Rg000004hWojIAE', 'Jessica Brown'],
+    ['indiana', 'STEPHANIE', 'Stephanie', '0054x0000082vHgAAI', 'Stephanie Guree'],
+    ['new-york', 'STEPHANIE', 'Stephanie', '0054x0000082vHgAAI', 'Stephanie Guree'],
+    ['puerto-rico', 'STEPHANIE', 'Stephanie', '0054x0000082vHgAAI', 'Stephanie Guree'],
+    ['PR', 'STEPHANIE', 'Stephanie', '0054x0000082vHgAAI', 'Stephanie Guree'],
+  ])('returns hardcoded owner config for %s', (state, adminKey, adminName, ownerId, ownerName) => {
+    expect(getLeadOwnerForState(state)).toEqual({
+      adminKey,
+      adminName,
+      ownerId,
+      ownerName,
+    });
+  });
+
+  it('throws for states without admin routing', () => {
+    expect(() => getLeadOwnerForState('not-a-state')).toThrow(
+      'No admin routing found for Salesforce Lead owner state',
+    );
+  });
+});

--- a/services/__tests__/salesforceLeadOwnerService.test.ts
+++ b/services/__tests__/salesforceLeadOwnerService.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/constants/api', () => ({
+  SALESFORCE_BASE_URL: 'https://sf.example.test',
+  SALESFORCE_API_VERSION: 'v62.0',
+}));
+
+vi.mock('@/services/api', () => ({
+  RequestType: {
+    GET: 'get',
+    PATCH: 'patch',
+  },
+  salesForceAPI: vi.fn(),
+}));
+
+vi.mock('@/services/salesForceTokenService', () => ({
+  getSalesforceToken: vi.fn(),
+}));
+
+vi.mock('@/services/loggingService', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+import { RequestType, salesForceAPI } from '@/services/api';
+import { logError, logInfo } from '@/services/loggingService';
+import {
+  appendLeadOwnerSubmissionMarker,
+  routeSalesforceLeadOwner,
+} from '@/services/salesforceLeadOwnerService';
+
+const BETH_OWNER_ID = '0054x000005GsUvAAK';
+
+function queryResponse(records: unknown[]) {
+  return {
+    status: 200,
+    data: {
+      totalSize: records.length,
+      done: true,
+      records,
+    },
+  };
+}
+
+function routeParams(overrides = {}) {
+  return {
+    submissionId: 'submission-test-id',
+    submissionStartedAt: new Date('2026-06-17T12:00:00.000Z'),
+    leadSource: 'Contact Agent' as const,
+    destinationStateCode: 'CO',
+    destinationStateSlug: 'colorado',
+    email: 'qa@example.test',
+    selectedAgentId: '0014x00000HWTqI',
+    ...overrides,
+  };
+}
+
+function decodedQuery(callIndex: number): string {
+  const call = vi.mocked(salesForceAPI).mock.calls[callIndex]?.[0];
+  const endpoint = call?.endpoint ?? '';
+  return new URL(endpoint).searchParams.get('q') ?? '';
+}
+
+function patchCall() {
+  return vi.mocked(salesForceAPI).mock.calls.find(([call]) => call.type === RequestType.PATCH)?.[0];
+}
+
+describe('salesforceLeadOwnerService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('appends a submission marker to the WebForm URL', () => {
+    expect(
+      appendLeadOwnerSubmissionMarker(
+        'https://www.veteranpcs.com/contact-agent?state=colorado',
+        'abc 123',
+      ),
+    ).toBe('https://www.veteranpcs.com/contact-agent?state=colorado&sid=abc+123');
+  });
+
+  it('keeps long marked WebForm URLs within the Salesforce URL field limit', () => {
+    const longQuery = `state=colorado&extra=${'x'.repeat(400)}`;
+    const marked = appendLeadOwnerSubmissionMarker(
+      `https://www.veteranpcs.com/contact-agent?${longQuery}`,
+      'submission-test-id',
+    );
+
+    expect(marked.length).toBeLessThanOrEqual(255);
+    expect(marked).toContain('sid=submission-test-id');
+  });
+
+  it('finds the Lead by submission marker, patches OwnerId, and confirms the owner', async () => {
+    vi.mocked(salesForceAPI)
+      .mockResolvedValueOnce(queryResponse([{ Id: '00QMARKER', OwnerId: '005WRONG' }]) as any)
+      .mockResolvedValueOnce({ status: 204 } as any)
+      .mockResolvedValueOnce(
+        queryResponse([{ Id: '00QMARKER', OwnerId: BETH_OWNER_ID, Owner: { Name: 'Beth Soldner' } }]) as any,
+      );
+
+    const result = await routeSalesforceLeadOwner(routeParams());
+
+    expect(decodedQuery(0)).toContain("WebFormURL__c LIKE '%sid=submission-test-id%'");
+    expect(patchCall()).toEqual(
+      expect.objectContaining({
+        endpoint: 'https://sf.example.test/services/data/v62.0/sobjects/Lead/00QMARKER',
+        type: RequestType.PATCH,
+        data: { OwnerId: BETH_OWNER_ID },
+      }),
+    );
+    expect(result).toEqual({
+      leadId: '00QMARKER',
+      ownerId: BETH_OWNER_ID,
+      ownerName: 'Beth Soldner',
+      adminName: 'Beth',
+    });
+    expect(logInfo).toHaveBeenCalledWith(
+      'Salesforce Lead owner routing confirmed',
+      expect.objectContaining({ leadId: '00QMARKER', ownerId: BETH_OWNER_ID }),
+    );
+  });
+
+  it('does not patch when the found Lead already has the routed owner', async () => {
+    vi.mocked(salesForceAPI)
+      .mockResolvedValueOnce(
+        queryResponse([{ Id: '00QALREADY', OwnerId: BETH_OWNER_ID, Owner: { Name: 'Beth Soldner' } }]) as any,
+      )
+      .mockResolvedValueOnce(
+        queryResponse([{ Id: '00QALREADY', OwnerId: BETH_OWNER_ID, Owner: { Name: 'Beth Soldner' } }]) as any,
+      );
+
+    const result = await routeSalesforceLeadOwner(routeParams());
+
+    expect(patchCall()).toBeUndefined();
+    expect(result).toEqual({
+      leadId: '00QALREADY',
+      ownerId: BETH_OWNER_ID,
+      ownerName: 'Beth Soldner',
+      adminName: 'Beth',
+    });
+    expect(logInfo).toHaveBeenCalledWith(
+      'Salesforce Lead owner already matched routing target',
+      expect.objectContaining({ leadId: '00QALREADY', ownerId: BETH_OWNER_ID }),
+    );
+  });
+
+  it('falls back to tight criteria when marker lookup misses', async () => {
+    vi.mocked(salesForceAPI)
+      .mockResolvedValueOnce(queryResponse([]) as any)
+      .mockResolvedValueOnce(queryResponse([{ Id: '00QFALLBACK', OwnerId: '005WRONG' }]) as any)
+      .mockResolvedValueOnce({ status: 204 } as any)
+      .mockResolvedValueOnce(
+        queryResponse([{ Id: '00QFALLBACK', OwnerId: BETH_OWNER_ID, Owner: { Name: 'Beth Soldner' } }]) as any,
+      );
+
+    await routeSalesforceLeadOwner(routeParams());
+
+    const fallbackQuery = decodedQuery(1);
+    expect(fallbackQuery).toContain("Email = 'qa@example.test'");
+    expect(fallbackQuery).toContain("LeadSource = 'Contact Agent'");
+    expect(fallbackQuery).toContain("RecordTypeId = '0124x000000Z5yDAAS'");
+    expect(fallbackQuery).toContain("Destination_State__c = 'CO'");
+    expect(fallbackQuery).toContain('CreatedDate >= 2026-06-17T12:00:00Z');
+    expect(fallbackQuery).toContain("WebFormAgentId__c = '0014x00000HWTqI'");
+  });
+
+  it('does not patch when lookup finds no Lead', async () => {
+    vi.mocked(salesForceAPI)
+      .mockResolvedValueOnce(queryResponse([]) as any)
+      .mockResolvedValueOnce(queryResponse([]) as any);
+
+    await expect(routeSalesforceLeadOwner(routeParams())).rejects.toThrow(
+      'Unable to locate unique Salesforce Lead',
+    );
+
+    expect(patchCall()).toBeUndefined();
+    expect(logError).toHaveBeenCalledWith(
+      'Salesforce Lead owner lookup found no matching Lead',
+      expect.objectContaining({ submissionId: 'submission-test-id' }),
+    );
+  });
+
+  it('does not patch when lookup is ambiguous', async () => {
+    vi.mocked(salesForceAPI).mockResolvedValueOnce(
+      queryResponse([{ Id: '00Q1' }, { Id: '00Q2' }]) as any,
+    );
+
+    await expect(routeSalesforceLeadOwner(routeParams())).rejects.toThrow(
+      'Ambiguous Salesforce Lead lookup',
+    );
+
+    expect(patchCall()).toBeUndefined();
+  });
+
+  it('throws when the OwnerId PATCH fails', async () => {
+    vi.mocked(salesForceAPI)
+      .mockResolvedValueOnce(queryResponse([{ Id: '00QPATCH', OwnerId: '005WRONG' }]) as any)
+      .mockResolvedValueOnce({ status: 403, data: [{ message: 'insufficient access' }] } as any);
+
+    await expect(routeSalesforceLeadOwner(routeParams())).rejects.toThrow(
+      'Salesforce Lead owner PATCH failed',
+    );
+
+    expect(logError).toHaveBeenCalledWith(
+      'Salesforce Lead owner PATCH failed',
+      expect.objectContaining({ leadId: '00QPATCH', ownerId: BETH_OWNER_ID, status: 403 }),
+    );
+  });
+
+  it('throws when owner confirmation does not match the requested owner', async () => {
+    vi.mocked(salesForceAPI)
+      .mockResolvedValueOnce(queryResponse([{ Id: '00QCONFIRM', OwnerId: '005WRONG' }]) as any)
+      .mockResolvedValueOnce({ status: 204 } as any)
+      .mockResolvedValueOnce(
+        queryResponse([{ Id: '00QCONFIRM', OwnerId: '005STILLWRONG', Owner: { Name: 'Stephanie Guree' } }]) as any,
+      );
+
+    await expect(routeSalesforceLeadOwner(routeParams())).rejects.toThrow(
+      'Salesforce Lead OwnerId confirmation mismatch',
+    );
+  });
+});

--- a/services/__tests__/stateRoutingService.test.ts
+++ b/services/__tests__/stateRoutingService.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAdminContactForState,
+  getAdminRoutingForState,
+  getStatesByAdmin,
+} from '@/services/stateRoutingService';
+
+describe('stateRoutingService admin routing', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['colorado', 'BETH', 'Beth'],
+    ['CO', 'BETH', 'Beth'],
+    ['texas', 'TARA', 'Tara'],
+    ['TX', 'TARA', 'Tara'],
+    ['florida', 'JESSICA', 'Jessica'],
+    ['FL', 'JESSICA', 'Jessica'],
+    ['indiana', 'STEPHANIE', 'Stephanie'],
+    ['new-york', 'STEPHANIE', 'Stephanie'],
+    ['puerto-rico', 'STEPHANIE', 'Stephanie'],
+    ['PR', 'STEPHANIE', 'Stephanie'],
+  ])('routes %s to %s', (state, adminKey, adminName) => {
+    expect(getAdminRoutingForState(state)).toEqual(
+      expect.objectContaining({
+        adminKey,
+        name: adminName,
+      }),
+    );
+  });
+
+  it('keeps OpenPhone fallback behavior for unmapped states', () => {
+    expect(getAdminRoutingForState('not-a-state')).toBeNull();
+    expect(getAdminContactForState('not-a-state')).toEqual({
+      name: 'Default',
+      phoneNumber: process.env.OPEN_PHONE_FROM_NUMBER || '719-249-5359',
+    });
+  });
+
+  it('includes Puerto Rico in Stephanie states', () => {
+    expect(getStatesByAdmin('STEPHANIE')).toContain('puerto-rico');
+  });
+});

--- a/services/api.tsx
+++ b/services/api.tsx
@@ -75,7 +75,8 @@ export const api = async ({
 export const salesForceAPI = async ({
     endpoint,
     data,
-    type
+    type,
+    customHeader
 }: ApiParams): Promise<AxiosResponse | undefined> => {
     let res: AxiosResponse | undefined;
 
@@ -90,6 +91,7 @@ export const salesForceAPI = async ({
         headers: {
             "Cache-Control": "no-cache",
             Authorization: `Bearer ${SALESFORCETOKEN}`,
+            ...customHeader,
         },
     };
 

--- a/services/salesForcePostFormsService.tsx
+++ b/services/salesForcePostFormsService.tsx
@@ -6,6 +6,11 @@ import stateService from '@/services/stateService';
 import { logDebug, logError, logInfo } from './loggingService';
 import { FormSubmissionStatus, trackFormSubmission, updateSubmissionStatus } from './formTrackingService';
 import { getAdminPhoneNumberForState } from '@/services/stateRoutingService';
+import { getLeadOwnerForState } from '@/services/salesforceLeadOwnerRouting';
+import {
+    appendLeadOwnerSubmissionMarker,
+    routeSalesforceLeadOwner,
+} from '@/services/salesforceLeadOwnerService';
 import { evaluateLeadSpam, tagSpamSuspected } from '@/lib/spam-protection';
 import { HP_FIELD, TS_FIELD } from '@/lib/validation/spam-fields';
 import { formatStateLabel, normalizeStateCode, normalizeStateSlug } from '@/lib/states';
@@ -260,6 +265,7 @@ export async function contactAgentPostForm(formData: any, queryString: string, o
             throw new Error('Invalid form data: state is required.');
         }
         formData.state = effectiveState.code;
+        const leadOwner = getLeadOwnerForState(effectiveState.slug);
 
         // Soft-quarantine spam-suspected leads: still written to Salesforce, but tagged so the
         // team can filter them and partner SMS is suppressed below. Never drop a real lead.
@@ -292,6 +298,10 @@ export async function contactAgentPostForm(formData: any, queryString: string, o
             }
         }
 
+        const webFormUrl = appendLeadOwnerSubmissionMarker(
+            `${BASE_URL}/contact-agent${queryString}`,
+            submissionId,
+        );
         const formBody = new URLSearchParams({
             oid: "00D4x000003yaV2",
             retURL: `${BASE_URL}/thank-you`,
@@ -300,7 +310,7 @@ export async function contactAgentPostForm(formData: any, queryString: string, o
             lead_source: "Contact Agent",
             "00N4x00000Lsr0G": "true",
             country_code: "US",
-            "00N4x00000QQ1LB": `${BASE_URL}/contact-agent${queryString}`,
+            "00N4x00000QQ1LB": webFormUrl,
             first_name: formData.firstName || "",
             last_name: formData.lastName || "",
             email: formData.email || "",
@@ -332,6 +342,7 @@ export async function contactAgentPostForm(formData: any, queryString: string, o
             formKeys: Object.keys(Object.fromEntries(new URLSearchParams(formBody)))
         });
 
+        const submissionStartedAt = new Date();
         const submissionResult = await submitToSalesforceWebToLead(
             "https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8",
             formBody,
@@ -356,6 +367,28 @@ export async function contactAgentPostForm(formData: any, queryString: string, o
         }
 
         const { response, redirectUrl } = submissionResult;
+
+        try {
+            await routeSalesforceLeadOwner({
+                submissionId,
+                submissionStartedAt,
+                leadSource: 'Contact Agent',
+                destinationStateCode: effectiveState.code,
+                destinationStateSlug: effectiveState.slug,
+                email: formData.email,
+                selectedAgentId: paramsObj.id || null,
+                owner: leadOwner,
+            });
+        } catch (ownerRoutingError) {
+            logError('Salesforce Lead owner routing failed after Web-to-Lead acceptance', {
+                submissionId,
+                leadSource: 'Contact Agent',
+                destinationStateCode: effectiveState.code,
+                destinationStateSlug: effectiveState.slug,
+                adminName: leadOwner.adminName,
+                ownerId: leadOwner.ownerId,
+            }, ownerRoutingError);
+        }
 
         const notificationTasks: Array<{ name: 'Slack' | 'OpenPhone'; promise: Promise<unknown> }> = [
             {
@@ -880,6 +913,7 @@ export async function contactLenderPostForm(formData: any, fullQueryString: stri
             throw new Error('Invalid form data: state is required.');
         }
         formData.state = effectiveState.code;
+        const leadOwner = getLeadOwnerForState(effectiveState.slug);
 
         // Soft-quarantine spam-suspected leads: tagged in Salesforce, partner SMS suppressed below.
         const spam = await evaluateLeadSpam({
@@ -911,6 +945,10 @@ export async function contactLenderPostForm(formData: any, fullQueryString: stri
             }
         }
 
+        const webFormUrl = appendLeadOwnerSubmissionMarker(
+            `${BASE_URL}/contact-lender${fullQueryString}`,
+            submissionId,
+        );
         const formBody = new URLSearchParams({
             oid: "00D4x000003yaV2",
             retURL: `${BASE_URL}/thank-you`,
@@ -919,7 +957,7 @@ export async function contactLenderPostForm(formData: any, fullQueryString: stri
             lead_source: "Contact Lender",
             "00N4x00000Lsr0G": "true",
             country_code: "US",
-            "00N4x00000QQ1LB": `${BASE_URL}/contact-lender${fullQueryString}`,
+            "00N4x00000QQ1LB": webFormUrl,
             first_name: formData.firstName || "",
             last_name: formData.lastName || "",
             email: formData.email || "",
@@ -940,6 +978,7 @@ export async function contactLenderPostForm(formData: any, fullQueryString: stri
             formKeys: Object.keys(Object.fromEntries(new URLSearchParams(formBody)))
         });
 
+        const submissionStartedAt = new Date();
         const submissionResult = await submitToSalesforceWebToLead(
             "https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8",
             formBody,
@@ -964,6 +1003,28 @@ export async function contactLenderPostForm(formData: any, fullQueryString: stri
         }
 
         const { response, redirectUrl } = submissionResult;
+
+        try {
+            await routeSalesforceLeadOwner({
+                submissionId,
+                submissionStartedAt,
+                leadSource: 'Contact Lender',
+                destinationStateCode: effectiveState.code,
+                destinationStateSlug: effectiveState.slug,
+                email: formData.email,
+                selectedLenderId: paramsObj.id || null,
+                owner: leadOwner,
+            });
+        } catch (ownerRoutingError) {
+            logError('Salesforce Lead owner routing failed after Web-to-Lead acceptance', {
+                submissionId,
+                leadSource: 'Contact Lender',
+                destinationStateCode: effectiveState.code,
+                destinationStateSlug: effectiveState.slug,
+                adminName: leadOwner.adminName,
+                ownerId: leadOwner.ownerId,
+            }, ownerRoutingError);
+        }
 
         // Fire and forget notifications - don't await them
         await Promise.all([

--- a/services/salesforceLeadOwnerRouting.ts
+++ b/services/salesforceLeadOwnerRouting.ts
@@ -1,0 +1,53 @@
+import 'server-only';
+
+import { getAdminRoutingForState, type AdminKey } from '@/services/stateRoutingService';
+
+type SalesforceLeadOwnerConfig = {
+    ownerId: string;
+    ownerName: string;
+};
+
+const SALESFORCE_LEAD_OWNERS_BY_ADMIN: Record<AdminKey, SalesforceLeadOwnerConfig> = {
+    BETH: {
+        ownerId: '0054x000005GsUvAAK',
+        ownerName: 'Beth Soldner',
+    },
+    JESSICA: {
+        ownerId: '005Rg000004hWojIAE',
+        ownerName: 'Jessica Brown',
+    },
+    STEPHANIE: {
+        ownerId: '0054x0000082vHgAAI',
+        ownerName: 'Stephanie Guree',
+    },
+    TARA: {
+        ownerId: '005Rg00000BAN0DIAX',
+        ownerName: 'Tara Gould',
+    },
+};
+
+export type SalesforceLeadOwner = {
+    adminKey: AdminKey;
+    adminName: string;
+    ownerId: string;
+    ownerName: string;
+};
+
+export function getLeadOwnerForState(state?: string): SalesforceLeadOwner {
+    const adminRouting = getAdminRoutingForState(state);
+    if (!adminRouting) {
+        throw new Error(`No admin routing found for Salesforce Lead owner state: ${state || '(missing)'}`);
+    }
+
+    const owner = SALESFORCE_LEAD_OWNERS_BY_ADMIN[adminRouting.adminKey];
+    if (!owner?.ownerId) {
+        throw new Error(`No Salesforce Lead OwnerId configured for admin: ${adminRouting.adminKey}`);
+    }
+
+    return {
+        adminKey: adminRouting.adminKey,
+        adminName: adminRouting.name,
+        ownerId: owner.ownerId,
+        ownerName: owner.ownerName,
+    };
+}

--- a/services/salesforceLeadOwnerService.ts
+++ b/services/salesforceLeadOwnerService.ts
@@ -1,0 +1,301 @@
+import 'server-only';
+
+import { SALESFORCE_API_VERSION, SALESFORCE_BASE_URL } from '@/constants/api';
+import { RequestType, salesForceAPI } from '@/services/api';
+import { getSalesforceToken } from '@/services/salesForceTokenService';
+import { getLeadOwnerForState, type SalesforceLeadOwner } from '@/services/salesforceLeadOwnerRouting';
+import { logError, logInfo } from '@/services/loggingService';
+import { escapeSoqlLiteral } from '@/services/soql';
+
+const CUSTOMER_LEAD_RECORD_TYPE_ID = '0124x000000Z5yDAAS';
+const WEB_FORM_URL_MAX_LENGTH = 255;
+const LEAD_LOOKUP_TIMEOUT_MS = process.env.NODE_ENV === 'test' ? 0 : 12_000;
+const LEAD_LOOKUP_INTERVAL_MS = process.env.NODE_ENV === 'test' ? 0 : 750;
+const OWNER_CONFIRM_TIMEOUT_MS = process.env.NODE_ENV === 'test' ? 0 : 10_000;
+const OWNER_CONFIRM_INTERVAL_MS = process.env.NODE_ENV === 'test' ? 0 : 750;
+
+type LeadSource = 'Contact Agent' | 'Contact Lender';
+
+type SalesforceLeadRecord = {
+    Id: string;
+    OwnerId?: string | null;
+    Owner?: {
+        Name?: string | null;
+    } | null;
+};
+
+type RouteSalesforceLeadOwnerParams = {
+    submissionId: string;
+    submissionStartedAt: Date;
+    leadSource: LeadSource;
+    destinationStateCode: string;
+    destinationStateSlug: string;
+    owner?: SalesforceLeadOwner;
+    email?: string | null;
+    selectedAgentId?: string | null;
+    selectedLenderId?: string | null;
+};
+
+export type SalesforceLeadOwnerRouteResult = {
+    leadId: string;
+    ownerId: string;
+    ownerName?: string | null;
+    adminName: string;
+};
+
+export function appendLeadOwnerSubmissionMarker(webFormUrl: string, submissionId: string): string {
+    const markerName = 'sid';
+    const encodedSubmissionId = encodeURIComponent(submissionId);
+
+    try {
+        const url = new URL(webFormUrl);
+        url.searchParams.set(markerName, submissionId);
+
+        const markedUrl = url.toString();
+        if (markedUrl.length <= WEB_FORM_URL_MAX_LENGTH) return markedUrl;
+
+        const compactUrl = `${url.origin}${url.pathname}?${markerName}=${encodedSubmissionId}`;
+        if (compactUrl.length <= WEB_FORM_URL_MAX_LENGTH) return compactUrl;
+
+        return markedUrl.slice(0, WEB_FORM_URL_MAX_LENGTH);
+    } catch {
+        const separator = webFormUrl.includes('?') ? '&' : '?';
+        const markedUrl = `${webFormUrl}${separator}${markerName}=${encodedSubmissionId}`;
+        return markedUrl.length <= WEB_FORM_URL_MAX_LENGTH
+            ? markedUrl
+            : markedUrl.slice(0, WEB_FORM_URL_MAX_LENGTH);
+    }
+}
+
+export async function routeSalesforceLeadOwner(
+    params: RouteSalesforceLeadOwnerParams,
+): Promise<SalesforceLeadOwnerRouteResult> {
+    const owner = params.owner ?? getLeadOwnerForState(params.destinationStateSlug);
+    const lead = await findCreatedLead(params);
+
+    if (lead.OwnerId === owner.ownerId) {
+        logInfo('Salesforce Lead owner already matched routing target', {
+            submissionId: params.submissionId,
+            leadId: lead.Id,
+            destinationStateCode: params.destinationStateCode,
+            destinationStateSlug: params.destinationStateSlug,
+            adminName: owner.adminName,
+            ownerId: owner.ownerId,
+            ownerName: lead.Owner?.Name ?? owner.ownerName,
+        });
+    } else {
+        await patchLeadOwner(lead.Id, owner, params.submissionId);
+    }
+
+    const confirmedLead = await waitForLeadOwnerConfirmation(lead.Id, owner, params.submissionId);
+
+    logInfo('Salesforce Lead owner routing confirmed', {
+        submissionId: params.submissionId,
+        leadId: lead.Id,
+        destinationStateCode: params.destinationStateCode,
+        destinationStateSlug: params.destinationStateSlug,
+        adminName: owner.adminName,
+        ownerId: owner.ownerId,
+        ownerName: confirmedLead.Owner?.Name ?? owner.ownerName,
+    });
+
+    return {
+        leadId: lead.Id,
+        ownerId: owner.ownerId,
+        ownerName: confirmedLead.Owner?.Name ?? owner.ownerName,
+        adminName: owner.adminName,
+    };
+}
+
+async function findCreatedLead(params: RouteSalesforceLeadOwnerParams): Promise<SalesforceLeadRecord> {
+    const deadline = Date.now() + LEAD_LOOKUP_TIMEOUT_MS;
+    let lastNoMatchLookupType = 'submission marker or fallback criteria';
+
+    while (Date.now() <= deadline) {
+        const markerLead = await findLeadBySubmissionMarker(params.submissionId);
+        if (markerLead) return markerLead;
+        lastNoMatchLookupType = 'submission marker';
+
+        const fallbackLead = await findLeadByFallbackCriteria(params);
+        if (fallbackLead) return fallbackLead;
+        lastNoMatchLookupType = 'fallback criteria';
+
+        await delay(LEAD_LOOKUP_INTERVAL_MS);
+    }
+
+    logError('Salesforce Lead owner lookup found no matching Lead', {
+        submissionId: params.submissionId,
+        lookupType: lastNoMatchLookupType,
+        timeoutMs: LEAD_LOOKUP_TIMEOUT_MS,
+    });
+    throw new Error(`Unable to locate unique Salesforce Lead for submission ${params.submissionId}`);
+}
+
+async function findLeadBySubmissionMarker(submissionId: string): Promise<SalesforceLeadRecord | null> {
+    const safeMarker = escapeSoqlLiteral(`sid=${submissionId}`);
+    const soql = `
+        SELECT Id, OwnerId, Owner.Name
+        FROM Lead
+        WHERE WebFormURL__c LIKE '%${safeMarker}%'
+        ORDER BY CreatedDate DESC
+        LIMIT 2
+    `.replace(/\s+/g, ' ').trim();
+
+    return findUniqueLead(soql, 'submission marker', submissionId);
+}
+
+async function findLeadByFallbackCriteria(
+    params: RouteSalesforceLeadOwnerParams,
+): Promise<SalesforceLeadRecord | null> {
+    const safeEmail = params.email?.trim();
+    if (!safeEmail) return null;
+
+    const conditions = [
+        `Email = '${escapeSoqlLiteral(safeEmail)}'`,
+        `LeadSource = '${escapeSoqlLiteral(params.leadSource)}'`,
+        `RecordTypeId = '${CUSTOMER_LEAD_RECORD_TYPE_ID}'`,
+        `Destination_State__c = '${escapeSoqlLiteral(params.destinationStateCode)}'`,
+        `CreatedDate >= ${formatSoqlDateTime(params.submissionStartedAt)}`,
+    ];
+
+    if (params.selectedAgentId) {
+        conditions.push(`WebFormAgentId__c = '${escapeSoqlLiteral(params.selectedAgentId)}'`);
+    }
+
+    if (params.selectedLenderId) {
+        conditions.push(`WebFormLenderId__c = '${escapeSoqlLiteral(params.selectedLenderId)}'`);
+    }
+
+    const soql = `
+        SELECT Id, OwnerId, Owner.Name
+        FROM Lead
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY CreatedDate DESC
+        LIMIT 2
+    `.replace(/\s+/g, ' ').trim();
+
+    return findUniqueLead(soql, 'fallback criteria', params.submissionId);
+}
+
+async function findUniqueLead(
+    soql: string,
+    lookupType: string,
+    submissionId: string,
+): Promise<SalesforceLeadRecord | null> {
+    const records = await runSalesforceQuery<SalesforceLeadRecord>(soql);
+
+    if (records.length === 0) {
+        return null;
+    }
+
+    if (records.length > 1) {
+        throw new Error(`Ambiguous Salesforce Lead lookup for submission ${submissionId} using ${lookupType}`);
+    }
+
+    return records[0];
+}
+
+async function fetchLeadOwner(leadId: string): Promise<SalesforceLeadRecord> {
+    const safeLeadId = escapeSoqlLiteral(leadId);
+    const soql = `
+        SELECT Id, OwnerId, Owner.Name
+        FROM Lead
+        WHERE Id = '${safeLeadId}'
+        LIMIT 1
+    `.replace(/\s+/g, ' ').trim();
+
+    const records = await runSalesforceQuery<SalesforceLeadRecord>(soql);
+    const lead = records[0];
+    if (!lead) throw new Error(`Unable to requery Salesforce Lead owner for ${leadId}`);
+    return lead;
+}
+
+async function waitForLeadOwnerConfirmation(
+    leadId: string,
+    owner: SalesforceLeadOwner,
+    submissionId: string,
+): Promise<SalesforceLeadRecord> {
+    const deadline = Date.now() + OWNER_CONFIRM_TIMEOUT_MS;
+    let lastLead: SalesforceLeadRecord | null = null;
+
+    while (Date.now() <= deadline) {
+        lastLead = await fetchLeadOwner(leadId);
+        if (lastLead.OwnerId === owner.ownerId) return lastLead;
+        await delay(OWNER_CONFIRM_INTERVAL_MS);
+    }
+
+    throw new Error(
+        `Salesforce Lead OwnerId confirmation mismatch for ${leadId}: expected ${owner.ownerId}, received ${lastLead?.OwnerId || '(missing)'}`,
+    );
+}
+
+async function patchLeadOwner(
+    leadId: string,
+    owner: SalesforceLeadOwner,
+    submissionId: string,
+): Promise<void> {
+    const response = await runSalesforceRequestWithRefresh({
+        endpoint: salesforceEndpoint(`/sobjects/Lead/${encodeURIComponent(leadId)}`),
+        type: RequestType.PATCH,
+        data: { OwnerId: owner.ownerId },
+        customHeader: {
+            'Sforce-Auto-Assign': 'FALSE',
+        },
+    });
+
+    if (response?.status !== 204 && response?.status !== 200) {
+        logError('Salesforce Lead owner PATCH failed', {
+            submissionId,
+            leadId,
+            ownerId: owner.ownerId,
+            status: response?.status,
+            responseData: response?.data,
+        });
+        throw new Error(`Salesforce Lead owner PATCH failed with status ${response?.status || 'unknown'}`);
+    }
+}
+
+async function runSalesforceQuery<T>(soql: string): Promise<T[]> {
+    const response = await runSalesforceRequestWithRefresh({
+        endpoint: salesforceEndpoint(`/query?q=${encodeURIComponent(soql)}`),
+        type: RequestType.GET,
+    });
+
+    if (response?.status !== 200) {
+        throw new Error(`Salesforce Lead owner query failed with status ${response?.status || 'unknown'}`);
+    }
+
+    return response.data?.records ?? [];
+}
+
+async function runSalesforceRequestWithRefresh(params: {
+    endpoint: string;
+    type: RequestType;
+    data?: unknown;
+    customHeader?: Record<string, string>;
+}) {
+    let response = await salesForceAPI(params);
+
+    if (response?.status === 401) {
+        await getSalesforceToken();
+        response = await salesForceAPI(params);
+    }
+
+    return response;
+}
+
+function salesforceEndpoint(path: string): string {
+    if (!SALESFORCE_BASE_URL || !SALESFORCE_API_VERSION) {
+        throw new Error('Salesforce base URL or API version is not configured');
+    }
+
+    return `${SALESFORCE_BASE_URL}/services/data/${SALESFORCE_API_VERSION}${path}`;
+}
+
+function formatSoqlDateTime(date: Date): string {
+    return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/services/stateRoutingService.ts
+++ b/services/stateRoutingService.ts
@@ -3,6 +3,8 @@
  * Maps states to appropriate admin phone numbers for contact form notifications
  */
 
+import { normalizeStateSlug } from '@/lib/states';
+
 export interface AdminContact {
     name: string;
     phoneNumber: string;
@@ -28,8 +30,14 @@ export const ADMIN_CONTACTS = {
     }
 } as const;
 
+export type AdminKey = keyof typeof ADMIN_CONTACTS;
+
+export interface AdminRouting extends AdminContact {
+    adminKey: AdminKey;
+}
+
 // State-to-admin mapping based on provided chart
-const STATE_TO_ADMIN_MAP: Record<string, keyof typeof ADMIN_CONTACTS> = {
+const STATE_TO_ADMIN_MAP: Record<string, AdminKey> = {
     // Beth's states
     'alaska': 'BETH',
     'arizona': 'BETH',
@@ -73,6 +81,7 @@ const STATE_TO_ADMIN_MAP: Record<string, keyof typeof ADMIN_CONTACTS> = {
     'new-york': 'STEPHANIE',
     'ohio': 'STEPHANIE',
     'pennsylvania': 'STEPHANIE',
+    'puerto-rico': 'STEPHANIE',
     'rhode-island': 'STEPHANIE',
     'vermont': 'STEPHANIE',
     'virginia': 'STEPHANIE',
@@ -90,6 +99,21 @@ const STATE_TO_ADMIN_MAP: Record<string, keyof typeof ADMIN_CONTACTS> = {
     'texas': 'TARA',
 };
 
+export function getAdminRoutingForState(state?: string): AdminRouting | null {
+    const normalizedState = normalizeStateSlug(state) ?? state?.toLowerCase().trim();
+    if (!normalizedState) return null;
+
+    const adminKey = STATE_TO_ADMIN_MAP[normalizedState];
+    if (!adminKey) return null;
+
+    const adminContact = ADMIN_CONTACTS[adminKey];
+    return {
+        adminKey,
+        name: adminContact.name,
+        phoneNumber: adminContact.phoneNumber,
+    };
+}
+
 /**
  * Get the appropriate admin phone number for a given state
  * @param state - State in lowercase with hyphens (e.g., "new-hampshire")
@@ -105,13 +129,8 @@ export function getAdminContactForState(state?: string): AdminContact {
         };
     }
 
-    // Normalize state string
-    const normalizedState = state.toLowerCase().trim();
-
-    // Get admin for this state
-    const adminKey = STATE_TO_ADMIN_MAP[normalizedState];
-
-    if (!adminKey) {
+    const adminRouting = getAdminRoutingForState(state);
+    if (!adminRouting) {
         console.warn(`No admin mapping found for state: ${state}, using fallback number`);
         return {
             name: 'Default',
@@ -119,10 +138,12 @@ export function getAdminContactForState(state?: string): AdminContact {
         };
     }
 
-    const adminContact = ADMIN_CONTACTS[adminKey];
-    console.log(`OpenPhone routing: ${state} -> ${adminContact.name} (${adminContact.phoneNumber})`);
+    console.log(`OpenPhone routing: ${state} -> ${adminRouting.name} (${adminRouting.phoneNumber})`);
 
-    return adminContact;
+    return {
+        name: adminRouting.name,
+        phoneNumber: adminRouting.phoneNumber,
+    };
 }
 
 /**
@@ -139,8 +160,8 @@ export function getAdminPhoneNumberForState(state?: string): string {
  * @param adminKey - Admin identifier
  * @returns Array of state names
  */
-export function getStatesByAdmin(adminKey: keyof typeof ADMIN_CONTACTS): string[] {
+export function getStatesByAdmin(adminKey: AdminKey): string[] {
     return Object.entries(STATE_TO_ADMIN_MAP)
         .filter(([, admin]) => admin === adminKey)
         .map(([state]) => state);
-} 
+}


### PR DESCRIPTION
Summary:
- Add server-only Salesforce Lead Owner routing IDs keyed to state admin routing.
- Mark contact-agent/contact-lender Web-to-Lead submissions, find the created Lead, verify OwnerId, and PATCH only when wrong.
- Add polling and Vitest coverage for routing, lookup, patching, confirmation, and form handoff.

Validation:
- npm test
- npm run type-check
- npm run lint
- npm run build
- pre-commit lint/type-check/build

Live QA:
- Colorado contact-agent submission for Jason Anderson routed to Beth Soldner.
- No lender submission tested.