### PR TITLE
fix(analytics): correct PostHog identity stitching, flush, and lender symmetry

### DIFF
--- a/app/(site)/contact-agent/__tests__/actions.test.ts
+++ b/app/(site)/contact-agent/__tests__/actions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { submitContactAgentLead } from '../actions';
 import { contactAgentPostForm } from '@/services/salesForcePostFormsService';
 import { logError } from '@/services/loggingService';
+import { captureServerEvent } from '@/lib/posthog-server';
 import { ContactAgentFormData } from '@/types';
 
 vi.mock('@/services/salesForcePostFormsService', () => ({
@@ -10,6 +11,10 @@ vi.mock('@/services/salesForcePostFormsService', () => ({
 
 vi.mock('@/services/loggingService', () => ({
   logError: vi.fn(),
+}));
+
+vi.mock('@/lib/posthog-server', () => ({
+  captureServerEvent: vi.fn(),
 }));
 
 const payload: ContactAgentFormData = {
@@ -50,6 +55,24 @@ describe('submitContactAgentLead', () => {
     });
   });
 
+  it('captures the server lead event keyed to the lead email on success', async () => {
+    vi.mocked(contactAgentPostForm).mockResolvedValueOnce({
+      redirectUrl: 'https://www.veteranpcs.com/thank-you',
+    });
+
+    await submitContactAgentLead(payload, '?id=001&state=colorado');
+
+    expect(captureServerEvent).toHaveBeenCalledWith({
+      distinctId: payload.email,
+      event: 'contact_agent_lead_created',
+      properties: {
+        firstName: payload.firstName,
+        lastName: payload.lastName,
+        email: payload.email,
+      },
+    });
+  });
+
   it('returns failure when the service throws', async () => {
     vi.mocked(contactAgentPostForm).mockRejectedValueOnce(new Error('Salesforce failed'));
 
@@ -61,5 +84,6 @@ describe('submitContactAgentLead', () => {
       undefined,
       expect.any(Error),
     );
+    expect(captureServerEvent).not.toHaveBeenCalled();
   });
 });

--- a/app/(site)/contact-agent/actions.ts
+++ b/app/(site)/contact-agent/actions.ts
@@ -3,7 +3,7 @@
 import { contactAgentPostForm } from '@/services/salesForcePostFormsService';
 import { logError } from '@/services/loggingService';
 import { ContactAgentFormData } from '@/types';
-import { getPostHogClient } from '@/lib/posthog-server';
+import { captureServerEvent } from '@/lib/posthog-server';
 
 export interface ContactAgentSubmitResult {
   success: boolean;
@@ -17,23 +17,16 @@ export async function submitContactAgentLead(
   try {
     const serverResponse = await contactAgentPostForm(formData, queryString);
 
-    if (serverResponse?.redirectUrl) {
-      const posthog = getPostHogClient();
-      posthog.capture({
-        distinctId: formData.email,
-        event: 'contact_agent_lead_created',
-        properties: {
-          firstName: formData.firstName,
-          lastName: formData.lastName,
-          email: formData.email,
-        },
-      });
-      return { success: true, redirectUrl: serverResponse.redirectUrl };
-    }
+    // Salesforce signals success either with an explicit redirect or a bare
+    // success message; normalise both to a redirect target.
+    const redirectUrl = serverResponse?.redirectUrl
+      ? serverResponse.redirectUrl
+      : serverResponse?.message
+        ? '/thank-you'
+        : null;
 
-    if (serverResponse?.message) {
-      const posthog = getPostHogClient();
-      posthog.capture({
+    if (redirectUrl) {
+      await captureServerEvent({
         distinctId: formData.email,
         event: 'contact_agent_lead_created',
         properties: {
@@ -42,7 +35,7 @@ export async function submitContactAgentLead(
           email: formData.email,
         },
       });
-      return { success: true, redirectUrl: '/thank-you' };
+      return { success: true, redirectUrl };
     }
 
     logError('contact-agent action completed without a success response', {

--- a/app/(site)/contact-agent/page.tsx
+++ b/app/(site)/contact-agent/page.tsx
@@ -29,11 +29,13 @@ export default function ContactAgentPage() {
 
       const result = await submitContactAgentLead(formData, fullQueryString);
       if (result.success) {
-        posthog.identify(formData.email, {
-          firstName: formData.firstName,
-          lastName: formData.lastName,
-          email: formData.email,
-        });
+        if (formData.email) {
+          posthog.identify(formData.email, {
+            firstName: formData.firstName,
+            lastName: formData.lastName,
+            email: formData.email,
+          });
+        }
         posthog.capture("contact_agent_form_submitted", {
           state: normalizeStateSlug(queryState) || "",
           agent_id: queryParams.get("id") || "",

--- a/app/(site)/contact-lender/__tests__/actions.test.ts
+++ b/app/(site)/contact-lender/__tests__/actions.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { recordContactLenderLead } from '../actions';
+import { captureServerEvent } from '@/lib/posthog-server';
+import { ContactLenderFormData } from '@/types';
+
+vi.mock('@/lib/posthog-server', () => ({
+  captureServerEvent: vi.fn(),
+}));
+
+const payload: ContactLenderFormData = {
+  firstName: 'QA',
+  lastName: 'Lender',
+  email: 'tech+lender@veteranpcs.com',
+  phone: '8302795914',
+  currentBase: 'QA Current Base',
+  destinationBase: 'QA Destination',
+  howDidYouHear: 'Other',
+  tellusMore: 'QA test',
+};
+
+describe('recordContactLenderLead', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('captures the server lead event keyed to the lead email', async () => {
+    await recordContactLenderLead(payload);
+
+    expect(captureServerEvent).toHaveBeenCalledWith({
+      distinctId: payload.email,
+      event: 'contact_lender_lead_created',
+      properties: {
+        firstName: payload.firstName,
+        lastName: payload.lastName,
+        email: payload.email,
+      },
+    });
+  });
+
+  it('skips capture when there is no email to key the person on', async () => {
+    await recordContactLenderLead({ ...payload, email: undefined });
+
+    expect(captureServerEvent).not.toHaveBeenCalled();
+  });
+});

--- a/app/(site)/contact-lender/actions.ts
+++ b/app/(site)/contact-lender/actions.ts
@@ -1,0 +1,28 @@
+'use server';
+
+import { ContactLenderFormData } from '@/types';
+import { captureServerEvent } from '@/lib/posthog-server';
+
+/**
+ * Record the server-side `contact_lender_lead_created` event, mirroring the
+ * agent flow's `contact_agent_lead_created` so both lead paths have a
+ * server-confirmed, ad-blocker-resilient conversion event in PostHog.
+ *
+ * Deliberately analytics-only: the lender Salesforce POST stays client-side in
+ * `contactLenderPostForm` (page.tsx). Moving it here would change where the
+ * Salesforce call originates, which is out of scope for an analytics fix.
+ */
+export async function recordContactLenderLead(
+  formData: ContactLenderFormData,
+): Promise<void> {
+  if (!formData.email) return;
+  await captureServerEvent({
+    distinctId: formData.email,
+    event: 'contact_lender_lead_created',
+    properties: {
+      firstName: formData.firstName,
+      lastName: formData.lastName,
+      email: formData.email,
+    },
+  });
+}

--- a/app/(site)/contact-lender/page.tsx
+++ b/app/(site)/contact-lender/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import posthog from "posthog-js";
 import ContactLender from "@/components/ContactLender/ContactLender";
 import { contactLenderPostForm } from "@/services/salesForcePostFormsService";
+import { recordContactLenderLead } from "./actions";
 import { useRouter } from 'next/navigation'
 import { sendGTMEvent } from "@next/third-parties/google";
 import { normalizeStateCode, normalizeStateSlug } from "@/lib/states";
@@ -47,6 +48,9 @@ export default function ContactLenderPage() {
           state: normalizeStateSlug(queryParams.get('state')) || "",
           lender_id: queryParams.get('id') || "",
         });
+        // Server-confirmed, ad-blocker-resilient conversion event (mirrors the
+        // agent flow). Awaited so the event flushes before we navigate away.
+        await recordContactLenderLead(formData);
         router.push(server_response.redirectUrl);
         return { success: true, redirectUrl: server_response.redirectUrl };
       }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -14,7 +14,7 @@ import { buildBlockedResponse } from '@/lib/ai/guardrails/responses';
 import { addSessionTokens } from '@/lib/ai/guardrails/budget';
 import { guardrailsEnforced, REFUSAL_MESSAGE } from '@/lib/ai/guardrails/config';
 import { logError } from '@/services/loggingService';
-import { getPostHogClient } from '@/lib/posthog-server';
+import { captureServerEvent } from '@/lib/posthog-server';
 import {
   deployedConciergeRequiresUpstash,
   missingUpstashEnvVars,
@@ -67,6 +67,13 @@ export async function POST(req: Request) {
   }
 
   const { sessionId } = await getOrCreateSessionId();
+
+  // Stitch the server event to the same PostHog person as the client. The widget
+  // forwards posthog-js's distinct_id (anonymous, or the lead's email once a form
+  // calls identify()) in this header; fall back to the concierge session id when
+  // the client couldn't read one so the event still lands somewhere consistent.
+  const posthogDistinctId =
+    req.headers.get('x-posthog-distinct-id')?.trim() || sessionId;
 
   const limit = await chatLimiter.limit(sessionId);
   if (!limit.success) {
@@ -132,9 +139,8 @@ export async function POST(req: Request) {
       onFinish: async ({ usage, totalUsage }) => {
         const tokens = totalUsage?.totalTokens ?? usage?.totalTokens ?? 0;
         await addSessionTokens(sessionId, tokens);
-        const phog = getPostHogClient();
-        phog.capture({
-          distinctId: sessionId,
+        await captureServerEvent({
+          distinctId: posthogDistinctId,
           event: 'concierge_chat_completed',
           properties: { tokens_used: tokens },
         });

--- a/components/Concierge/ConciergeWidget.tsx
+++ b/components/Concierge/ConciergeWidget.tsx
@@ -116,7 +116,17 @@ export default function ConciergeWidget() {
       new DefaultChatTransport({
         api: '/api/chat',
         prepareSendMessagesRequest({ messages, id, trigger, messageId }) {
+          // Forward posthog-js's distinct_id so the server `concierge_chat_completed`
+          // event stitches to the same person as the client events and any form
+          // identify(). Guarded because posthog may be uninitialised (flag/env off).
+          let distinctId: string | undefined;
+          try {
+            distinctId = posthog.get_distinct_id?.();
+          } catch {
+            distinctId = undefined;
+          }
           return {
+            headers: distinctId ? { 'x-posthog-distinct-id': distinctId } : undefined,
             body: {
               id,
               trigger,

--- a/lib/posthog-server.ts
+++ b/lib/posthog-server.ts
@@ -12,3 +12,28 @@ export function getPostHogClient(): PostHog {
   }
   return posthogClient;
 }
+
+interface ServerEvent {
+  distinctId: string;
+  event: string;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * Capture a server-side event and wait for it to reach PostHog before returning.
+ *
+ * On Vercel Fluid Compute the function instance can freeze the moment a response
+ * is sent, dropping anything still buffered in posthog-node. `flushAt: 1` triggers
+ * a flush per event but does not give the caller a promise to await, so we flush
+ * explicitly. Failures are swallowed: analytics is best-effort and must never break
+ * a lead submission or a concierge response.
+ */
+export async function captureServerEvent({ distinctId, event, properties }: ServerEvent): Promise<void> {
+  try {
+    const client = getPostHogClient();
+    client.capture({ distinctId, event, properties });
+    await client.flush();
+  } catch {
+    // best-effort: never surface analytics errors to the caller
+  }
+}


### PR DESCRIPTION
## What

Four correctness fixes to the PostHog wiring added in `210371d`. **No Salesforce payload, field mapping, or required-state behavior changes** — analytics-only.

| # | Bug | Fix |
|---|-----|-----|
| 1 | Concierge server event `concierge_chat_completed` keyed to the concierge session UUID — never joins the client's posthog-js `distinct_id` (or the email set via `identify()`) | Widget forwards posthog-js's `distinct_id` in an `x-posthog-distinct-id` header; the chat route captures with it (falls back to `sessionId`) |
| 2 | Server `capture()` calls not awaited/flushed — droppable on Vercel Fluid Compute freeze; `flushAt: 1` is only a partial mitigation | New `captureServerEvent()` helper does `capture()` then `await flush()`; used in the chat route and the contact-agent action |
| 3 | contact-agent called `posthog.identify()` even with an empty email (junk profile) | Guarded with `if (formData.email)`, matching the lender/keep-in-touch flows |
| 4 | contact-lender had a client event only (asymmetric vs contact-agent's server-confirmed event) | New thin `recordContactLenderLead` server action emits `contact_lender_lead_created`. **The lender Salesforce POST stays client-side** — only analytics is added server-side, so the lead path is untouched |

## Deliberately *not* changed

- **No `posthog.reset()`.** This is a no-logout marketing site; a site-wide reset would stop recognizing genuine returning visitors (a core PostHog value) to defend against the rare shared-kiosk case. Decision: keep current behavior. (Reset belongs on specific kiosk surfaces only, if ever.)
- **Event names unchanged.** Renaming toward the documented GA4-plan taxonomy is a separate follow-up (the "reconcile event names" item), tracked outside this PR.

## Tests / verification

- `captureServerEvent()` helper centralizes capture+flush.
- contact-agent action test now mocks `posthog-server` and asserts the server capture fires (and does **not** fire on failure).
- Added a contact-lender action test (`recordContactLenderLead`).
- ✅ type-check clean, ✅ lint clean, ✅ build succeeds, ✅ all 6 new/updated tests pass.
- Note: the full suite shows 1 failure in `services/__tests__/salesforceLeadOwnerService.test.ts` — confirmed **pre-existing and unrelated** (fails identically on a clean tree in the parallel run, passes in isolation on both trees). Order/timing flake, not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)