### PR TITLE
Make blog author attribution resilient

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Script from "next/script";
+import { cache } from "react";
 import { BlogPosting, WithContext } from "schema-dts";
 import BlogDetailsHeroSection from "@/components/BlogDetails/BlogDetailsHeroSection/BlogDetailsHeroSection";
 import BlogBeginingPostAgent from "@/components/BlogDetails/BlogBeginingBlogPostAgent/BlogBeginingBlogPostAgent";
@@ -11,12 +12,21 @@ import KeepInTouch from "@/components/homepage/KeepInTouch/KeepInTouch";
 import CommonBlog from "@/components/BlogPage/BlogPage/BlogCTA/CommonBlog";
 import FindAgentInState from "@/components/Blog/FindAgentInState";
 import { getBlogBySlug, getBlogSlugs } from "@/lib/blog/mdx";
+import { resolveAuthor } from "@/lib/blog/authors";
 import { getStateForBlog } from "@/lib/blog/getStateForBlog";
 import { splitMdxAtMidpoint } from "@/lib/blog/splitMdxAtMidpoint";
 import { formatDate } from "@/utils/helper";
 import { buildBreadcrumbList } from "@/lib/structured-data";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+const getBlogPageData = cache(async (slug: string) => {
+    const blog = await getBlogBySlug(slug);
+    if (!blog) return null;
+
+    const resolvedAuthor = await resolveAuthor(blog.author);
+    return { blog, resolvedAuthor };
+});
 
 export async function generateStaticParams() {
     const slugs = await getBlogSlugs();
@@ -25,11 +35,13 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: { params: Promise<{ slug: string }> }) {
     const params = await props.params;
-    const blog = await getBlogBySlug(params.slug);
+    const pageData = await getBlogPageData(params.slug);
 
-    if (!blog) {
+    if (!pageData) {
         return { title: "Blog not found" };
     }
+
+    const { blog, resolvedAuthor } = pageData;
 
     return {
         title: blog.metaTitle,
@@ -42,7 +54,7 @@ export async function generateMetadata(props: { params: Promise<{ slug: string }
             description: blog.metaDescription,
             url: `${BASE_URL}/blog/${params.slug}`,
             type: "article",
-            authors: blog.author?.name ? [blog.author.name] : undefined,
+            authors: [resolvedAuthor.name],
         },
         twitter: {
             card: "summary_large_image",
@@ -54,12 +66,13 @@ export async function generateMetadata(props: { params: Promise<{ slug: string }
 
 export default async function Home(props: { params: Promise<{ slug: string }> }) {
     const { slug } = await props.params;
-    const blog = await getBlogBySlug(slug);
+    const pageData = await getBlogPageData(slug);
 
-    if (!blog) {
+    if (!pageData) {
         notFound();
     }
 
+    const { blog, resolvedAuthor } = pageData;
     const { first: bodyFirstHalf, second: bodySecondHalf } = splitMdxAtMidpoint(blog.content);
     const bridgeState = getStateForBlog(slug);
 
@@ -80,10 +93,15 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
         image: heroImageUrl,
         datePublished: formatDate(blog.publishedAt),
         dateModified: formatDate(blog.updatedAt ?? blog.publishedAt),
-        author: {
-            "@type": "Person",
-            name: blog.author?.name ?? "VeteranPCS",
-        },
+        author: resolvedAuthor.kind === "salesforce"
+            ? {
+                "@type": "Person",
+                name: resolvedAuthor.name,
+            }
+            : {
+                "@type": "Organization",
+                name: resolvedAuthor.name,
+            },
         publisher: {
             "@type": "Organization",
             name: "VeteranPCS",
@@ -125,14 +143,21 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
             />
-            <BlogDetailsHeroSection blog={blog} />
-            <BlogBeginingPostAgent blog={blog} bodyFirstHalf={bodyFirstHalf} />
+            <BlogDetailsHeroSection blog={blog} resolvedAuthor={resolvedAuthor} />
+            <BlogBeginingPostAgent
+                blog={blog}
+                bodyFirstHalf={bodyFirstHalf}
+                resolvedAuthor={resolvedAuthor}
+            />
             {bridgeState && (
                 <FindAgentInState state={bridgeState} blogSlug={slug} position="top" />
             )}
             <Testimonials />
             <BlogDetailsCta />
-            <EndBlogPostDetails bodySecondHalf={bodySecondHalf} />
+            <EndBlogPostDetails
+                bodySecondHalf={bodySecondHalf}
+                resolvedAuthor={resolvedAuthor}
+            />
             {bridgeState && (
                 <FindAgentInState state={bridgeState} blogSlug={slug} position="bottom" />
             )}

--- a/components/Blog/AuthorByline.tsx
+++ b/components/Blog/AuthorByline.tsx
@@ -1,10 +1,8 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import Button from '@/components/common/Button';
-import { resolveAuthor } from '@/lib/blog/authors';
-import { buildContactCtaHref } from '@/lib/contactAgentUrl';
-import { normalizeStateSlug } from '@/lib/states';
-import type { FrontmatterAuthor } from '@/lib/blog/types';
+import { getAuthorContactHref, resolveAuthor } from '@/lib/blog/authors';
+import type { FrontmatterAuthor, ResolvedAuthor } from '@/lib/blog/types';
 
 const VPCS_FALLBACK = {
   logo: '/logo-stacked.png',
@@ -18,26 +16,20 @@ const VPCS_FALLBACK = {
 
 type Props = {
   frontmatterAuthor: FrontmatterAuthor | null | undefined;
+  resolvedAuthor?: ResolvedAuthor | null;
   variant?: 'card' | 'inline';
   ctaStateSlug?: string | null;
 };
 
-function normalizeCtaState(value: string | undefined): string | null {
-  if (!value) return null;
-  return normalizeStateSlug(value) ?? normalizeStateSlug(value.replace(/\s+/g, '-'));
-}
-
 export default async function AuthorByline({
   frontmatterAuthor,
+  resolvedAuthor,
   variant = 'card',
   ctaStateSlug,
 }: Props) {
-  const author = await resolveAuthor(frontmatterAuthor ?? null);
-  const frontmatterStateSlug =
-    normalizeCtaState(frontmatterAuthor?.stateSlug) ??
-    normalizeCtaState(frontmatterAuthor?.state);
+  const author = resolvedAuthor ?? await resolveAuthor(frontmatterAuthor ?? null);
 
-  if (!author) {
+  if (author.kind === 'fallback') {
     if (variant === 'inline') {
       return (
         <span className="inline-flex items-center gap-2">
@@ -74,7 +66,7 @@ export default async function AuthorByline({
           <b className="text-[#495057]">{VPCS_FALLBACK.brokerage}</b>
         </p>
         <div className="w-full flex justify-center mt-4">
-          <Link href="/contact-agent">
+          <Link href={author.contactHref}>
             <Button buttonText="Get in Touch" />
           </Link>
         </div>
@@ -101,12 +93,9 @@ export default async function AuthorByline({
     );
   }
 
-  const showCta = Boolean(author.salesforceId && author.active);
-  const ctaHref = buildContactCtaHref({
-    firstName: author.firstName,
-    salesforceId: author.salesforceId,
-    stateSlug: ctaStateSlug ?? frontmatterStateSlug ?? author.stateSlug,
-    form: author.isLender ? 'lender' : 'agent',
+  const ctaHref = getAuthorContactHref(author, {
+    stateSlug: ctaStateSlug ?? frontmatterAuthor?.stateSlug,
+    state: frontmatterAuthor?.state,
   });
 
   return (
@@ -141,13 +130,11 @@ export default async function AuthorByline({
           </>
         ) : null}
       </p>
-      {showCta ? (
-        <div className="w-full flex justify-center mt-4">
-          <Link href={ctaHref}>
-            <Button buttonText="Get in Touch" />
-          </Link>
-        </div>
-      ) : null}
+      <div className="w-full flex justify-center mt-4">
+        <Link href={ctaHref}>
+          <Button buttonText="Get in Touch" />
+        </Link>
+      </div>
     </div>
   );
 }

--- a/components/Blog/mdx/AgentCTA.tsx
+++ b/components/Blog/mdx/AgentCTA.tsx
@@ -1,17 +1,35 @@
 import AuthorByline from '@/components/Blog/AuthorByline';
+import { resolvedAuthorMatchesSalesforceId } from '@/lib/blog/authors';
+import type { ResolvedAuthor } from '@/lib/blog/types';
 
 type Props = {
   salesforceId: string;
   name?: string;
   state?: string;
   stateSlug?: string;
+  resolvedAuthor?: ResolvedAuthor | null;
 };
 
-export default function AgentCTA({ salesforceId, name, state, stateSlug }: Props) {
+export default function AgentCTA({
+  salesforceId,
+  name,
+  state,
+  stateSlug,
+  resolvedAuthor,
+}: Props) {
+  const frontmatterAuthor = { salesforceId, name, state, stateSlug };
+  const matchingResolvedAuthor = resolvedAuthorMatchesSalesforceId(
+    resolvedAuthor,
+    salesforceId,
+  )
+    ? resolvedAuthor
+    : null;
+
   return (
     <div className="my-8 flex justify-center">
       <AuthorByline
-        frontmatterAuthor={{ salesforceId, name, state, stateSlug }}
+        frontmatterAuthor={frontmatterAuthor}
+        resolvedAuthor={matchingResolvedAuthor}
         variant="card"
       />
     </div>

--- a/components/Blog/mdx/AgentContactLink.tsx
+++ b/components/Blog/mdx/AgentContactLink.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import {
+  getAuthorContactHref,
+  resolveAuthor,
+  resolvedAuthorMatchesSalesforceId,
+} from '@/lib/blog/authors';
+import type { ResolvedAuthor } from '@/lib/blog/types';
+
+type Props = {
+  salesforceId: string;
+  name?: string;
+  state?: string;
+  stateSlug?: string;
+  children: ReactNode;
+  resolvedAuthor?: ResolvedAuthor | null;
+};
+
+export default async function AgentContactLink({
+  salesforceId,
+  name,
+  state,
+  stateSlug,
+  children,
+  resolvedAuthor,
+}: Props) {
+  const authorInput = { salesforceId, name, state, stateSlug };
+  const author = resolvedAuthorMatchesSalesforceId(resolvedAuthor, salesforceId)
+    ? resolvedAuthor
+    : await resolveAuthor(authorInput);
+
+  const href = getAuthorContactHref(author, authorInput);
+
+  return (
+    <Link href={href} className="text-[#A81F23] underline hover:text-[#871B1C]">
+      {children}
+    </Link>
+  );
+}

--- a/components/Blog/mdx/index.ts
+++ b/components/Blog/mdx/index.ts
@@ -1,5 +1,6 @@
 export { default as Callout } from './Callout';
 export { default as PromoCard } from './PromoCard';
 export { default as AgentCTA } from './AgentCTA';
+export { default as AgentContactLink } from './AgentContactLink';
 export { default as YouTubeEmbed } from './YouTubeEmbed';
 export { default as BlogImage } from './BlogImage';

--- a/components/BlogDetails/BlogBeginingBlogPostAgent/BlogBeginingBlogPostAgent.tsx
+++ b/components/BlogDetails/BlogBeginingBlogPostAgent/BlogBeginingBlogPostAgent.tsx
@@ -2,16 +2,23 @@ import "@/app/globals.css";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import AuthorByline from "@/components/Blog/AuthorByline";
 import { formatDate } from "@/utils/helper";
-import { mdxComponents } from "@/mdx-components";
+import { createBlogMdxComponents } from "@/mdx-components";
 import { mdxOptions } from "@/lib/blog/mdx-options";
-import type { BlogPost } from "@/lib/blog/types";
+import type { BlogPost, ResolvedAuthor } from "@/lib/blog/types";
 
 type Props = {
   blog: BlogPost;
   bodyFirstHalf: string;
+  resolvedAuthor: ResolvedAuthor;
 };
 
-export default function BlogBeginningBlogPostAgent({ blog, bodyFirstHalf }: Props) {
+export default function BlogBeginningBlogPostAgent({
+  blog,
+  bodyFirstHalf,
+  resolvedAuthor,
+}: Props) {
+  const mdxComponents = createBlogMdxComponents({ resolvedAuthor });
+
   return (
     <div className="relative py-12 md:px-10 px-5">
       <div className="container mx-auto">
@@ -23,7 +30,11 @@ export default function BlogBeginningBlogPostAgent({ blog, bodyFirstHalf }: Prop
               </p>
               <p className="text-[#495057] lora text-sm font-bold">4 minutes</p>
             </div>
-            <AuthorByline frontmatterAuthor={blog.author} variant="card" />
+            <AuthorByline
+              frontmatterAuthor={blog.author}
+              resolvedAuthor={resolvedAuthor}
+              variant="card"
+            />
           </div>
           <article className="w-full lg:w-4/5 lg:pl-10">
             <MDXRemote source={bodyFirstHalf} components={mdxComponents} options={mdxOptions} />

--- a/components/BlogDetails/BlogDetailsHeroSection/BlogDetailsHeroSection.tsx
+++ b/components/BlogDetails/BlogDetailsHeroSection/BlogDetailsHeroSection.tsx
@@ -1,10 +1,13 @@
 import "@/app/globals.css";
 import classes from "./BlogDetailsHeroSection.module.css";
-import type { BlogPost } from "@/lib/blog/types";
+import type { BlogPost, ResolvedAuthor } from "@/lib/blog/types";
 
-type Props = { blog: BlogPost };
+type Props = {
+  blog: BlogPost;
+  resolvedAuthor: ResolvedAuthor;
+};
 
-export default function BlogDetailsHeroSection({ blog }: Props) {
+export default function BlogDetailsHeroSection({ blog, resolvedAuthor }: Props) {
   const bg = blog.mainImage?.src || "/assets/blogctabgimage.png";
   return (
     <div className="relative">
@@ -18,13 +21,11 @@ export default function BlogDetailsHeroSection({ blog }: Props) {
               <h1 className="text-white text-center tahoma lg:text-[36px] md:text-[36px] sm:text-[36px] text-[36px] font-bold mt-8 mb-3 max-w-[800px]">
                 {blog.title}
               </h1>
-              {blog.author?.name ? (
-                <div>
-                  <h6 className="text-white tahoma text-sm font-bold mt-10">
-                    By {blog.author.name}
-                  </h6>
-                </div>
-              ) : null}
+              <div>
+                <h6 className="text-white tahoma text-sm font-bold mt-10">
+                  By {resolvedAuthor.name}
+                </h6>
+              </div>
             </div>
           </div>
         </div>

--- a/components/BlogDetails/EndBlogPostDetails/EndBlogPostDetails.tsx
+++ b/components/BlogDetails/EndBlogPostDetails/EndBlogPostDetails.tsx
@@ -1,14 +1,21 @@
 import "@/app/globals.css";
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { mdxComponents } from "@/mdx-components";
+import { createBlogMdxComponents } from "@/mdx-components";
 import { mdxOptions } from "@/lib/blog/mdx-options";
+import type { ResolvedAuthor } from "@/lib/blog/types";
 
 type Props = {
   bodySecondHalf: string;
+  resolvedAuthor: ResolvedAuthor;
 };
 
-export default function EndBlogPostDetails({ bodySecondHalf }: Props) {
+export default function EndBlogPostDetails({
+  bodySecondHalf,
+  resolvedAuthor,
+}: Props) {
   if (!bodySecondHalf) return null;
+  const mdxComponents = createBlogMdxComponents({ resolvedAuthor });
+
   return (
     <div className="relative py-12 md:px-10 px-5">
       <div className="container mx-auto">

--- a/content/blog/best-neighborhoods-redstone-arsenal-military.mdx
+++ b/content/blog/best-neighborhoods-redstone-arsenal-military.mdx
@@ -68,7 +68,7 @@ If budget is the main driver, look at Harvest and Monrovia in zip 35749. This ar
 
 *Typical home values by neighborhood (2026 ZHVI, a typical-value measure, not a median sale price).*
 
-[Kelli Malace can match you to the right neighborhood](https://www.veteranpcs.com/contact-agent?form=agent&fn=Kelli&id=0014x00001uLvPH&state=alabama) based on your budget, gate, and school needs.
+<AgentContactLink salesforceId="0014x00001uLvPH" state="alabama">A VeteranPCS agent can match you to the right neighborhood</AgentContactLink> based on your budget, gate, and school needs.
 
 ## Meridianville: Rural and Affordable
 

--- a/content/blog/colorado-springs-housing-market-update-october-2025.mdx
+++ b/content/blog/colorado-springs-housing-market-update-october-2025.mdx
@@ -76,13 +76,13 @@ If a PCS (Permanent Change of Station) move is bringing you to the area, timing 
 
 Putting it all together, Colorado Springs in October 2025 looked like a balanced market heading into the winter. Prices were steady, inventory was up sharply from a year ago, and homes were taking a little longer to sell. For active-duty service members, veterans, and military spouses, that combination is encouraging. You get more choices and a calmer pace without the worry of values dropping out from under you.
 
-The best move is to pair this market snapshot with current, on-the-ground advice. A local agent can pull up-to-the-day numbers, point you toward the right neighborhoods near Fort Carson, Peterson Space Force Base, or Schriever, and help you make the most of your VA loan benefits. When you are ready, [connect with a VeteranPCS agent in Colorado Springs](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jacob&id=0014x00001sa3ch&state=colorado) who understands military moves.
+The best move is to pair this market snapshot with current, on-the-ground advice. A local agent can pull up-to-the-day numbers, point you toward the right neighborhoods near Fort Carson, Peterson Space Force Base, or Schriever, and help you make the most of your VA loan benefits. When you are ready, <AgentContactLink salesforceId="0014x00001sa3ch" state="colorado">connect with a VeteranPCS agent in Colorado Springs</AgentContactLink> who understands military moves.
 
 ## About the agent
 
 This update was contributed by Jacob McCrackin, an Army veteran and the founder of Veterans Move Together (Solid Oak Realty) in Colorado Springs. Jacob helps fellow service members and military families navigate the Pikes Peak region housing market with the kind of guidance that comes from living the military life himself.
 
-Have questions about a specific neighborhood or what your budget can buy today? [Connect with a VeteranPCS agent in Colorado Springs](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jacob&id=0014x00001sa3ch&state=colorado) to get started.
+Have questions about a specific neighborhood or what your budget can buy today? <AgentContactLink salesforceId="0014x00001sa3ch" state="colorado">Connect with a VeteranPCS agent in Colorado Springs</AgentContactLink> to get started.
 
 Market data is sourced from the Pikes Peak Multiple Listing Service (PPMLS). It is considered reliable but not guaranteed, and it reflects conditions as of the publish date.
 

--- a/content/blog/fort-meade-bah-2026-what-your-allowance-buys.mdx
+++ b/content/blog/fort-meade-bah-2026-what-your-allowance-buys.mdx
@@ -62,7 +62,7 @@ Mid-grade enlisted with dependents are in a genuinely strong spot. An E-7 with d
 
 Officers will find their BAH competitive across the area. An O-3 with dependents gets $3,336 a month, which is enough for a solid mortgage in Crofton or the more affordable Columbia villages. An O-5 and O-6 with dependents ($3,918 and $3,954) have real buying power even in Howard County's premium market.
 
-If you want to see exactly what your rate buys near base, [connect with a VeteranPCS agent in Maryland](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jon&id=001Rg00000l1Wys&state=maryland) who knows these neighborhoods.
+If you want to see exactly what your rate buys near base, <AgentContactLink salesforceId="001Rg00000l1Wys" state="maryland">connect with a VeteranPCS agent in Maryland</AgentContactLink> who knows these neighborhoods.
 
 ## Buy vs. Rent Near Fort Meade
 
@@ -88,7 +88,7 @@ One thing to weigh honestly: on-post schools are run by Anne Arundel County Publ
 
 Fort Meade BAH gives you real buying power in a market that, unlike Northern Virginia, has not fully outpaced what the allowance can cover. Mid-grade enlisted and officers who use their VA loan benefit and choose wisely between Odenton, Crofton, and Columbia could leave a tour here with equity built. That is not something you can say about every D.C.-area base. One more thing worth checking: the VA loan does not always carry the lowest rate, so it pays to compare. See our explainer on whether [the VA loan always has the best rate](/blog/does-the-va-loan-always-have-the-best-rate).
 
-The smartest first move is to confirm your exact rate at the official DoD calculator, then [connect with a VeteranPCS agent in Maryland](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jon&id=001Rg00000l1Wys&state=maryland) to see exactly what your BAH will buy near Fort Meade.
+The smartest first move is to confirm your exact rate at the official DoD calculator, then <AgentContactLink salesforceId="001Rg00000l1Wys" state="maryland">connect with a VeteranPCS agent in Maryland</AgentContactLink> to see exactly what your BAH will buy near Fort Meade.
 
 All BAH figures reflect 2026 rates effective January 1, 2026. Verify your specific rate at the Department of Defense BAH calculator.
 

--- a/content/blog/huntsville-housing-market-2026-military-buyer.mdx
+++ b/content/blog/huntsville-housing-market-2026-military-buyer.mdx
@@ -94,7 +94,7 @@ Second, affordability is a genuine strength here. Below-average living costs and
 
 Third, demand has a floor under it from the existing Redstone and research-park jobs, with SPACECOM as a potential addition over the next several years rather than a sure thing. That is a reasonable backdrop for a buyer, but it is not a promise of appreciation.
 
-If you are weighing whether to buy here or hold onto a home you already own, especially during an overseas tour, our guide on [what to do with your home when PCSing OCONUS](/blog/pcsing-oconus-what-do-i-do-with-my-home) walks through your options. And when you want a read on today's listings and what is realistic in your price range, you can [ask VeteranPCS agent Kelli Malace for a current market read](https://www.veteranpcs.com/contact-agent?form=agent&fn=Kelli&id=0014x00001uLvPH&state=alabama).
+If you are weighing whether to buy here or hold onto a home you already own, especially during an overseas tour, our guide on [what to do with your home when PCSing OCONUS](/blog/pcsing-oconus-what-do-i-do-with-my-home) walks through your options. And when you want a read on today's listings and what is realistic in your price range, you can <AgentContactLink salesforceId="0014x00001uLvPH" state="alabama">ask a VeteranPCS agent for a current market read</AgentContactLink>.
 
 ## The Bottom Line
 

--- a/content/blog/huntsville-redstone-bah-2026-buy-vs-rent.mdx
+++ b/content/blog/huntsville-redstone-bah-2026-buy-vs-rent.mdx
@@ -88,7 +88,7 @@ Adding those together gives an estimated monthly housing cost of about $2,044 ($
 
 One more note: the VA funding fee is a one-time cost on most VA loans, and it can be financed into the loan rather than paid up front. We kept it out of the monthly figures above to keep the math clean, but it does add slightly to the loan balance. For more on how the no-down-payment structure and funding fee work, see the [VA's home loan limits and funding fee page](https://www.va.gov/housing-assistance/home-loans/loan-limits/) and our explainer on [how a $0 down VA loan works](/blog/how-does-a-0-down-va-loan-work).
 
-If you want help building this with your real rate and rank, you can [ask VeteranPCS agent Kelli Malace to run your numbers](https://www.veteranpcs.com/contact-agent?form=agent&fn=Kelli&id=0014x00001uLvPH&state=alabama).
+If you want help building this with your real rate and rank, you can <AgentContactLink salesforceId="0014x00001uLvPH" state="alabama">ask a VeteranPCS agent to run your numbers</AgentContactLink>.
 
 ![Bar chart of 2026 Huntsville BAH with dependents by rank (E-6 $2,079, E-7 $2,133, O-1 $1,839, O-2 $2,076, O-3 $2,226) with a dashed line at the estimated $2,044 monthly housing cost.](/images/blog/huntsville-redstone-bah-2026-buy-vs-rent/bah-vs-mortgage-by-rank.png)
 

--- a/content/blog/pcs-moves-buying-or-selling-during-relocation.mdx
+++ b/content/blog/pcs-moves-buying-or-selling-during-relocation.mdx
@@ -49,7 +49,7 @@ A good agent does detailed walk-throughs for you, takes video, and explains what
 
 Selling from a distance works the same way. Your agent coordinates everything that needs to happen on-site, from photos and showings to repairs and the final walk-through, so you can keep your focus on the move.
 
-If you are weighing how to pick the right person for this, our guide on [how to choose the right real estate agent for your military PCS move](/blog/how-to-choose-the-right-real-estate-agent-for-your-military-pcs-move) is a helpful next step. And if you would rather talk it through, you can [connect with a veteran-friendly agent in Colorado](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jacob&id=0014x00001sa3ch&state=colorado) today.
+If you are weighing how to pick the right person for this, our guide on [how to choose the right real estate agent for your military PCS move](/blog/how-to-choose-the-right-real-estate-agent-for-your-military-pcs-move) is a helpful next step. And if you would rather talk it through, you can <AgentContactLink salesforceId="0014x00001sa3ch" state="colorado">connect with a veteran-friendly agent in Colorado</AgentContactLink> today.
 
 ## Use Your VA Loan the Right Way
 
@@ -73,7 +73,7 @@ Every PCS is different. The base, the market, the season, and your family's need
 
 A military-experienced agent has walked this road with families like yours many times. They know the questions to ask, the steps to take, and the pitfalls to avoid. With the right person beside you, the next move becomes one clear step at a time instead of one big unknown. For more on getting ready, see our guide on [preparing to PCS and what you need to know](/blog/preparing-to-pcs-what-you-need-to-know).
 
-When you are ready, [reach out to a veteran-friendly agent in Colorado](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jacob&id=0014x00001sa3ch&state=colorado) and take that first step with confidence.
+When you are ready, <AgentContactLink salesforceId="0014x00001sa3ch" state="colorado">reach out to a veteran-friendly agent in Colorado</AgentContactLink> and take that first step with confidence.
 
 ## About the Agent
 

--- a/content/blog/pcs-redstone-arsenal-huntsville-guide.mdx
+++ b/content/blog/pcs-redstone-arsenal-huntsville-guide.mdx
@@ -140,7 +140,7 @@ The honest answer is that it depends on your timeline and your family's plans. T
 
 The SPACECOM move adds long-term demand, but as noted above, the largest arrivals are years out. So a steady market today and growth ahead can both be true. For a deeper read on supply, pricing trends, and what they mean for a military buyer, see our [2026 Huntsville housing market guide for military buyers](/blog/huntsville-housing-market-2026-military-buyer). And if you are weighing the move itself, our notes on [preparing to PCS](/blog/preparing-to-pcs-what-you-need-to-know) cover the basics.
 
-A local agent who knows military buyers can save you real money and headaches here. You can [connect with VeteranPCS agent Kelli Malace](https://www.veteranpcs.com/contact-agent?form=agent&fn=Kelli&id=0014x00001uLvPH&state=alabama) to talk through neighborhoods, schools, and timing for your specific orders.
+A local agent who knows military buyers can save you real money and headaches here. You can <AgentContactLink salesforceId="0014x00001uLvPH" state="alabama">connect with a VeteranPCS agent</AgentContactLink> to talk through neighborhoods, schools, and timing for your specific orders.
 
 ## Things to Do
 

--- a/content/blog/pcs-to-bremerton-naval-base-kitsap-2026-guide.mdx
+++ b/content/blog/pcs-to-bremerton-naval-base-kitsap-2026-guide.mdx
@@ -72,7 +72,7 @@ Here is a quick look at the main areas at a glance:
 | North Kitsap (Poulsbo / Kingston) | Small-town feel, charm, more space, good schools | Longer drive to the Bremerton base |
 | Port Orchard / South Kitsap | More house for your BAH, affordability | The Gorst commute during peak hours |
 
-Need help weighing these areas against your budget and commute? You can [connect with a military-experienced VeteranPCS agent in Washington](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jason&id=001Rg00000izCXZ&state=washington) who knows the Kitsap market.
+Need help weighing these areas against your budget and commute? You can <AgentContactLink salesforceId="001Rg00000izCXZ" state="washington">connect with a military-experienced VeteranPCS agent in Washington</AgentContactLink> who knows the Kitsap market.
 
 ## Port Orchard and the Gorst Commute
 
@@ -106,7 +106,7 @@ Before you come, make a bucket list. People travel to Seattle and Tacoma from al
 
 ## Planning Your Move the Right Way
 
-A smooth Kitsap PCS comes down to a few early steps: get pre-approved with a VA-experienced lender, reach out to your school district before orders are final, and decide which area fits your commute and budget. From there, the rest of the move falls into place. When you are ready, [connect with a military-experienced VeteranPCS agent in Washington](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jason&id=001Rg00000izCXZ&state=washington) who can help you weigh renting versus buying and find the right neighborhood before you arrive.
+A smooth Kitsap PCS comes down to a few early steps: get pre-approved with a VA-experienced lender, reach out to your school district before orders are final, and decide which area fits your commute and budget. From there, the rest of the move falls into place. When you are ready, <AgentContactLink salesforceId="001Rg00000izCXZ" state="washington">connect with a military-experienced VeteranPCS agent in Washington</AgentContactLink> who can help you weigh renting versus buying and find the right neighborhood before you arrive.
 
 ## About the Agents
 

--- a/content/blog/pcs-to-kitsap-county-five-things-military-families.mdx
+++ b/content/blog/pcs-to-kitsap-county-five-things-military-families.mdx
@@ -61,7 +61,7 @@ There are trade-offs to know about:
 
 When the numbers and the schedule line up, though, the monthly savings can be large enough to completely change what is in reach. To understand the rules before you commit, read our guide to [VA loan assumptions and what military families must know](https://www.veteranpcs.com/blog/va-loan-assumptions-what-military-families-must-know).
 
-**Not sure whether buying or assuming makes sense for your tour?** [Connect with a VeteranPCS agent in Washington](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jason&id=001Rg00000izCXZ&state=washington) who knows the Kitsap market.
+**Not sure whether buying or assuming makes sense for your tour?** <AgentContactLink salesforceId="001Rg00000izCXZ" state="washington">Connect with a VeteranPCS agent in Washington</AgentContactLink> who knows the Kitsap market.
 
 ## 3. The Gorst Commute Changes Everything
 
@@ -103,7 +103,7 @@ Marilyn brings years of experience as a military "brat," military spouse, and Mi
 
 Richesin Homes operates under Keller Williams Greater 360. For questions about housing near Naval Base Kitsap, VA loan strategy, or commute planning, reach them at 360-386-2045 or richesinhomeskitsap.com.
 
-**Ready to start your home search near Naval Base Kitsap?** [Connect with a VeteranPCS agent in Washington](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jason&id=001Rg00000izCXZ&state=washington) who understands military timelines and the local market.
+**Ready to start your home search near Naval Base Kitsap?** <AgentContactLink salesforceId="001Rg00000izCXZ" state="washington">Connect with a VeteranPCS agent in Washington</AgentContactLink> who understands military timelines and the local market.
 
 <AgentCTA salesforceId="001Rg00000izCXZ" name="Marilyn and Jason Richesin" />
 

--- a/content/blog/pcs-to-walter-reed-bethesda-2026-neighborhoods-bah.mdx
+++ b/content/blog/pcs-to-walter-reed-bethesda-2026-neighborhoods-bah.mdx
@@ -80,7 +80,7 @@ These figures reflect 2026 market conditions. Use them as a starting point, not 
 | Potomac | Around $1.25 million | 20 to 30 min via I-270 or River Road | Premium; O-6 and above |
 | Chevy Chase | Rivals Bethesda proper | Adjacent to campus | Premium; closest to base |
 
-Ready to put real listings against your pay grade? You can [connect with a VeteranPCS agent in Maryland who knows Montgomery County](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jon&id=001Rg00000l1Wys&state=maryland) and works with military families every PCS season.
+Ready to put real listings against your pay grade? You can <AgentContactLink salesforceId="001Rg00000l1Wys" state="maryland">connect with a VeteranPCS agent in Maryland who knows Montgomery County</AgentContactLink> and works with military families every PCS season.
 
 ## Schools: Montgomery County Is Genuinely Excellent
 
@@ -106,7 +106,7 @@ The trade-off is commute consistency. Northern Virginia offers more direct highw
 
 Montgomery County is a competitive market and moves fast. Desirable homes in Rockville and Silver Spring routinely go pending within a week. Getting VA loan pre-approval before you arrive is the baseline for being a serious buyer here, not an optional step. If a VA loan is new to you, our [complete guide to buying your first home with a VA loan](/blog/complete-guide-to-buying-your-first-home-with-a-va-loan) covers how the benefit works and why you can often skip PMI (private mortgage insurance). And to keep the whole move on track, our [ultimate PCS checklist and timeline](/blog/the-ultimate-pcs-checklist-and-timeline-for-active-duty-military-personnel) lays out what to do and when.
 
-When you are ready to turn this research into a real home search, [connect with a VeteranPCS agent in Maryland who knows Montgomery County](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jon&id=001Rg00000l1Wys&state=maryland) and works with military families navigating this assignment every PCS season.
+When you are ready to turn this research into a real home search, <AgentContactLink salesforceId="001Rg00000l1Wys" state="maryland">connect with a VeteranPCS agent in Maryland who knows Montgomery County</AgentContactLink> and works with military families navigating this assignment every PCS season.
 
 Home prices reflect 2026 market conditions.
 

--- a/content/blog/understanding-escrow-in-real-estate-veterans-guide.mdx
+++ b/content/blog/understanding-escrow-in-real-estate-veterans-guide.mdx
@@ -51,7 +51,7 @@ The escrow process runs from the moment your offer is accepted until the day you
 
 That step-by-step structure is exactly why so many people lean on a skilled agent during a purchase. If you want a clearer picture of the whole buying journey, our [complete guide to buying your first home with a VA loan](/blog/complete-guide-to-buying-your-first-home-with-a-va-loan) walks through it from start to finish.
 
-Have questions about the escrow timeline in Colorado? [Connect with a VeteranPCS agent in Colorado Springs](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jacob&id=0014x00001sa3ch&state=colorado) who can walk you through it.
+Have questions about the escrow timeline in Colorado? <AgentContactLink salesforceId="0014x00001sa3ch" state="colorado">Connect with a VeteranPCS agent in Colorado Springs</AgentContactLink> who can walk you through it.
 
 ## Escrow for Future Maintenance
 
@@ -77,7 +77,7 @@ The right team also makes sure your closing stays on schedule, which matters whe
 
 This guide was contributed by Jacob McCrackin, an Army veteran and the founder of Veterans Move Together (Solid Oak Realty) in Colorado Springs. Jacob helps fellow service members and military families understand the home-buying process with guidance shaped by living the military life himself.
 
-Ready to put a trusted team behind your move? [Connect with a VeteranPCS agent in Colorado Springs](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jacob&id=0014x00001sa3ch&state=colorado) to get started.
+Ready to put a trusted team behind your move? <AgentContactLink salesforceId="0014x00001sa3ch" state="colorado">Connect with a VeteranPCS agent in Colorado Springs</AgentContactLink> to get started.
 
 <AgentCTA salesforceId="0014x00001sa3ch" name="Jacob McCrackin" />
 

--- a/content/blog/va-loan-huntsville-madison-county-2026.mdx
+++ b/content/blog/va-loan-huntsville-madison-county-2026.mdx
@@ -57,7 +57,7 @@ Most VA borrowers pay a one-time charge called the funding fee. It helps keep th
 
 There is an important exception. The funding fee is waived for veterans who are rated 10 percent or more disabled by the VA. It is also waived for certain surviving spouses and for Purple Heart recipients on active duty. That waiver can save you thousands of dollars at closing. Confirm your own situation on the VA's page about the [VA funding fee and closing costs](https://www.va.gov/housing-assistance/home-loans/funding-fee-and-closing-costs/). For a fuller look at why this benefit is so valuable, see our overview of [the benefits of a VA loan](/blog/what-are-the-benefits-of-a-va-loan).
 
-If you want help running real numbers for a Huntsville home, you can [connect with VeteranPCS agent Kelli Malace and a VA-loan lender](https://www.veteranpcs.com/contact-agent?form=agent&fn=Kelli&id=0014x00001uLvPH&state=alabama) who works with military buyers every day.
+If you want help running real numbers for a Huntsville home, you can <AgentContactLink salesforceId="0014x00001uLvPH" state="alabama">connect with a VeteranPCS agent</AgentContactLink> who works with military buyers every day.
 
 ## Alabama's Tax Breaks for Veterans
 

--- a/content/blog/why-realtors-still-matter-for-military-homebuyers.mdx
+++ b/content/blog/why-realtors-still-matter-for-military-homebuyers.mdx
@@ -45,7 +45,7 @@ A listing can tell you the square footage and the asking price. It cannot tell y
 
 Good realtors know local market trends, recent sale prices, and the small details that separate one block from another. They understand local rules and can read the history behind a property. That knowledge helps you price an offer correctly and avoid homes with hidden issues. If you are weighing which agent to hire, our guide on [how to choose the right real estate agent for your military PCS move](/blog/how-to-choose-the-right-real-estate-agent-for-your-military-pcs-move) walks through the questions worth asking.
 
-Ready to talk to someone who knows the area? [Connect with a VeteranPCS agent in Colorado Springs](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jacob&id=0014x00001sa3ch&state=colorado).
+Ready to talk to someone who knows the area? <AgentContactLink salesforceId="0014x00001sa3ch" state="colorado">Connect with a VeteranPCS agent in Colorado Springs</AgentContactLink>.
 
 ## Deals close more often when both sides have representation
 
@@ -81,7 +81,7 @@ That blend of real estate skill and military know-how is exactly why representat
 
 This post was contributed by Jacob McCrackin, an Army veteran and the founder of Veterans Move Together (Solid Oak Realty) in Colorado Springs. Jacob helps fellow service members and military families buy and sell homes with the kind of guidance that comes from living the military life himself.
 
-When you are ready to put a knowledgeable advocate in your corner, [connect with a VeteranPCS agent in Colorado Springs](https://www.veteranpcs.com/contact-agent?form=agent&fn=Jacob&id=0014x00001sa3ch&state=colorado) to get started.
+When you are ready to put a knowledgeable advocate in your corner, <AgentContactLink salesforceId="0014x00001sa3ch" state="colorado">connect with a VeteranPCS agent in Colorado Springs</AgentContactLink> to get started.
 
 <AgentCTA salesforceId="0014x00001sa3ch" name="Jacob McCrackin" />
 

--- a/lib/blog/__tests__/authors.test.ts
+++ b/lib/blog/__tests__/authors.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache: <T extends (...args: any[]) => any>(fn: T) => fn,
+}));
+
+vi.mock('@/constants/api', () => ({
+  SALESFORCE_BASE_URL: 'https://sf.example.test',
+  SALESFORCE_API_VERSION: 'v62.0',
+}));
+
+vi.mock('@/services/api', () => ({
+  RequestType: {
+    GET: 'get',
+  },
+  salesForceAPI: vi.fn(),
+}));
+
+vi.mock('@/services/salesForceTokenService', () => ({
+  getSalesforceToken: vi.fn(),
+}));
+
+import { salesForceAPI } from '@/services/api';
+import { resolveAuthor } from '@/lib/blog/authors';
+
+const AGENT_ID = '001AGENT0000001';
+const LENDER_ID = '001LENDER000001';
+const MARYLAND_AGENT_ID = '001MARYLAND0001';
+
+function queryResponse(records: unknown[]) {
+  return {
+    status: 200,
+    data: {
+      records,
+    },
+  };
+}
+
+function account(overrides: Record<string, unknown> = {}) {
+  return {
+    Id: AGENT_ID,
+    AccountId_15__c: AGENT_ID,
+    FirstName: 'Test',
+    LastName: 'Agent',
+    Military_Status__pc: 'Veteran',
+    Brokerage_Name__pc: 'Solid Oak Realty',
+    BillingStateCode: 'CO',
+    BillingAddress: { city: 'Colorado Springs', state: 'Colorado' },
+    isAgent__pc: true,
+    isLender__pc: false,
+    Active_on_Website__pc: true,
+    ...overrides,
+  };
+}
+
+describe('resolveAuthor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves an active agent and builds a specific contact-agent URL', async () => {
+    vi.mocked(salesForceAPI).mockResolvedValueOnce(
+      queryResponse([account()]) as never,
+    );
+
+    const author = await resolveAuthor({ salesforceId: AGENT_ID });
+
+    expect(author.kind).toBe('salesforce');
+    expect(author.name).toBe('Test Agent');
+    expect(author.role).toBe('agent');
+    expect(author.contactHref).toBe(
+      `/contact-agent?form=agent&fn=Test&id=${AGENT_ID}&state=colorado`,
+    );
+  });
+
+  it('preserves lender authors with the contact-lender flow', async () => {
+    vi.mocked(salesForceAPI).mockResolvedValueOnce(
+      queryResponse([
+        account({
+          Id: LENDER_ID,
+          AccountId_15__c: LENDER_ID,
+          FirstName: 'Lee',
+          LastName: 'Lender',
+          BillingStateCode: 'HI',
+          BillingAddress: { city: 'Honolulu', state: 'Hawaii' },
+          isAgent__pc: false,
+          isLender__pc: true,
+        }),
+      ]) as never,
+    );
+
+    const author = await resolveAuthor({ salesforceId: LENDER_ID });
+
+    expect(author.kind).toBe('salesforce');
+    expect(author.role).toBe('lender');
+    expect(author.contactHref).toBe(
+      `/contact-lender?form=lender&fn=Lee&id=${LENDER_ID}&state=hawaii`,
+    );
+  });
+
+  it('falls back to VeteranPCS when a Salesforce author is inactive', async () => {
+    vi.mocked(salesForceAPI).mockResolvedValueOnce(
+      queryResponse([
+        account({
+          Active_on_Website__pc: false,
+        }),
+      ]) as never,
+    );
+
+    const author = await resolveAuthor({
+      salesforceId: AGENT_ID,
+      name: 'Stale Frontmatter Name',
+    });
+
+    expect(author.kind).toBe('fallback');
+    expect(author.name).toBe('VeteranPCS');
+    expect(author.salesforceId).toBeNull();
+    expect(author.contactHref).toBe('/contact-agent');
+    expect(salesForceAPI).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to VeteranPCS when the Salesforce author is missing', async () => {
+    vi.mocked(salesForceAPI).mockResolvedValueOnce(queryResponse([]) as never);
+
+    const author = await resolveAuthor({
+      salesforceId: AGENT_ID,
+      name: 'Stale Frontmatter Name',
+    });
+
+    expect(author.kind).toBe('fallback');
+    expect(author.name).toBe('VeteranPCS');
+    expect(author.contactHref).toBe('/contact-agent');
+    expect(salesForceAPI).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a post state override when the Salesforce billing state differs', async () => {
+    vi.mocked(salesForceAPI).mockResolvedValueOnce(
+      queryResponse([
+        account({
+          Id: MARYLAND_AGENT_ID,
+          AccountId_15__c: MARYLAND_AGENT_ID,
+          FirstName: 'Mary',
+          LastName: 'Market',
+          BillingStateCode: 'VA',
+          BillingAddress: { city: 'Alexandria', state: 'Virginia' },
+        }),
+      ]) as never,
+    );
+
+    const author = await resolveAuthor({
+      salesforceId: MARYLAND_AGENT_ID,
+      stateSlug: 'maryland',
+    });
+
+    expect(author.kind).toBe('salesforce');
+    expect(author.state).toBe('VA');
+    expect(author.stateSlug).toBe('maryland');
+    expect(author.contactHref).toBe(
+      `/contact-agent?form=agent&fn=Mary&id=${MARYLAND_AGENT_ID}&state=maryland`,
+    );
+  });
+});

--- a/lib/blog/authors.ts
+++ b/lib/blog/authors.ts
@@ -6,7 +6,8 @@ import { unstable_cache } from 'next/cache';
 import { SALESFORCE_BASE_URL, SALESFORCE_API_VERSION } from '@/constants/api';
 import { RequestType, salesForceAPI } from '@/services/api';
 import { getSalesforceToken } from '@/services/salesForceTokenService';
-import { stateSlugFromAbbr } from '@/lib/states';
+import { buildContactCtaHref } from '@/lib/contactAgentUrl';
+import { normalizeStateSlug, stateSlugFromAbbr } from '@/lib/states';
 import type { FrontmatterAuthor, ResolvedAuthor } from '@/lib/blog/types';
 
 const AUTHOR_FIELDS = [
@@ -38,6 +39,43 @@ type SfAccount = {
 };
 
 const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'] as const;
+const FALLBACK_AUTHOR_NAME = 'VeteranPCS';
+
+function normalizeAuthorStateSlug(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return normalizeStateSlug(value) ?? normalizeStateSlug(value.replace(/\s+/g, '-'));
+}
+
+function frontmatterStateSlug(input: FrontmatterAuthor | undefined | null): string | null {
+  return (
+    normalizeAuthorStateSlug(input?.stateSlug) ??
+    normalizeAuthorStateSlug(input?.state)
+  );
+}
+
+function fallbackAuthor(input?: FrontmatterAuthor | null): ResolvedAuthor {
+  return {
+    kind: 'fallback',
+    salesforceId: null,
+    sourceSalesforceId: input?.salesforceId ?? null,
+    firstName: '',
+    lastName: '',
+    fullName: FALLBACK_AUTHOR_NAME,
+    name: FALLBACK_AUTHOR_NAME,
+    city: null,
+    state: null,
+    stateSlug: null,
+    militaryStatus: 'Veteran Agents',
+    brokerage: 'Solid Oak Realty',
+    headshotPath: '/logo-stacked.png',
+    contactHref: '/contact-agent',
+    isAgent: false,
+    isLender: false,
+    active: false,
+    role: 'organization',
+    matchKind: 'fallback',
+  };
+}
 
 function resolveHeadshotPath(salesforceId: string, isLender: boolean): string | null {
   const folders = isLender ? ['lenders', 'agents'] : ['agents', 'lenders'];
@@ -104,55 +142,113 @@ const fetchByName = unstable_cache(
 
 function toResolved(
   record: SfAccount,
-  matchKind: ResolvedAuthor['matchKind'],
+  matchKind: Extract<ResolvedAuthor, { kind: 'salesforce' }>['matchKind'],
+  input?: FrontmatterAuthor | null,
 ): ResolvedAuthor {
   const firstName = record.FirstName ?? '';
   const lastName = record.LastName ?? '';
   const fullName = [firstName, lastName].filter(Boolean).join(' ').trim();
   const stateAbbr = record.BillingStateCode ?? null;
   const isLender = record.isLender__pc === true;
+  const isAgent = record.isAgent__pc === true;
   const salesforceId = record.AccountId_15__c ?? record.Id;
+  const stateSlug = frontmatterStateSlug(input) ?? stateSlugFromAbbr(stateAbbr);
 
   return {
+    kind: 'salesforce',
     salesforceId,
     firstName,
     lastName,
-    fullName: fullName || 'VeteranPCS',
+    fullName: fullName || FALLBACK_AUTHOR_NAME,
+    name: fullName || FALLBACK_AUTHOR_NAME,
     city: record.BillingAddress?.city ?? null,
     state: stateAbbr,
-    stateSlug: stateSlugFromAbbr(stateAbbr),
+    stateSlug,
     militaryStatus: record.Military_Status__pc ?? null,
     brokerage: record.Brokerage_Name__pc ?? null,
     headshotPath: resolveHeadshotPath(salesforceId, isLender),
-    isAgent: record.isAgent__pc === true,
+    contactHref: buildContactCtaHref({
+      firstName,
+      salesforceId,
+      stateSlug,
+      form: isLender ? 'lender' : 'agent',
+    }),
+    isAgent,
     isLender,
-    active: record.Active_on_Website__pc !== false,
+    active: true,
+    role: isLender ? 'lender' : 'agent',
     matchKind,
   };
 }
 
+function isPublicAuthor(record: SfAccount): boolean {
+  return (
+    record.Active_on_Website__pc !== false &&
+    (record.isAgent__pc === true || record.isLender__pc === true)
+  );
+}
+
+export function isSameSalesforceId(
+  first: string | null | undefined,
+  second: string | null | undefined,
+): boolean {
+  if (!first || !second) return false;
+  return first.slice(0, 15) === second.slice(0, 15);
+}
+
+export function resolvedAuthorMatchesSalesforceId(
+  author: ResolvedAuthor | null | undefined,
+  salesforceId: string | null | undefined,
+): author is ResolvedAuthor {
+  if (!author || !salesforceId) return false;
+  const authorId = author.kind === 'fallback' ? author.sourceSalesforceId : author.salesforceId;
+  return isSameSalesforceId(authorId, salesforceId);
+}
+
+export function getAuthorContactHref(
+  author: ResolvedAuthor,
+  input?: Pick<FrontmatterAuthor, 'state' | 'stateSlug'> | null,
+): string {
+  if (author.kind === 'fallback') return author.contactHref;
+
+  return buildContactCtaHref({
+    firstName: author.firstName,
+    salesforceId: author.salesforceId,
+    stateSlug: frontmatterStateSlug(input) ?? author.stateSlug,
+    form: author.isLender ? 'lender' : 'agent',
+  });
+}
+
 export async function resolveAuthor(
   input: FrontmatterAuthor | undefined | null,
-): Promise<ResolvedAuthor | null> {
-  if (!input) return null;
+): Promise<ResolvedAuthor> {
+  if (!input) return fallbackAuthor(input);
 
   if (input.salesforceId) {
     try {
       const record = await fetchById(input.salesforceId);
-      if (record) return toResolved(record, 'salesforceId');
+      if (!record || !isPublicAuthor(record)) return fallbackAuthor(input);
+      return toResolved(record, 'salesforceId', input);
     } catch (err) {
       console.error('[resolveAuthor] by-id lookup failed:', err);
+      return fallbackAuthor(input);
     }
   }
 
   if (input.name) {
     try {
       const record = await fetchByName(input.name);
-      if (record) return toResolved(record, 'name');
+      if (record && isPublicAuthor(record)) return toResolved(record, 'name', input);
     } catch (err) {
       console.error('[resolveAuthor] by-name lookup failed:', err);
     }
   }
 
-  return null;
+  return fallbackAuthor(input);
 }
+
+export const __testables = {
+  fallbackAuthor,
+  frontmatterStateSlug,
+  isPublicAuthor,
+};

--- a/lib/blog/types.ts
+++ b/lib/blog/types.ts
@@ -34,19 +34,41 @@ export type BlogPost = BlogFrontmatter & {
   filepath: string;
 };
 
-export type ResolvedAuthor = {
-  salesforceId: string | null;
+type BaseResolvedAuthor = {
   firstName: string;
   lastName: string;
   fullName: string;
+  name: string;
   city: string | null;
   state: string | null;
   stateSlug: string | null;
   militaryStatus: string | null;
   brokerage: string | null;
   headshotPath: string | null;
+  contactHref: string;
   isAgent: boolean;
   isLender: boolean;
   active: boolean;
   matchKind: 'salesforceId' | 'name' | 'fallback';
 };
+
+export type SalesforceBlogAuthor = BaseResolvedAuthor & {
+  kind: 'salesforce';
+  salesforceId: string;
+  role: 'agent' | 'lender';
+  active: true;
+  matchKind: 'salesforceId' | 'name';
+};
+
+export type VeteranPcsBlogAuthor = BaseResolvedAuthor & {
+  kind: 'fallback';
+  salesforceId: null;
+  role: 'organization';
+  sourceSalesforceId: string | null;
+  active: false;
+  matchKind: 'fallback';
+};
+
+export type ResolvedBlogAuthor = SalesforceBlogAuthor | VeteranPcsBlogAuthor;
+
+export type ResolvedAuthor = ResolvedBlogAuthor;

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,9 +1,11 @@
 import type { MDXComponents } from 'mdx/types';
+import type { ComponentProps } from 'react';
 import Image, { type ImageProps } from 'next/image';
 import Link from 'next/link';
 import * as BlogMdx from '@/components/Blog/mdx';
 import BAHCalculator from '@/components/BAHCalculator';
 import MovingBonusCalculator from '@/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator';
+import type { ResolvedAuthor } from '@/lib/blog/types';
 
 function isExternal(href: string): boolean {
   return /^https?:\/\//i.test(href);
@@ -137,6 +139,26 @@ export const mdxComponents: MDXComponents = {
     BAHCalculator,
     MovingBonusCalculator,
 };
+
+type BlogMdxContext = {
+  resolvedAuthor?: ResolvedAuthor | null;
+};
+
+export function createBlogMdxComponents({
+  resolvedAuthor,
+}: BlogMdxContext = {}): MDXComponents {
+  return {
+    ...mdxComponents,
+    AgentCTA: (props: ComponentProps<typeof BlogMdx.AgentCTA>) => (
+      <BlogMdx.AgentCTA {...props} resolvedAuthor={resolvedAuthor} />
+    ),
+    AgentContactLink: (
+      props: ComponentProps<typeof BlogMdx.AgentContactLink>,
+    ) => (
+      <BlogMdx.AgentContactLink {...props} resolvedAuthor={resolvedAuthor} />
+    ),
+  };
+}
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return { ...mdxComponents, ...components };


### PR DESCRIPTION
## Summary
- resolve blog authors through a Salesforce-aware abstraction that falls back to VeteranPCS for missing, inactive, or unavailable records
- use the resolved author for blog hero bylines, sidebar cards, OpenGraph authors, JSON-LD, and MDX CTAs
- add AgentContactLink and migrate recent personalized contact-agent links to dynamic Salesforce-aware links

## Validation
- npm test -- lib/blog/__tests__/authors.test.ts
- npm run lint
- npm run type-check
- npm run build
- npm test
- local HTTP spot checks for Maryland, Alabama, Colorado, and Washington migrated blog posts