### PR TITLE
[codex] Improve homepage conversion UX

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,7 +1,6 @@
 import StateMap from "@/components/homepage/StateMap";
 import HeroSection from "@/components/homepage/HeroSection/HeroSection";
 import FeaturedLogos from "@/components/homepage/FeaturedLogos/FeaturedLogos";
-import Testimonials from "@/components/Testimonials/TestimonialPage";
 import VideoFamily from "@/components/homepage/VideoFamily";
 import Covered from "@/components/homepage/Covered/Covered";
 import FamilySupport from "@/components/homepage/FamilySupport/FamilySupport";
@@ -26,25 +25,24 @@ export default function Home() {
         page="home"
       />
       <StateMap
-        title="Buying or Selling?"
-        subTitle="Choose a state below to connect with our veteran and military spouse agents and lenders"
-        buttonText="Don't want to browse? Find an Agent For Me"
+        title="Where are you moving?"
+        subTitle="Choose your destination state to see military-friendly agents and VA loan experts, or let us match you directly."
+        buttonText="Match Me With An Agent"
         buttonLink="/contact-agent"
       />
       <FeaturedLogos />
-      <VideoFamily />
-      <Testimonials />
       <MovingBonusCalculator />
-      <Covered />
+      <VeteranPCS />
+      <ReviewsList />
+      <VideoFamily />
+      <VeteranCommunity component_slug="support-our-veteran-community" />
+      <WhyVeteranPcs />
       <FamilySupport
         link="https://www.veteranpcs.com/impact"
         component_slug="support-our-veteran-community"
       />
-      <VeteranPCS />
-      <ReviewsList />
       <MakeItHome />
-      <VeteranCommunity component_slug="support-our-veteran-community" />
-      <WhyVeteranPcs />
+      <Covered />
       <AgentLoanExpert />
       <SkillFuturesBuild />
       <KeepInTouch />

--- a/app/globals.css
+++ b/app/globals.css
@@ -83,8 +83,18 @@ select option:not([value=""]) {
 }
 
 .nav li:hover>.sub-menu,
+.nav li:focus-within>.sub-menu,
 .nav .sub-menu:hover {
   @apply opacity-100 visible transition-visibility duration-300;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid theme('colors.accent.red.DEFAULT');
+  outline-offset: 3px;
 }
 
 .menu .menu-nav ul ul {

--- a/components/About/aboutherosection/AboutHeroSection.module.css
+++ b/components/About/aboutherosection/AboutHeroSection.module.css
@@ -2,12 +2,11 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  padding: 115px 30px;
-  margin-top: 80px;
+  padding: 195px 30px 115px;
+  margin-top: 0;
 }
 @media screen and (max-width: 575px) {
   .AboutHeroSectionContainer {
-    padding: 40px 30px 115px 30px;
-    margin-top: 40px;
+    padding: 80px 30px 115px 30px;
   }
 }

--- a/components/AgentFinderPopup/AgentFinderPopup.css
+++ b/components/AgentFinderPopup/AgentFinderPopup.css
@@ -45,8 +45,8 @@
   font-size: 24px;
   cursor: pointer;
   color: #666;
-  width: 30px;
-  height: 30px;
+  width: 44px;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -57,6 +57,11 @@
 .agent-finder-popup__close:hover {
   background-color: #f0f0f0;
   color: #333;
+}
+
+.agent-finder-popup__close:focus-visible {
+  outline: 2px solid #a81f23;
+  outline-offset: 2px;
 }
 
 .agent-finder-popup__content {
@@ -117,9 +122,10 @@
 }
 
 .agent-finder-popup__select:focus {
-  outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  outline: 2px solid #a81f23;
+  outline-offset: 2px;
+  border-color: #a81f23;
+  box-shadow: none;
 }
 
 .agent-finder-popup__select:disabled {
@@ -129,7 +135,7 @@
 }
 
 .agent-finder-popup__submit {
-  background-color: #dc2626;
+  background-color: #a81f23;
   color: white;
   border: none;
   padding: 14px 24px;
@@ -142,9 +148,14 @@
 }
 
 .agent-finder-popup__submit:hover:not(:disabled) {
-  background-color: #b91c1c;
+  background-color: #7e1618;
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(220, 38, 38, 0.3);
+}
+
+.agent-finder-popup__submit:focus-visible {
+  outline: 2px solid #a81f23;
+  outline-offset: 3px;
 }
 
 .agent-finder-popup__submit:disabled {

--- a/components/AgentFinderPopup/AgentFinderPopupWrapper.tsx
+++ b/components/AgentFinderPopup/AgentFinderPopupWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import AgentFinderPopup from './AgentFinderPopup';
 import { useScrollTrigger } from './useScrollTrigger';
 
@@ -11,44 +11,14 @@ const AgentFinderPopupWrapper: React.FC = () => {
         cooldownDuration: 60000 // 1 minute cooldown
     });
 
-    // Add manual trigger for testing
-    const [manualShow, setManualShow] = useState(false);
-
-    const handleManualTrigger = () => {
-        console.log('Manual popup trigger');
-        setManualShow(true);
-    };
-
     const handleClose = () => {
-        setManualShow(false);
         closePopup();
     };
 
-    // For development - add a button to manually trigger popup
-    const isDev = process.env.NODE_ENV === 'development';
-
     return (
         <>
-            {isDev && (
-                <button
-                    onClick={handleManualTrigger}
-                    style={{
-                        position: 'fixed',
-                        top: '10px',
-                        right: '10px',
-                        zIndex: 10000,
-                        padding: '10px',
-                        backgroundColor: '#ff0000',
-                        color: 'white',
-                        border: 'none',
-                        borderRadius: '5px'
-                    }}
-                >
-                    Test Popup
-                </button>
-            )}
             <AgentFinderPopup
-                isVisible={showPopup || manualShow}
+                isVisible={showPopup}
                 onClose={handleClose}
             />
         </>

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import classes from "./Footer.module.css";
 import Image from "next/image";
 import Link from "next/link";
-import { date } from "yup";
 
 const Locations = () => {
   const locations = [
@@ -69,17 +68,34 @@ const Locations = () => {
     <div className={classes.FooterLocationsContainer}>
       <div className={classes.FooterContainer}>
         <div className="container mx-auto">
-          <div className="flex justify-center items-center mb-10 roboto font-bold">
+          <details className="mx-5 mb-8 rounded-xl border border-white/30 px-4 py-3 text-white md:hidden">
+            <summary className="cursor-pointer text-center roboto text-2xl font-bold">
+              Locations
+            </summary>
+            <div className="mt-5 grid grid-cols-1 gap-2">
+              {locations.map((location, index) => (
+                <div key={index} className={classes.LocationItem}>
+                  <Link
+                    href={`/${formattedLocation(location)}`}
+                    className="flex min-h-11 items-center justify-center text-center roboto text-base font-medium text-white"
+                  >
+                    {location}
+                  </Link>
+                </div>
+              ))}
+            </div>
+          </details>
+          <div className="mb-10 hidden justify-center items-center roboto font-bold md:flex">
             <div className="text-white text-center roboto text-3xl font-bold">
               LOCATIONS
             </div>
           </div>
-          <div className={classes.LocationsGrid}>
+          <div className="hidden grid-cols-1 gap-2 md:grid md:grid-cols-3 lg:grid-cols-4">
             {locations.map((location, index) => (
               <div key={index} className={classes.LocationItem}>
                 <Link
                   href={`/${formattedLocation(location)}`}
-                  className="text-white text-center roboto text-base font-medium"
+                  className="flex min-h-11 items-center justify-center text-white text-center roboto text-base font-medium"
                 >
                   {location}
                 </Link>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,6 +6,10 @@ import Link from "next/link";
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [cashBackAmount, setCashBackAmount] = useState("$500,000");
+  const navItemClass =
+    "relative max-w-fit pr-3 py-1 text-sm after:absolute after:bottom-0 after:left-0 after:h-1 after:w-0 after:bg-accent-red after:transition-all after:duration-300 hover:after:w-full focus-within:after:w-full md:pr-0 xl:text-base";
+  const navLinkClass =
+    "text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white";
 
   useEffect(() => {
     const fetchMetrics = async () => {
@@ -30,51 +34,61 @@ const Header = () => {
   };
 
   return (
-    <header className="bg-[#292f6c] fixed top-0 left-0 w-full z-50 shadow-lg lg:px-0 px-5">
+    <header className="fixed left-0 top-0 z-50 w-full bg-primary px-5 shadow-lg lg:px-0">
       <div className="container mx-auto w-full">
-        <nav className="flex justify-between">
+        <nav className="flex min-h-[64px] justify-between lg:min-h-[80px]" aria-label="Primary navigation">
           <Link className="w-[130px] md:w-[200px] flex items-center" href="/">
             <Image
               width={235}
               height={63}
               src="/icon/VeteranPCSlogo.svg"
-              className="lg:w-[235px] lg:h-[63px] md:w-[235px] md:h-[63px] sm:w-[200px] sm:h-[63px] w-[200px] h-[63px]"
+              className="h-auto w-[200px] md:w-[235px]"
               alt="VeteranPCS logo"
               onClick={isMenuOpen ? onMenuToggle : undefined}
             />
           </Link>
           <div className="flex items-center lg:gap-8 xl:gap-10">
             <div
-              className={`navLinks duration-500 absolute md:static md:w-auto ${isMenuOpen ? "w-[60%]" : "w-full"} w-full md:h-auto ${isMenuOpen ? "h-[100vh]" : "h-[100vh]"}  bg-[#292f6c] flex md:items-center gap-[1.5vw] top-[100%] ${isMenuOpen ? "left-[0%]" : "left-[-100%]"} px-5 md:py-0 py-5`}
+              id="primary-navigation"
+              className={`navLinks absolute top-full bg-primary px-5 py-5 md:static md:flex md:h-auto md:w-auto md:items-center md:bg-transparent md:px-0 md:py-0 ${isMenuOpen ? "left-0 flex h-[calc(100vh-64px)] w-[min(86vw,340px)]" : "hidden"} gap-[1.5vw]`}
             >
               <ul className="menu nav flex md:flex-row flex-col md:items-center xl:gap-12 gap-6">
-                <li className="relative xl:text-base text-sm max-w-fit pr-3 md:pr-0 py-1 after:bg-gradient-to-r from-[#A81F23] to-[#A81F23] after:absolute after:h-1 after:w-0 after:bottom-0 after:left-0 hover:after:w-full after:transition-all after:duration-300">
-                  <Link className="text-white" href="/about" onClick={onMenuToggle}>
+                <li className="md:hidden">
+                  <Link
+                    className="inline-flex min-h-11 rounded-2xl bg-accent-red px-5 py-3 text-white transition-colors hover:bg-accent-red-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
+                    href="/contact-agent"
+                    onClick={onMenuToggle}
+                  >
+                    Find An Agent
+                  </Link>
+                </li>
+                <li className={navItemClass}>
+                  <Link className={navLinkClass} href="/about" onClick={onMenuToggle}>
                     About
                   </Link>
                 </li>
-                <li className="relative xl:text-base text-sm max-w-fit pr-3 md:pr-0 py-1 after:bg-gradient-to-r from-[#A81F23] to-[#A81F23] after:absolute after:h-1 after:w-0 after:bottom-0 after:left-0 hover:after:w-full after:transition-all after:duration-300">
-                  <Link className="text-white" href="/how-it-works" onClick={onMenuToggle}>
+                <li className={navItemClass}>
+                  <Link className={navLinkClass} href="/how-it-works" onClick={onMenuToggle}>
                     How It Works
                   </Link>
                 </li>
-                <li className="relative xl:text-base text-sm max-w-fit pr-3 md:pr-0 py-1 after:bg-gradient-to-r from-[#A81F23] to-[#A81F23] after:absolute after:h-1 after:w-0 after:bottom-0 after:left-0 hover:after:w-full after:transition-all after:duration-300">
-                  <Link className="text-white" href="/impact" onClick={onMenuToggle}>
+                <li className={navItemClass}>
+                  <Link className={navLinkClass} href="/impact" onClick={onMenuToggle}>
                     Impact
                   </Link>
                 </li>
-                <li className="relative xl:text-base text-sm max-w-fit pr-3 md:pr-0 py-1 after:bg-gradient-to-r from-[#A81F23] to-[#A81F23] after:absolute after:h-1 after:w-0 after:bottom-0 after:left-0 hover:after:w-full after:transition-all after:duration-300">
-                  <Link className="text-white" href="/blog" onClick={onMenuToggle}>
+                <li className={navItemClass}>
+                  <Link className={navLinkClass} href="/blog" onClick={onMenuToggle}>
                     Blog
                   </Link>
                 </li>
-                <li className="relative xl:text-base text-sm max-w-fit pr-3 md:pr-0 py-1 after:bg-gradient-to-r from-[#A81F23] to-[#A81F23] after:absolute after:h-1 after:w-0 after:bottom-0 after:left-0 hover:after:w-full after:transition-all after:duration-300">
-                  <Link className="text-white" href="/pcs-resources" onClick={onMenuToggle}>
+                <li className={navItemClass}>
+                  <Link className={navLinkClass} href="/pcs-resources" onClick={onMenuToggle}>
                     PCS Resources
                   </Link>
                 </li>
-                <li className="relative xl:text-base text-sm max-w-fit pr-3 md:pr-0 py-1 after:bg-gradient-to-r from-[#A81F23] to-[#A81F23] after:absolute after:h-1 after:w-0 after:bottom-0 after:left-0 hover:after:w-full after:transition-all after:duration-300">
-                  <Link className="text-white" href="/contact" onClick={onMenuToggle}>
+                <li className={navItemClass}>
+                  <Link className={navLinkClass} href="/contact" onClick={onMenuToggle}>
                     Contact
                   </Link>
                   <ul className="sub-menu">
@@ -102,22 +116,32 @@ const Header = () => {
               </ul>
             </div>
             <div className="flex items-center gap-2">
-              <div className="text-sm bg-[#7e1618] px-5 lg:block md:hidden sm:hidden hidden">
-                <div className="text-center py-[28px]">
-                  <p className="text-white text-[33px]">
-                    <strong className="text-[33px] text-white font-bold">
-                      {cashBackAmount}<strong></strong>
+              <Link
+                href="/contact-agent"
+                className="hidden min-h-11 items-center rounded-2xl bg-accent-red px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-accent-red-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white lg:inline-flex"
+              >
+                Find An Agent
+              </Link>
+              <div className="hidden bg-accent-red-dark px-4 text-sm xl:block">
+                <div className="text-center py-4">
+                  <p className="text-white text-xl">
+                    <strong className="text-xl text-white font-bold">
+                      {cashBackAmount}
                     </strong>
                   </p>
-                  <p className="py-4 text-white mb-0 pb-0 text-xs">
+                  <p className="pt-1 text-white mb-0 pb-0 text-xs">
                     Given Back to Military Families
                   </p>
                 </div>
               </div>
               <button
+                type="button"
                 name={isMenuOpen ? "close" : "menu"}
                 onClick={onMenuToggle}
-                className="text-[30px] cursor-pointer md:hidden"
+                className="relative min-h-11 min-w-11 cursor-pointer text-[30px] md:hidden"
+                aria-label={isMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+                aria-expanded={isMenuOpen}
+                aria-controls="primary-navigation"
               >
                 <span className="absolute top-1/2 left-1/2 size-12 -translate-x-1/2 -translate-y-1/2 [@media(pointer:fine):hidden]"></span>
                 <svg

--- a/components/HowItWork/HowItWorkHeroSection/HowItWorkHeroSection.module.css
+++ b/components/HowItWork/HowItWorkHeroSection/HowItWorkHeroSection.module.css
@@ -3,12 +3,12 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  padding: 115px 30px;
-  margin-top: 100px;
+  padding: 215px 30px 115px;
+  margin-top: 0;
 }
 
 @media screen and (max-width: 844px) {
   .HowitworkHeroSectionContainer {
-    margin-top: 0;
+    padding: 115px 30px;
   }
 }

--- a/components/MilitarySpouse/MilitarySpouseHerosection/MilitarySpouseHeroSection.module.css
+++ b/components/MilitarySpouse/MilitarySpouseHerosection/MilitarySpouseHeroSection.module.css
@@ -3,13 +3,13 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  padding: 115px 30px;
-  margin-top: 100px;
+  padding: 215px 30px 115px;
+  margin-top: 0;
 }
 
 @media screen and (max-width: 1024px) {
   .MilitrarySpouseContainer {
-    margin-top: 0;
+    padding: 115px 30px;
     margin-bottom: 120px;
   }
 }

--- a/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx
+++ b/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx
@@ -122,8 +122,9 @@ const MovingBonusCalculator = () => {
                             <div className="flex-shrink-0">
                                 <Image
                                     src={imgHouse}
-                                    alt="House Icon"
-                                    className="h-16 lg:w-20 w-auto"
+                                    alt=""
+                                    className="w-16 lg:w-20"
+                                    style={{ height: "auto" }}
                                     width={80}
                                     height={80}
                                 />
@@ -137,7 +138,7 @@ const MovingBonusCalculator = () => {
                                         Estimated <span className="font-normal">Veteran</span>PCS Bonus
                                     </h2>
                                     <p className="text-[#231f20] text-sm tahoma">
-                                        Adjust the slider to see your estimated VeteranPCSBonus! Are you a Veteran? See if you qualify today!
+	                                        Adjust the slider to estimate your VeteranPCS bonus. We can confirm your options when we match you with an agent.
                                     </p>
                                 </div>
 
@@ -149,7 +150,8 @@ const MovingBonusCalculator = () => {
                                             min={sliderMinValue}
                                             max={sliderMaxValue}
                                             value={Math.min(Math.max(homeValue, sliderMinValue), sliderMaxValue)}
-                                            onChange={handleSliderChange}
+	                                            onChange={handleSliderChange}
+	                                            aria-label="Estimated home price"
                                             className={`w-full h-3 rounded-md appearance-none cursor-pointer outline-none ${styles.sliderThumb}`}
                                             style={{
                                                 background: `linear-gradient(to right, #A81F23 0%, #A81F23 ${sliderPercentage}%, #8B8B8B ${sliderPercentage}%, #8B8B8B 100%)`
@@ -184,11 +186,11 @@ const MovingBonusCalculator = () => {
                                         </p>
                                     </div>
 
-                                    {/* Connect Button */}
+                                    {/* CTA Button */}
                                     <div className="text-center md:text-center">
                                         <Link href="/contact-agent" onClick={handleConnectClick}>
                                             <Button
-                                                buttonText="Connect Now"
+                                                buttonText="Find An Agent"
                                                 divClassName="py-0"
                                             />
                                         </Link>
@@ -212,4 +214,4 @@ const MovingBonusCalculator = () => {
     );
 };
 
-export default MovingBonusCalculator; 
+export default MovingBonusCalculator;

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -20,12 +20,11 @@ const Button: React.FC<ButtonProps> = ({
   divClassName = "",
   buttonClassName = "",
 }) => {
-  const className = `${buttonClassName} items-center bg-[#A81F23] w-auto inline-flex xl:px-8 lg:px-8 sm:px-5 px-5 xl:py-4 lg:py-4 sm:py-3.5 py-3.5 rounded-2xl text-center duration-500 transition-all hover:bg-[#871B1C] active:bg-[#871B1C]`;
+  const className = `${buttonClassName} inline-flex min-h-11 max-w-full items-center justify-center rounded-2xl bg-accent-red px-5 py-3.5 text-center transition-colors duration-200 hover:bg-accent-red-dark active:bg-accent-red-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:px-5 lg:px-8 lg:py-4 xl:px-8 xl:py-4`;
 
   const label = (
     <span
-      className="xl:text-lg lg:text-lg md:text-lg text-sm font-normal leading-6 bg-cover 
-            text-white text-nowrap tahoma"
+      className="bg-cover text-sm font-normal leading-6 text-white tahoma md:text-lg"
     >
       {buttonText}
     </span>
@@ -37,6 +36,10 @@ const Button: React.FC<ButtonProps> = ({
         <a href={href} target={target} rel={rel} onClick={onClick} className={className}>
           {label}
         </a>
+      ) : !onClick ? (
+        <span className={className}>
+          {label}
+        </span>
       ) : (
         <button onClick={onClick} className={className}>
           {label}

--- a/components/common/Slider.tsx
+++ b/components/common/Slider.tsx
@@ -11,7 +11,7 @@ const Carousel = ({ logoList }: { logoList: any }) => {
     dots: false,
     infinite: true,
     speed: 500,
-    slidesToShow: 5,
+    slidesToShow: 4,
     slidesToScroll: 1,
     autoplay: true,
     autoplaySpeed: 3000,
@@ -40,16 +40,20 @@ const Carousel = ({ logoList }: { logoList: any }) => {
   };
 
   return (
-    <div className="container mx-auto comlogoslider">
-      <h3 className="text-center text-2xl sm:text-4xl font-bold text-[#292F6C] pt-6 sm:pt-10">
+    <section
+      id="features-partners"
+      aria-labelledby="features-partners-title"
+      className="container mx-auto comlogoslider scroll-mt-24 px-4"
+    >
+      <h3 id="features-partners-title" className="pt-6 text-center text-2xl font-bold text-primary sm:pt-10 sm:text-4xl">
         Features & Partners
       </h3>
       <Box className="w-full">
-        <Slider {...settings} className="md:py-8 py-3">
+        <Slider {...settings} className="py-5 md:py-10">
           {logoList.map((item: any, index: number) => (
             <a
               key={"logo-slider" + (item._id || index)}
-              className="w-[230px] px-9"
+              className="mx-auto flex h-16 w-full max-w-[220px] items-center justify-center px-3 sm:h-20 sm:max-w-[260px] md:h-28 md:max-w-[340px] md:px-4 xl:h-32 xl:max-w-[420px]"
               href={item.url}
             >
               <Image
@@ -57,13 +61,13 @@ const Carousel = ({ logoList }: { logoList: any }) => {
                 width={1000}
                 src={item?.mainImage?.asset?.image_url || item.imageUrl}
                 alt={item?.mainImage?.alt || item.title}
-                className="w-full h-full opacity-40 hover:opacity-100 transition-all duration-300 ease-in-out object-contain"
+                className="h-full w-full object-contain opacity-80 transition-opacity duration-200 ease-in-out hover:opacity-100"
               />
             </a>
           ))}
         </Slider>
       </Box>
-    </div>
+    </section>
   );
 };
 

--- a/components/contactpage/ContactHeroSection/ContactHeroSection.module.css
+++ b/components/contactpage/ContactHeroSection/ContactHeroSection.module.css
@@ -3,11 +3,11 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  padding: 115px 30px;
-  margin-top: 100px;
+  padding: 215px 30px 115px;
+  margin-top: 0;
 }
 @media screen and (max-width: 1024px)  {
   .HeroSectionContainer {
-     margin-top: 0;
+    padding: 115px 30px;
   } 
 }

--- a/components/homepage/AgentLoanExpert/AgentLoanExpert.tsx
+++ b/components/homepage/AgentLoanExpert/AgentLoanExpert.tsx
@@ -1,5 +1,4 @@
 import "@/app/globals.css";
-import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import classes from "./AgentLoanExpert.module.css";
 import Link from "next/link";

--- a/components/homepage/Covered/Covered.tsx
+++ b/components/homepage/Covered/Covered.tsx
@@ -54,6 +54,7 @@ const Covered = () => {
   useEffect(() => {
     AOS.init({
       once: true,      // Make animation run once
+      disable: () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
     });
   }, []);
 

--- a/components/homepage/FamilySupport/FamilySupport.tsx
+++ b/components/homepage/FamilySupport/FamilySupport.tsx
@@ -56,13 +56,13 @@ const FamilySupport = async ({ link, component_slug }: { link: string, component
                 height={150}
                 className={component_slug === "freedom-service-dogs" ? "w-auto h-auto min-w-64" : "hidden md:block w-auto h-auto lg:min-w-32 min-w-32"}
                 src={pageData?.icon?.asset?.image_url || "/icon/userplus.svg"}
-                alt={pageData?.icon?.alt || "Description of the image"}
+                alt={pageData?.icon?.alt || ""}
               />
             </div>
             <div>
-              <h1 className="text-white poppins lg:text-[31px] md:text-[31px] sm:text-[29px] text-[29px] font-bold mt-5 lg:text-left md:text-left sm:text-center text-center lg:w-[400px]">
+              <h2 className="text-white poppins lg:text-[31px] md:text-[31px] sm:text-[29px] text-[29px] font-bold mt-5 lg:text-left md:text-left sm:text-center text-center lg:w-[400px]">
                 {pageData?.title}
-              </h1>
+              </h2>
               <div className="text-white roboto lg:text-[18px] md:text-[19px] sm:text-[16px] text-[16px] italic font-medium leading-[25px] mt-4 lg:text-left md:text-left sm:text-center text-center">
                 {pageData?.description?.map((block, index) => (
                   <SupportContent
@@ -88,7 +88,7 @@ const FamilySupport = async ({ link, component_slug }: { link: string, component
                     height={100}
                     className="md:mt-1 mt-0.5 w-6 h-6"
                     src="/icon/checkred.svg"
-                    alt="Description of the image"
+                    alt=""
                   />
                   <h6 className="text-white roboto lg:text-[18px] md:text-[19px] sm:text-[16px] text-[16px] font-medium leading-[41px]">
                     <SupportContent

--- a/components/homepage/FamilySupport/SupportContent.tsx
+++ b/components/homepage/FamilySupport/SupportContent.tsx
@@ -47,7 +47,7 @@ const SupportContent: React.FC<BlockContentProps> = ({ block }) => {
 
   switch (block.style) {
     case "h1":
-      return <h1 className="text-4xl font-bold mb-2">{renderContent(block)}</h1>;
+      return <h3 className="text-3xl font-bold mb-2">{renderContent(block)}</h3>;
     case "h2":
       return <h2 className="text-2xl font-bold my-4">{renderContent(block)}</h2>;
     case "h3":

--- a/components/homepage/HeroSection/HeroSection.module.css
+++ b/components/homepage/HeroSection/HeroSection.module.css
@@ -4,42 +4,39 @@
   background-position: center;
   background-repeat: no-repeat;
   background-color: #aeb0c7;
-  padding: 50px 30px;
+  padding: 128px 30px 64px;
   z-index: 10;
   position: relative;
   width: 100%;
-  margin-top: 105px;
+  margin-top: 0;
 }
 
 @media screen and (max-width: 767px) {
   .herosectioncontainer {
-    margin-top: 50px;
-    height: 1000px;
-    background-position: right;
+    padding: 92px 20px 56px;
+    background-position: center top;
   }
 }
 @media screen and (max-width: 575px) {
   .herosectioncontainer {
-    margin-top: 50px;
-    height: 850px;
-    background-position: left;
-    background-size: auto;
+    background-position: center top;
+    background-size: cover;
   }
 }
 @media screen and (min-width: 768px) {
   .herosectioncontainer {
-    margin-top: 50px;
+    padding-top: 112px;
   }
 }
 
 @media screen and (min-width: 1024px) {
   .herosectioncontainer {
-    margin-top: 80px;
+    padding-top: 128px;
   }
 }
 
 @media screen and (min-width: 1290px) {
   .herosectioncontainer {
-    margin-top: 105px;
+    padding-top: 153px;
   }
 }

--- a/components/homepage/HeroSection/HeroSection.tsx
+++ b/components/homepage/HeroSection/HeroSection.tsx
@@ -14,16 +14,24 @@ const HeroSection = ({ title, subTitle, page }: HeroSectionProps) => {
 
   return (
     <div>
-      <div className={classes.herosectioncontainer}>
+      <section className={classes.herosectioncontainer} aria-labelledby="home-hero-title">
         <div className="container mx-auto">
-          <div className="grid lg:grid-cols-2 md:grid-cols-1 sm:grid-cols-1 grid-cols-1 items-start justify-between gap-4">
-            <div className="mx-auto lg:text-left md:text-left sm:text-center text-center w-full sm:order-2 order-2 lg:order-none md:order-none lg:mt-12">
-              <h2 className="text-white font-bold lg:text-[59px] md:text-[29px] sm:text-[32px] text-[32px] leading-[1.3] tahoma sm:px-0 md:px-0 sm:mt-24 mt-24 md:mt-10">
+          <div className="grid grid-cols-1 items-center justify-between gap-6 lg:grid-cols-2 lg:gap-10">
+            <div className="order-1 mx-auto w-full max-w-[680px] text-center lg:mt-8 lg:max-w-none lg:text-left">
+              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.18em] text-white/90 tahoma">
+                Free military-friendly agent matching
+              </p>
+              <h1 id="home-hero-title" className="text-[2.25rem] font-bold leading-[1.12] text-white tahoma sm:text-[2.75rem] md:text-[3.25rem] lg:text-[3.7rem]">
                 {title}
-              </h2>
-              <h1 className="lg:text-[18px] md:text-[18px] sm:text-[16px] text-[16px] font-normal text-white lg:my-10 md:my-5 sm:my-10 my-10 tahoma">
-                {subTitle}
               </h1>
+              <p className="mx-auto my-5 max-w-[38rem] text-base font-normal leading-7 text-white tahoma md:text-lg lg:mx-0 lg:my-7">
+                {subTitle}
+              </p>
+              {page == "home" && (
+                <p className="mx-auto max-w-[36rem] text-base leading-7 text-white/95 tahoma lg:mx-0">
+                  Tell us where you are moving. We will help match you with a vetted agent who understands military moves.
+                </p>
+              )}
               {page == "spanish" && (
                 <div className="hidden md:flex flex-col gap-4 text-white text-lg">
                   <ul className="list-disc list-outside">
@@ -37,13 +45,13 @@ const HeroSection = ({ title, subTitle, page }: HeroSectionProps) => {
                 </div>
               )}
               {page == "home" && (
-                <div className="flex justify-between xl:justify-start lg:justify-start md:justify-start sm:justify-between gap-4 lg:my-10 md:my-5 sm:my-10 my-10 mx-auto text-center ">
+                <div className="mx-auto my-6 flex max-w-[360px] flex-wrap justify-center gap-4 text-center lg:mx-0 lg:my-8 lg:max-w-none lg:justify-start">
                   <div className="flex items-center gap-4">
                     <Image
                       width={6}
                       height={6}
                       src="/icon/checkred.svg"
-                      alt="check"
+                      alt=""
                       className="w-6 h-6"
                       loading="eager"
                     />
@@ -56,7 +64,7 @@ const HeroSection = ({ title, subTitle, page }: HeroSectionProps) => {
                       width={6}
                       height={6}
                       src="/icon/checkred.svg"
-                      alt="check"
+                      alt=""
                       className="w-6 h-6"
                       loading="eager"
                     />
@@ -67,9 +75,15 @@ const HeroSection = ({ title, subTitle, page }: HeroSectionProps) => {
                 </div>
               )}
               {page == "home" && (
-                <div className="lg:mb-28 md:mt-4 sm:mt-10 mt-10">
-                  <Link href="#state-map">
+                <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center lg:mb-12 lg:justify-start">
+                  <Link href="/contact-agent">
                     <Button buttonText="Find An Agent" />
+                  </Link>
+                  <Link
+                    href="#state-map"
+                    className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-white/70 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white md:text-base"
+                  >
+                    Browse by State
                   </Link>
                 </div>
               )}
@@ -87,31 +101,33 @@ const HeroSection = ({ title, subTitle, page }: HeroSectionProps) => {
                 </div>
               )}
             </div>
-            <div className="mx-auto w-full md:mb-20 lg:mb-0 sm:order-1 order-1 lg:order-none md:order-none">
+            <div className="order-2 mx-auto w-full md:mb-12 lg:mb-0">
               <div className="flex justify-center">
-                <div className="relative">
+                <div className="relative w-full max-w-[873px]">
                   <Image
                     width={873}
                     height={482}
                     src="/assets/house-hero-2024.png"
-                    className="w-[873px] sm:h-[482px] h-[300px] object-contain"
+                    className="h-auto w-full object-contain"
                     alt="A home sold by VeteranPCS"
                     loading="eager"
+                    priority
                   />
                   <Image
                     width={533}
                     height={533}
                     src="/assets/veteranPCS-slider-checks-03.png"
-                    className="absolute top-3/4 left-1/2 transform -translate-x-1/2 -translate-y-1/2 xl:w-[533px] xl:h-[533px] lg:w-[533px] lg:h-auto md:w-[465px] md:h-auto sm:w-[450px] sm:h-auto w-[400px] h-auto object-cover"
+                    className="absolute left-1/2 top-3/4 h-auto w-[min(92vw,533px)] -translate-x-1/2 -translate-y-1/2 object-contain md:w-[465px] lg:w-[533px]"
                     alt="A military couple stands in front of their newly purchased home after using a military-friendly realtor from VeteranPCS"
                     loading="eager"
+                    priority
                   />
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </section>
     </div>
   );
 };

--- a/components/homepage/KeepInTouch/KeepInTouch.module.css
+++ b/components/homepage/KeepInTouch/KeepInTouch.module.css
@@ -9,9 +9,10 @@
   font-size: 1rem;
 
   &:focus {
-    outline: none;
-    border-color: #6b46c1;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.5);
+    outline: 2px solid #a81f23;
+    outline-offset: 2px;
+    border-color: #a81f23;
+    box-shadow: none;
   }
 }
 @media screen and (max-width: 575px) {

--- a/components/homepage/KeepInTouch/KeepInTouch.tsx
+++ b/components/homepage/KeepInTouch/KeepInTouch.tsx
@@ -135,40 +135,52 @@ const KeepInTouch = () => {
           <div className="mt-5 lg:mt-0 md:mt-0 sm:mt-5">
             <div className={classes.CustomResponsiveCenter}>
               <form onSubmit={handleSubmit(handleFormSubmission)}>
-                <h2 className="lg:text-[36px] sm:text-[25px] text-[25px] poppins font-bold text-[#292F6C] lg:text-left md:text-left sm:text-center text-center">
+                <h2 className="lg:text-[36px] sm:text-[25px] text-[25px] poppins font-bold text-primary lg:text-left md:text-left sm:text-center text-center">
                   Keep In Touch
                 </h2>
-                <p className="text-[#292F6C] font-bold lg:text-[21px] sm:text-[15px] text-[15px] roboto mb-6 lg:text-left md:text-left sm:text-center text-center">
+                <p className="text-primary font-bold lg:text-[21px] sm:text-[15px] text-[15px] roboto mb-6 lg:text-left md:text-left sm:text-center text-center">
                   No spam mail, no fees. VeteranPCS is free to use.
                 </p>
                 <div className="flex flex-col mb-5">
+                  <label htmlFor="keep-first-name" className="mb-2 text-left text-sm font-semibold text-primary roboto">
+                    First name <span aria-hidden="true">*</span>
+                  </label>
                   <input
+                    id="keep-first-name"
                     className={classes.KeepInTouchInput}
                     type="text"
                     {...register('firstName')}
-                    placeholder="First Name*"
+                    autoComplete="given-name"
                   />
                   {renderError('firstName')}
                 </div>
                 <div className="flex flex-col mb-5">
+                  <label htmlFor="keep-last-name" className="mb-2 text-left text-sm font-semibold text-primary roboto">
+                    Last name <span aria-hidden="true">*</span>
+                  </label>
                   <input
+                    id="keep-last-name"
                     className={classes.KeepInTouchInput}
                     type="text"
-                    placeholder="Last Name*"
                     {...register('lastName')}
+                    autoComplete="family-name"
                   />
                   {renderError('lastName')}
                 </div>
                 <div className="flex flex-col mb-5">
+                  <label htmlFor="keep-email" className="mb-2 text-left text-sm font-semibold text-primary roboto">
+                    Email <span aria-hidden="true">*</span>
+                  </label>
                   <input
+                    id="keep-email"
                     className={classes.KeepInTouchInput}
                     type="email"
-                    placeholder="Email*"
                     {...register('email')}
+                    autoComplete="email"
                   />
                   {renderError('email')}
                 </div>
-                <p className="text-[#292F6C] roboto lg:text-[14px] max-w-[390px] sm:max-w-full mx-auto sm:text-[9px] text-[9px] font-medium mb-3 text-left md:pl-0 sm:pl-3 pl-3">
+                <p className="text-primary roboto text-xs lg:text-sm max-w-[390px] sm:max-w-full mx-auto font-medium mb-3 text-left md:pl-0 sm:pl-3 pl-3">
                   Fields marked with an asterisk (*) are required.
                 </p>
                 <HoneypotField ref={honeypotRef} />
@@ -178,7 +190,7 @@ const KeepInTouch = () => {
                       <button
                         type="submit"
                         disabled={isSubmitting}
-                        className={`items-center ${isSubmitting ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#A81F23]'} w-auto inline-flex xl:px-[30px] lg:px-[30px] sm:px-[20px] px-[20px] xl:py-[15px] lg:py-[15px] sm:py-[14px] py-[14px] rounded-[16px] text-center tracking-[1px] hover:tracking-[5px] duration-500 transition-all hover:bg-[#871B1C]`}
+	                        className={`inline-flex min-h-11 items-center rounded-2xl px-5 py-3.5 text-center transition-colors duration-200 sm:px-5 lg:px-[30px] lg:py-[15px] xl:px-[30px] xl:py-[15px] ${isSubmitting ? 'cursor-not-allowed bg-gray-400' : 'bg-accent-red hover:bg-accent-red-dark'}`}
                       >
                         <span
                           className="xl:text-[18px] lg:text-[18px] md:text-[18px] sm:text-[14px] text-[14px] font-normal leading-6 bg-cover 

--- a/components/homepage/MakeItHome.tsx
+++ b/components/homepage/MakeItHome.tsx
@@ -19,9 +19,9 @@ const MilitaryHomePage = () => {
             />
           </div>
           <div className="w-full md:w-1/2 mt-10 md:mt-0">
-            <h1 className="lg:text-left md:text-left sm:text-center text-center text-3xl font-bold text-navy-500 mb-4 text-[#292F6C] poppins leading-[31px]">
+            <h2 className="lg:text-left md:text-left sm:text-center text-center text-3xl font-bold text-navy-500 mb-4 text-[#292F6C] poppins leading-[31px]">
               Together we&apos;ll make it home
-            </h1>
+            </h2>
             <p className="lg:text-left md:text-left sm:text-center text-center text-xl font-medium text-[#292F6C] italic mb-6 leading-[24px] roboto">
               Your service is your down payment
             </p>
@@ -29,13 +29,13 @@ const MilitaryHomePage = () => {
               <div className="flex items-baseline">
                 <span className="w-2 h-2 min-w-2 min-h-2 rounded-full bg-[#a81f23] inline-block mr-2"></span>
                 <li className="list-none text-[17px] md:font-medium sm:font-normal font-normal roboto">
-                  Many companies prey on our military community Many companies prey on our military community
+                  Some companies do not understand military moves, VA loans, or PCS timing.
                 </li>
               </div>
               <div className="flex items-baseline">
                 <span className="w-2 h-2 min-w-2 min-h-2 rounded-full bg-[#a81f23] inline-block mr-2"></span>
                 <li className="list-none text-[17px] md:font-medium sm:font-normal font-normal roboto">
-                  We&apos;ve hand selected veteran and military spouse VA loan
+                  We&apos;ve hand-selected veteran and military spouse VA loan
                   experts to help guide you whether you&apos;re a first-time home
                   buyer or experienced.
                 </li>

--- a/components/homepage/ReviewTestimonial/ReviewTestimonialSlider.tsx
+++ b/components/homepage/ReviewTestimonial/ReviewTestimonialSlider.tsx
@@ -90,7 +90,7 @@ const ReviewCard: React.FC<{ review: Review }> = ({ review }) => {
         {shouldShowReadMore && (
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="mt-2 text-[#A81F23] hover:text-[#8a1a1d] font-medium focus:outline-none transition-colors duration-200"
+            className="mt-2 text-[#A81F23] hover:text-[#8a1a1d] font-medium transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A81F23]"
           >
             {isExpanded ? 'Show less' : 'Read more'}
           </button>
@@ -132,7 +132,7 @@ const ReviewsSlider: React.FC<ReviewsSliderProps> = ({ reviews, averageRating, t
     return (
       <button
         onClick={onClick}
-        className="absolute -right-4 md:-right-8 lg:-right-10 top-1/2 -translate-y-1/2 w-10 h-10 flex items-center justify-center bg-[#A81F23] hover:bg-opacity-90 rounded-full transition-all duration-200 focus:outline-none z-10 shadow-lg"
+        className="absolute -right-4 md:-right-8 lg:-right-10 top-1/2 -translate-y-1/2 w-11 h-11 flex items-center justify-center bg-[#A81F23] hover:bg-opacity-90 rounded-full transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white z-10 shadow-lg"
         aria-label="Next slide"
       >
         <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -147,7 +147,7 @@ const ReviewsSlider: React.FC<ReviewsSliderProps> = ({ reviews, averageRating, t
     return (
       <button
         onClick={onClick}
-        className="absolute -left-4 md:-left-8 lg:-left-10 top-1/2 -translate-y-1/2 w-10 h-10 flex items-center justify-center bg-[#A81F23] hover:bg-opacity-90 rounded-full transition-all duration-200 focus:outline-none z-10 shadow-lg"
+        className="absolute -left-4 md:-left-8 lg:-left-10 top-1/2 -translate-y-1/2 w-11 h-11 flex items-center justify-center bg-[#A81F23] hover:bg-opacity-90 rounded-full transition-all duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white z-10 shadow-lg"
         aria-label="Previous slide"
       >
         <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/components/homepage/SkillsFuturesBuild/SkillsFuturesBuild.tsx
+++ b/components/homepage/SkillsFuturesBuild/SkillsFuturesBuild.tsx
@@ -10,9 +10,9 @@ const SkillFuturesBuild = () => {
         <div className="container mx-auto">
           <div className="absolute top-[50%] left-[50%] transform -translate-x-1/2 -translate-y-1/2 w-full">
             <div className="text-center">
-              <h1 className="text-white lg:text-[48px] text-[30px] font-bold poppins px-10 sm:px-0 mb-5">
+              <h2 className="text-white lg:text-[48px] text-[30px] font-bold poppins px-10 sm:px-0 mb-5">
                 Skills to share. Futures to build
-              </h1>
+              </h2>
               <p className="font-medium text-[18px] leading-[30px] text-white roboto lg:w-full w-[300px] mx-auto">
                 Interested in Starting a Career as a Real Estate Agent or
                 Mortgage Loan Officer?

--- a/components/homepage/StateMap.tsx
+++ b/components/homepage/StateMap.tsx
@@ -1,9 +1,18 @@
 "use client";
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import Button from "@/components/common/Button";
 import { sendGTMEvent } from "@next/third-parties/google";
-import StateMapSvg from "@/components/homepage/StateMapSvg";
+
+const StateMapSvg = dynamic(() => import("@/components/homepage/StateMapSvg"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex min-h-[420px] items-center justify-center text-primary tahoma">
+      Loading state map...
+    </div>
+  ),
+});
 
 interface TooltipState {
   display: boolean;
@@ -19,6 +28,17 @@ const StateMap = ({ title, subTitle, buttonText, buttonLink }: { title: string, 
     x: 0,
     y: 0,
   });
+  const [showDesktopMap, setShowDesktopMap] = useState(false);
+
+  useEffect(() => {
+    const desktopQuery = window.matchMedia("(min-width: 768px)");
+    const updateMapVisibility = () => setShowDesktopMap(desktopQuery.matches);
+
+    updateMapVisibility();
+    desktopQuery.addEventListener("change", updateMapVisibility);
+
+    return () => desktopQuery.removeEventListener("change", updateMapVisibility);
+  }, []);
 
   // NOTE: these handlers are wrapped in useCallback with empty deps so they keep
   // a stable identity across renders. The tooltip-position state above changes on
@@ -60,61 +80,59 @@ const StateMap = ({ title, subTitle, buttonText, buttonLink }: { title: string, 
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
-  const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
-
   const states = [
-    { name: 'Alabama', link: `${BASE_URL}/alabama` },
-    { name: 'Alaska', link: `${BASE_URL}/alaska` },
-    { name: 'Arizona', link: `${BASE_URL}/arizona` },
-    { name: 'Arkansas', link: `${BASE_URL}/arkansas` },
-    { name: 'California', link: `${BASE_URL}/california` },
-    { name: 'Colorado', link: `${BASE_URL}/colorado` },
-    { name: 'Connecticut', link: `${BASE_URL}/connecticut` },
-    { name: 'Delaware', link: `${BASE_URL}/delaware` },
-    { name: 'Florida', link: `${BASE_URL}/florida` },
-    { name: 'Georgia', link: `${BASE_URL}/georgia` },
-    { name: 'Hawaii', link: `${BASE_URL}/hawaii` },
-    { name: 'Idaho', link: `${BASE_URL}/idaho` },
-    { name: 'Illinois', link: `${BASE_URL}/illinois` },
-    { name: 'Indiana', link: `${BASE_URL}/indiana` },
-    { name: 'Iowa', link: `${BASE_URL}/iowa` },
-    { name: 'Kansas', link: `${BASE_URL}/kansas` },
-    { name: 'Kentucky', link: `${BASE_URL}/kentucky` },
-    { name: 'Louisiana', link: `${BASE_URL}/louisiana` },
-    { name: 'Maine', link: `${BASE_URL}/maine` },
-    { name: 'Maryland', link: `${BASE_URL}/maryland` },
-    { name: 'Massachusetts', link: `${BASE_URL}/massachusetts` },
-    { name: 'Michigan', link: `${BASE_URL}/michigan` },
-    { name: 'Minnesota', link: `${BASE_URL}/minnesota` },
-    { name: 'Mississippi', link: `${BASE_URL}/mississippi` },
-    { name: 'Missouri', link: `${BASE_URL}/missouri` },
-    { name: 'Montana', link: `${BASE_URL}/montana` },
-    { name: 'Nebraska', link: `${BASE_URL}/nebraska` },
-    { name: 'Nevada', link: `${BASE_URL}/nevada` },
-    { name: 'New Hampshire', link: `${BASE_URL}/new-hampshire` },
-    { name: 'New Jersey', link: `${BASE_URL}/new-jersey` },
-    { name: 'New Mexico', link: `${BASE_URL}/new-mexico` },
-    { name: 'New York', link: `${BASE_URL}/new-york` },
-    { name: 'North Carolina', link: `${BASE_URL}/north-carolina` },
-    { name: 'North Dakota', link: `${BASE_URL}/north-dakota` },
-    { name: 'Ohio', link: `${BASE_URL}/ohio` },
-    { name: 'Oklahoma', link: `${BASE_URL}/oklahoma` },
-    { name: 'Oregon', link: `${BASE_URL}/oregon` },
-    { name: 'Pennsylvania', link: `${BASE_URL}/pennsylvania` },
-    { name: 'Puerto Rico', link: `${BASE_URL}/puerto-rico` },
-    { name: 'Rhode Island', link: `${BASE_URL}/rhode-island` },
-    { name: 'South Carolina', link: `${BASE_URL}/south-carolina` },
-    { name: 'South Dakota', link: `${BASE_URL}/south-dakota` },
-    { name: 'Tennessee', link: `${BASE_URL}/tennessee` },
-    { name: 'Texas', link: `${BASE_URL}/texas` },
-    { name: 'Utah', link: `${BASE_URL}/utah` },
-    { name: 'Vermont', link: `${BASE_URL}/vermont` },
-    { name: 'Virginia', link: `${BASE_URL}/virginia` },
-    { name: 'Washington', link: `${BASE_URL}/washington` },
-    { name: 'Washington DC', link: `${BASE_URL}/washington-dc` },
-    { name: 'West Virginia', link: `${BASE_URL}/west-virginia` },
-    { name: 'Wisconsin', link: `${BASE_URL}/wisconsin` },
-    { name: 'Wyoming', link: `${BASE_URL}/wyoming` }
+    { name: 'Alabama', link: `/alabama` },
+    { name: 'Alaska', link: `/alaska` },
+    { name: 'Arizona', link: `/arizona` },
+    { name: 'Arkansas', link: `/arkansas` },
+    { name: 'California', link: `/california` },
+    { name: 'Colorado', link: `/colorado` },
+    { name: 'Connecticut', link: `/connecticut` },
+    { name: 'Delaware', link: `/delaware` },
+    { name: 'Florida', link: `/florida` },
+    { name: 'Georgia', link: `/georgia` },
+    { name: 'Hawaii', link: `/hawaii` },
+    { name: 'Idaho', link: `/idaho` },
+    { name: 'Illinois', link: `/illinois` },
+    { name: 'Indiana', link: `/indiana` },
+    { name: 'Iowa', link: `/iowa` },
+    { name: 'Kansas', link: `/kansas` },
+    { name: 'Kentucky', link: `/kentucky` },
+    { name: 'Louisiana', link: `/louisiana` },
+    { name: 'Maine', link: `/maine` },
+    { name: 'Maryland', link: `/maryland` },
+    { name: 'Massachusetts', link: `/massachusetts` },
+    { name: 'Michigan', link: `/michigan` },
+    { name: 'Minnesota', link: `/minnesota` },
+    { name: 'Mississippi', link: `/mississippi` },
+    { name: 'Missouri', link: `/missouri` },
+    { name: 'Montana', link: `/montana` },
+    { name: 'Nebraska', link: `/nebraska` },
+    { name: 'Nevada', link: `/nevada` },
+    { name: 'New Hampshire', link: `/new-hampshire` },
+    { name: 'New Jersey', link: `/new-jersey` },
+    { name: 'New Mexico', link: `/new-mexico` },
+    { name: 'New York', link: `/new-york` },
+    { name: 'North Carolina', link: `/north-carolina` },
+    { name: 'North Dakota', link: `/north-dakota` },
+    { name: 'Ohio', link: `/ohio` },
+    { name: 'Oklahoma', link: `/oklahoma` },
+    { name: 'Oregon', link: `/oregon` },
+    { name: 'Pennsylvania', link: `/pennsylvania` },
+    { name: 'Puerto Rico', link: `/puerto-rico` },
+    { name: 'Rhode Island', link: `/rhode-island` },
+    { name: 'South Carolina', link: `/south-carolina` },
+    { name: 'South Dakota', link: `/south-dakota` },
+    { name: 'Tennessee', link: `/tennessee` },
+    { name: 'Texas', link: `/texas` },
+    { name: 'Utah', link: `/utah` },
+    { name: 'Vermont', link: `/vermont` },
+    { name: 'Virginia', link: `/virginia` },
+    { name: 'Washington', link: `/washington` },
+    { name: 'Washington DC', link: `/washington-dc` },
+    { name: 'West Virginia', link: `/west-virginia` },
+    { name: 'Wisconsin', link: `/wisconsin` },
+    { name: 'Wyoming', link: `/wyoming` }
   ];
 
   const filteredStates = states.filter((state) =>
@@ -127,52 +145,55 @@ const StateMap = ({ title, subTitle, buttonText, buttonLink }: { title: string, 
 
   return (
     <>
-      <div className="z-0 w-full" id="state-map">
-        <div className="bg-[#aeb0c7] lg:px-16 py-10 w-full">
+      <section className="z-0 w-full scroll-mt-24" id="state-map" aria-labelledby="state-map-title">
+        <div className="w-full bg-primary-light px-4 py-10 lg:px-16">
           <div>
             <div className="text-center pb-5 w-full relative">
-              <h2 className="text-[#292f6c] text-center text-shadow-lg tahoma font-bold leading-10 lg:text-[59px] md:text-[40px] sm:text-[32px] text-[32px]">
+              <h2 id="state-map-title" className="text-center text-[2rem] font-bold leading-tight text-primary tahoma sm:text-[2.4rem] md:text-[2.75rem] lg:text-[3.4rem]">
                 {title}
               </h2>
-              <p className="lg:text-[18px] md:text-[18px] sm:text-[16px] text-[16px] text-[#292f6c] text-center text-shadow-lg font-normal lg:my-10 md:my-5 sm:my-5 my-5 tahoma px-2 sm:px-28 lg:px-36 max-w-screen-md mx-auto">
+              <p className="mx-auto my-5 max-w-[46rem] px-2 text-center text-base font-normal leading-7 text-primary tahoma md:my-6 md:text-lg">
                 {subTitle}
               </p>
             </div>
-            <StateMapSvg
-              onMouseEnter={handleMouseEnter}
-              onMouseMove={handleMouseMove}
-              onMouseLeave={handleMouseLeave}
-              onGtmEvent={handleSendGtmEvent}
-            />
-            <div className="dropdown md:hidden block">
-              <div className="flex mb-2 bg-white w-[337px] mx-auto rounded-xl py-3">
-                <button onClick={toggleDropdown} className="dropbtn ml-6 flex justify-between items-center w-[85%]">
-                  Select State    <svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <div className="dropdown mx-auto block w-full max-w-[360px] md:hidden">
+              <div className="mb-2 flex w-full rounded-xl bg-white py-3 shadow-sm">
+                <button
+                  type="button"
+                  onClick={toggleDropdown}
+                  className="dropbtn mx-5 flex min-h-11 w-full items-center justify-between text-left font-medium text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  aria-expanded={isOpen}
+                  aria-controls="mobile-state-list"
+                >
+                  Choose your destination state
+                  <svg aria-hidden="true" width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path id="Vector" d="M1.42857 -3.74668e-07L5 3.57143L8.57143 -6.24447e-08L10 0.714286L5 5.71429L-3.12225e-08 0.714285L1.42857 -3.74668e-07Z" fill="#252B42" />
                   </svg>
-
                 </button>
               </div>
               {isOpen && (
-                <div id="myDropdown" className="dropdown-content">
-                  <div className="w-[337px] mx-auto">
+                <div id="mobile-state-list" className="dropdown-content">
+                  <div className="mx-auto w-full">
+                    <label htmlFor="stateSearch" className="sr-only">
+                      Search destination states
+                    </label>
                     <input
                       type="text"
                       id="stateSearch"
-                      className="search-input h-[48px] w-full rounded-xl pl-3"
-                      placeholder="Search..."
+                      className="search-input h-12 w-full rounded-xl px-3 text-base text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                      placeholder="Search by state"
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
                     />
                   </div>
-                  <div className="bg-white mt-2 w-[337px] mx-auto h-[250px] overflow-auto rounded-lg">
+                  <div className="mx-auto mt-2 h-[250px] w-full overflow-auto rounded-lg bg-white">
                     {filteredStates.length === 0 ? (
                       <div className="flex items-center justify-center h-full">
-                        <span className="text-gray-500">No data found</span>
+                        <span className="text-gray-500">No states found</span>
                       </div>
                     ) : (
                       filteredStates.map((state) => (
-                        <a key={state.name} href={state.link} className="py-2 flex justify-center border border-solid">
+                        <a key={state.name} href={state.link} className="flex min-h-11 items-center justify-center border border-solid px-3 py-2 text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-primary">
                           {state.name}
                         </a>
                       ))
@@ -181,12 +202,25 @@ const StateMap = ({ title, subTitle, buttonText, buttonLink }: { title: string, 
                 </div>
               )}
             </div>
-            <Link href={buttonLink} className="md:py-8 py-2 flex justify-center" onClick={handleSendGtmEvent}>
+            <div className="hidden md:block" aria-describedby="state-map-help">
+              <p id="state-map-help" className="sr-only">
+                Select a state on the map to view VeteranPCS agents and lenders for that destination.
+              </p>
+              {showDesktopMap && (
+                <StateMapSvg
+                  onMouseEnter={handleMouseEnter}
+                  onMouseMove={handleMouseMove}
+                  onMouseLeave={handleMouseLeave}
+                  onGtmEvent={handleSendGtmEvent}
+                />
+              )}
+            </div>
+            <Link href={buttonLink} className="flex justify-center py-4 md:py-8" onClick={handleSendGtmEvent}>
               <Button buttonText={buttonText} />
             </Link>
           </div>
         </div>
-      </div>
+      </section>
       {tooltip.display && (
         <div
           className="tooltip"

--- a/components/homepage/StateMapSvg.tsx
+++ b/components/homepage/StateMapSvg.tsx
@@ -32,7 +32,7 @@ function StateMapSvgInner({
               viewBox="0 0 1766 1067"
               className="w-full h-full mx-auto"
             >
-              <Link href="/washington" onClick={onGtmEvent}>
+              <Link href="/washington" aria-label="View VeteranPCS agents in Washington" onClick={onGtmEvent}>
                 <g
                   id="Washington"
                   className="state"
@@ -61,7 +61,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/oregon" onClick={onGtmEvent}>
+              <Link href="/oregon" aria-label="View VeteranPCS agents in Oregon" onClick={onGtmEvent}>
                 <g
                   id="Oregon"
                   className="state"
@@ -90,7 +90,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/california" onClick={onGtmEvent}>
+              <Link href="/california" aria-label="View VeteranPCS agents in California" onClick={onGtmEvent}>
                 <g
                   id="California"
                   className="state"
@@ -119,7 +119,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/nevada" onClick={onGtmEvent}>
+              <Link href="/nevada" aria-label="View VeteranPCS agents in Nevada" onClick={onGtmEvent}>
                 <g
                   id="Nevada"
                   className="state"
@@ -147,7 +147,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/idaho" onClick={onGtmEvent}>
+              <Link href="/idaho" aria-label="View VeteranPCS agents in Idaho" onClick={onGtmEvent}>
                 <g
                   id="Idaho"
                   className="state"
@@ -175,7 +175,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/utah" onClick={onGtmEvent}>
+              <Link href="/utah" aria-label="View VeteranPCS agents in Utah" onClick={onGtmEvent}>
                 <g
                   id="Utah"
                   className="state"
@@ -205,7 +205,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/arizona" onClick={onGtmEvent}>
+              <Link href="/arizona" aria-label="View VeteranPCS agents in Arizona" onClick={onGtmEvent}>
                 <g
                   id="Arizona"
                   className="state"
@@ -233,7 +233,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/new-mexico" onClick={onGtmEvent}>
+              <Link href="/new-mexico" aria-label="View VeteranPCS agents in New Mexico" onClick={onGtmEvent}>
                 <g
                   id="New Mexico"
                   className="state"
@@ -261,7 +261,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/colorado" onClick={onGtmEvent}>
+              <Link href="/colorado" aria-label="View VeteranPCS agents in Colorado" onClick={onGtmEvent}>
                 <g
                   id="Colorado"
                   className="state"
@@ -289,7 +289,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/wyoming" onClick={onGtmEvent}>
+              <Link href="/wyoming" aria-label="View VeteranPCS agents in Wyoming" onClick={onGtmEvent}>
                 <g
                   id="Wyoming"
                   className="state"
@@ -317,7 +317,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/montana" onClick={onGtmEvent}>
+              <Link href="/montana" aria-label="View VeteranPCS agents in Montana" onClick={onGtmEvent}>
                 <g
                   id="Montana"
                   className="state"
@@ -345,7 +345,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/north-dakota" onClick={onGtmEvent}>
+              <Link href="/north-dakota" aria-label="View VeteranPCS agents in North Dakota" onClick={onGtmEvent}>
                 <g
                   id="North Dakota"
                   className="state"
@@ -373,7 +373,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/south-dakota" onClick={onGtmEvent}>
+              <Link href="/south-dakota" aria-label="View VeteranPCS agents in South Dakota" onClick={onGtmEvent}>
                 <g
                   id="South Dakota"
                   className="state"
@@ -401,7 +401,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/nebraska" onClick={onGtmEvent}>
+              <Link href="/nebraska" aria-label="View VeteranPCS agents in Nebraska" onClick={onGtmEvent}>
                 <g
                   id="Nebraska"
                   className="state"
@@ -429,7 +429,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/kansas" onClick={onGtmEvent}>
+              <Link href="/kansas" aria-label="View VeteranPCS agents in Kansas" onClick={onGtmEvent}>
                 <g
                   id="Kansas"
                   className="state"
@@ -457,7 +457,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/oklahoma" onClick={onGtmEvent}>
+              <Link href="/oklahoma" aria-label="View VeteranPCS agents in Oklahoma" onClick={onGtmEvent}>
                 <g
                   id="Oklahoma"
                   className="state"
@@ -485,7 +485,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/wisconsin" onClick={onGtmEvent}>
+              <Link href="/wisconsin" aria-label="View VeteranPCS agents in Wisconsin" onClick={onGtmEvent}>
                 <g
                   id="Wisconsin"
                   className="state"
@@ -514,7 +514,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/minnesota" onClick={onGtmEvent}>
+              <Link href="/minnesota" aria-label="View VeteranPCS agents in Minnesota" onClick={onGtmEvent}>
                 <g
                   id="Minnesota"
                   className="state"
@@ -542,7 +542,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/michigan" onClick={onGtmEvent}>
+              <Link href="/michigan" aria-label="View VeteranPCS agents in Michigan" onClick={onGtmEvent}>
                 <g
                   id="Michigan"
                   className="state"
@@ -571,7 +571,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/iowa" onClick={onGtmEvent}>
+              <Link href="/iowa" aria-label="View VeteranPCS agents in Iowa" onClick={onGtmEvent}>
                 <g
                   id="Iowa"
                   className="state"
@@ -599,7 +599,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/missouri" onClick={onGtmEvent}>
+              <Link href="/missouri" aria-label="View VeteranPCS agents in Missouri" onClick={onGtmEvent}>
                 <g
                   id="Missouri"
                   className="state"
@@ -627,7 +627,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/illinois" onClick={onGtmEvent}>
+              <Link href="/illinois" aria-label="View VeteranPCS agents in Illinois" onClick={onGtmEvent}>
                 <g
                   id="Illinois"
                   className="state"
@@ -655,7 +655,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/indiana" onClick={onGtmEvent}>
+              <Link href="/indiana" aria-label="View VeteranPCS agents in Indiana" onClick={onGtmEvent}>
                 <g
                   id="Indiana"
                   className="state"
@@ -683,7 +683,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/ohio" onClick={onGtmEvent}>
+              <Link href="/ohio" aria-label="View VeteranPCS agents in Ohio" onClick={onGtmEvent}>
                 <g
                   id="Ohio"
                   className="state"
@@ -711,7 +711,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/maine" onClick={onGtmEvent}>
+              <Link href="/maine" aria-label="View VeteranPCS agents in Maine" onClick={onGtmEvent}>
                 <g
                   id="Maine"
                   className="state"
@@ -740,7 +740,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/new-york" onClick={onGtmEvent}>
+              <Link href="/new-york" aria-label="View VeteranPCS agents in New York" onClick={onGtmEvent}>
                 <g
                   id="New York"
                   className="state"
@@ -769,7 +769,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/pennsylvania" onClick={onGtmEvent}>
+              <Link href="/pennsylvania" aria-label="View VeteranPCS agents in Pennsylvania" onClick={onGtmEvent}>
                 <g
                   id="Pennsylvania"
                   className="state"
@@ -797,7 +797,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/kentucky" onClick={onGtmEvent}>
+              <Link href="/kentucky" aria-label="View VeteranPCS agents in Kentucky" onClick={onGtmEvent}>
                 <g
                   id="Kentucky"
                   className="state"
@@ -826,7 +826,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/tennessee" onClick={onGtmEvent}>
+              <Link href="/tennessee" aria-label="View VeteranPCS agents in Tennessee" onClick={onGtmEvent}>
                 <g
                   id="Tennessee"
                   className="state"
@@ -854,7 +854,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/arkansas" onClick={onGtmEvent}>
+              <Link href="/arkansas" aria-label="View VeteranPCS agents in Arkansas" onClick={onGtmEvent}>
                 <g
                   id="Arkansas"
                   className="state"
@@ -882,7 +882,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/louisiana" onClick={onGtmEvent}>
+              <Link href="/louisiana" aria-label="View VeteranPCS agents in Louisiana" onClick={onGtmEvent}>
                 <g
                   id="Louisiana"
                   className="state"
@@ -911,7 +911,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/mississippi" onClick={onGtmEvent}>
+              <Link href="/mississippi" aria-label="View VeteranPCS agents in Mississippi" onClick={onGtmEvent}>
                 <g
                   id="Mississippi"
                   className="state"
@@ -940,7 +940,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/alabama" onClick={onGtmEvent}>
+              <Link href="/alabama" aria-label="View VeteranPCS agents in Alabama" onClick={onGtmEvent}>
                 <g
                   id="Alabama"
                   className="state"
@@ -969,7 +969,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/georgia" onClick={onGtmEvent}>
+              <Link href="/georgia" aria-label="View VeteranPCS agents in Georgia" onClick={onGtmEvent}>
                 <g
                   id="Georgia"
                   className="state"
@@ -998,7 +998,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/west-virginia" onClick={onGtmEvent}>
+              <Link href="/west-virginia" aria-label="View VeteranPCS agents in West Virginia" onClick={onGtmEvent}>
                 <g
                   id="West Virginia"
                   className="state"
@@ -1026,7 +1026,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/virginia" onClick={onGtmEvent}>
+              <Link href="/virginia" aria-label="View VeteranPCS agents in Virginia" onClick={onGtmEvent}>
                 <g
                   id="Virginia"
                   className="state"
@@ -1055,7 +1055,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/north-carolina" onClick={onGtmEvent}>
+              <Link href="/north-carolina" aria-label="View VeteranPCS agents in North Carolina" onClick={onGtmEvent}>
                 <g
                   id="North Carolina"
                   className="state"
@@ -1084,7 +1084,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/south-carolina" onClick={onGtmEvent}>
+              <Link href="/south-carolina" aria-label="View VeteranPCS agents in South Carolina" onClick={onGtmEvent}>
                 <g
                   id="South Carolina"
                   className="state"
@@ -1113,7 +1113,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/florida" onClick={onGtmEvent}>
+              <Link href="/florida" aria-label="View VeteranPCS agents in Florida" onClick={onGtmEvent}>
                 <g
                   id="Florida"
                   className="state"
@@ -1142,7 +1142,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/maryland" onClick={onGtmEvent}>
+              <Link href="/maryland" aria-label="View VeteranPCS agents in Maryland" onClick={onGtmEvent}>
                 <g
                   id="Maryland"
                   className="state small-state-group"
@@ -1175,7 +1175,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/washington-dc" onClick={onGtmEvent}>
+              <Link href="/washington-dc" aria-label="View VeteranPCS agents in Washington Dc" onClick={onGtmEvent}>
                 <g
                   id="Washington DC"
                   className="state small-state-group"
@@ -1203,7 +1203,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/delaware" onClick={onGtmEvent}>
+              <Link href="/delaware" aria-label="View VeteranPCS agents in Delaware" onClick={onGtmEvent}>
                 <g
                   id="Delaware"
                   className="state small-state-group"
@@ -1236,7 +1236,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/new-jersey" onClick={onGtmEvent}>
+              <Link href="/new-jersey" aria-label="View VeteranPCS agents in New Jersey" onClick={onGtmEvent}>
                 <g
                   id="New Jersey"
                   className="state small-state-group"
@@ -1269,7 +1269,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/connecticut" onClick={onGtmEvent}>
+              <Link href="/connecticut" aria-label="View VeteranPCS agents in Connecticut" onClick={onGtmEvent}>
                 <g
                   id="Connecticut"
                   className="state small-state-group"
@@ -1301,7 +1301,7 @@ function StateMapSvgInner({
                   ></path>
                 </g>
               </Link>
-              <Link href="/rhode-island" onClick={onGtmEvent}>
+              <Link href="/rhode-island" aria-label="View VeteranPCS agents in Rhode Island" onClick={onGtmEvent}>
                 <g
                   id="Rhode Island"
                   className="state small-state-group"
@@ -1333,7 +1333,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/massachusetts" onClick={onGtmEvent}>
+              <Link href="/massachusetts" aria-label="View VeteranPCS agents in Massachusetts" onClick={onGtmEvent}>
                 <g
                   id="Massachusetts"
                   className="state small-state-group"
@@ -1366,7 +1366,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/new-hampshire" onClick={onGtmEvent}>
+              <Link href="/new-hampshire" aria-label="View VeteranPCS agents in New Hampshire" onClick={onGtmEvent}>
                 <g
                   id="New Hampshire"
                   className="state small-state-group"
@@ -1398,7 +1398,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/vermont" onClick={onGtmEvent}>
+              <Link href="/vermont" aria-label="View VeteranPCS agents in Vermont" onClick={onGtmEvent}>
                 <g
                   id="Vermont"
                   className="state small-state-group"
@@ -1430,7 +1430,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/texas" onClick={onGtmEvent}>
+              <Link href="/texas" aria-label="View VeteranPCS agents in Texas" onClick={onGtmEvent}>
                 <g
                   id="Texas"
                   className="state"
@@ -1459,7 +1459,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/alaska" onClick={onGtmEvent}>
+              <Link href="/alaska" aria-label="View VeteranPCS agents in Alaska" onClick={onGtmEvent}>
                 <g
                   id="Alaska"
                   className="state"
@@ -1488,7 +1488,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/hawaii" onClick={onGtmEvent}>
+              <Link href="/hawaii" aria-label="View VeteranPCS agents in Hawaii" onClick={onGtmEvent}>
                 <g
                   id="Hawaii"
                   className="state small-state-group"
@@ -1523,7 +1523,7 @@ function StateMapSvgInner({
                   </g>
                 </g>
               </Link>
-              <Link href="/puerto-rico">
+              <Link href="/puerto-rico" aria-label="View VeteranPCS agents in Puerto Rico" onClick={onGtmEvent}>
                 <g
                   id="Puerto Rico"
                   className="state small-state-group"

--- a/components/homepage/VeteranCommunity/VeteranCommunity.tsx
+++ b/components/homepage/VeteranCommunity/VeteranCommunity.tsx
@@ -76,13 +76,13 @@ const VeteranCommunity = async ({ component_slug }: { component_slug: string }) 
                 height={100}
                 src={pageData?.icon?.asset?.image_url || "/icon/userplus.svg"}
                 className="w-auto h-auto"
-                alt={pageData?.icon?.alt || "Description of the image"}
+                alt={pageData?.icon?.alt || ""}
               />
             </div>
             <div>
-              <h1 className="text-white poppins lg:text-left md:text-left sm:text-center text-center text-3xl font-bold leading-[40px] mt-5">
+              <h2 className="text-white poppins lg:text-left md:text-left sm:text-center text-center text-3xl font-bold leading-[40px] mt-5">
                 {pageData?.title}
-              </h1>
+              </h2>
               <div className="text-white md:text-xl sm:text-sm lg:text-left md:text-left sm:text-center text-center italic font-medium leading-[25px] mt-4 roboto">
                 {pageData?.description?.map((block, index) => (
                   <SupportContent
@@ -107,7 +107,7 @@ const VeteranCommunity = async ({ component_slug }: { component_slug: string }) 
                     height={100}
                     src="/icon/checkred.svg"
                     className="md:w-[25px] md:h-[25px] sm:w-[20px] sm:h-[20px] w-[25px] h-[25px] mt-1"
-                    alt="Description of the image"
+                    alt=""
                   />
                   <h6 className="text-white roboto md:text-lg sm:text-sm font-medium my-0">
                     <SupportContent

--- a/components/homepage/VeteranPCSWorksComp/VeteranPCSWorks.tsx
+++ b/components/homepage/VeteranPCSWorksComp/VeteranPCSWorks.tsx
@@ -14,8 +14,8 @@ const cardsData = [
     img: "/icon/checkred.svg",
     title: "VA LOAN",
     subTitle:
-      "Don’t overpay when using your va loan. Our va loan experts are here to help.",
-    link: "#state-map",
+      "Don’t overpay when using your VA loan. Our VA loan experts are here to help.",
+    link: "/va-loan-help",
   },
   {
     img: "/icon/checkred.svg",

--- a/components/homepage/VideoFamily.tsx
+++ b/components/homepage/VideoFamily.tsx
@@ -46,12 +46,12 @@ const FamilyVideo = () => {
           autoPlay
           playsInline
           muted
-          preload="auto"
+          preload="metadata"
           src="/assets/military-families.mp4"
           className="w-full"
+          aria-label="Military families helped by VeteranPCS"
         >
-          <source type="video/mp4" src="/assets/military-families.mp4 " />
-          <source type="video/webm" src="/assets/military-families.mp4" />
+          <source type="video/mp4" src="/assets/military-families.mp4" />
         </video>
       </div>
       <div className="container mx-auto overflow-hidden">
@@ -64,7 +64,7 @@ const FamilyVideo = () => {
                     width={100}
                     height={100}
                     src="/icon/yourimpacthendwhhite.svg"
-                    alt="impact_wearblue"
+	                    alt=""
                     className="w-full h-full"
                   />
                 </div>
@@ -84,7 +84,7 @@ const FamilyVideo = () => {
                     width={100}
                     height={100}
                     src="/icon/yourhome.svg"
-                    alt="impact_wearblue"
+	                    alt=""
                     className="w-full h-full"
                   />
                 </div>
@@ -104,7 +104,7 @@ const FamilyVideo = () => {
                     width={100}
                     height={100}
                     src="/icon/yourSymbol.svg"
-                    alt="impact_wearblue"
+	                    alt=""
                     className="w-full h-full"
                   />
                 </div>

--- a/components/stories/StoriesHeroSection/StoriesHeroSection.module.css
+++ b/components/stories/StoriesHeroSection/StoriesHeroSection.module.css
@@ -4,7 +4,7 @@
   background-position: center;
   background-repeat: no-repeat;
   padding: 115px 30px;
-  margin-top: 100px;
+  margin-top: 0;
 }
 
 @media screen and (max-width: 575px) {
@@ -28,12 +28,12 @@
 
 @media screen and (min-width: 1024px) {
   .StoriesHeroSectionContainer {
-    margin-top: 100px;
+    padding: 215px 30px 115px;
   }
 }
 
 @media screen and (min-width: 1290px) {
   .StoriesHeroSectionContainer {
-    margin-top: 100px;
+    padding: 215px 30px 115px;
   }
 }


### PR DESCRIPTION
## Summary

This PR improves the VeteranPCS homepage and related hero layouts to reduce friction for PCS movers trying to connect with a vetted agent or VA loan expert.

## What changed

- Reworked the homepage hero to surface the value prop and primary Find An Agent CTA faster on desktop and mobile.
- Improved the state-selection path with clearer copy, accessible labels, relative state links, and a mobile-first picker instead of the heavy map.
- Added a persistent header Find An Agent affordance and improved mobile menu ARIA behavior.
- Removed the development test popup trigger.
- Corrected homepage heading hierarchy, form labels, focus states, touch targets, decorative alt text, and CTA copy.
- Reduced homepage distraction by removing/demoting heavier sections and reordering toward conversion.
- Enlarged desktop partner logos and fixed footer/state-list mobile friction.
- Moved hero top spacing from external margins into internal padding across affected page heroes so fixed-header gaps no longer show.
- Fixed the VA LOAN tile so it links to /va-loan-help instead of the homepage state map.

## Validation

- npm run lint
- npm run type-check
- npm run build via pre-commit hook
- git diff --check
- Desktop and mobile screenshot checks for homepage, state selector, About, Contact, How It Works, Stories, and Military Spouse hero seams
- DOM check confirmed the VA Loan tile href is /va-loan-help

## Notes

The working tree still has unrelated untracked blog/docs/image files that were intentionally left out of this commit.