### PR TITLE
[codex] Harden telemetry coverage

### DIFF
--- a/app/(site)/[state]/page.tsx
+++ b/app/(site)/[state]/page.tsx
@@ -173,6 +173,8 @@ export default async function StatePage(props: { params: Promise<{ state: string
         stateName={state_data?.state_name || 'Unknown'}
         stateImage={state_data?.state_map}
         cityList={Object.keys(formatted_data).sort()}
+        stateSlug={state}
+        stateCode={state_code}
       />
       <StatePageHeroSecondSection
         stateName={state_data?.state_name || 'Unknown'}
@@ -184,13 +186,15 @@ export default async function StatePage(props: { params: Promise<{ state: string
       <StatePageRelatedGuides
         stateName={stateName}
         guides={guidePosts}
+        stateSlug={state}
+        stateCode={state_code}
       />
 
       {Object.entries(formatted_data).sort().map(([cityName, agents]: [string, any[]]) => (
         <StatePageCityAgents key={cityName} city={cityName} agent_data={agents} state={state} />
       ))}
 
-      <StatePageLetFindAgent />
+      <StatePageLetFindAgent stateSlug={state} stateCode={state_code} />
       <StatePageWhyChooseVetpcs cityName={state_data?.state_name || 'Unknown'} />
       <FrequentlyAskedQuestion />
       <KeepInTouch />

--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -29,6 +29,7 @@ import { formatDate } from "@/utils/helper";
 import { buildBreadcrumbList } from "@/lib/structured-data";
 import { SITE_URL } from "@/lib/siteUrl";
 import { buildContactCtaHref } from "@/lib/contactAgentUrl";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const BASE_URL = SITE_URL;
 
@@ -209,12 +210,25 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
             <FrequentlyAskedQuestion />
             <KeepInTouch />
             <div className="fixed inset-x-0 bottom-0 z-40 border-t border-[#E5E7EB] bg-white/95 px-5 py-3 shadow-lg md:hidden">
-                <Link
+                <TrackedCtaLink
                     href={contactHref}
                     className="block min-h-11 rounded-custom bg-[#a81f23] px-5 py-3 text-center text-sm font-bold text-white"
+                    cta={{
+                        ctaId: 'blog_mobile_sticky_agent',
+                        ctaIntent: 'contact_agent',
+                        ctaPosition: 'mobile_sticky_footer',
+                        ctaComponent: 'blog_mobile_sticky_cta',
+                        ctaLabel,
+                        destination: contactHref,
+                        pageType: 'blog_post',
+                        stateSlug: bridgeState,
+                        contentSlug: slug,
+                        contentType: 'blog_post',
+                        partnerType: 'agent',
+                    }}
                 >
                     {ctaLabel}
-                </Link>
+                </TrackedCtaLink>
             </div>
         </>
     );

--- a/app/(site)/blog/category/[category]/CategoryBlogPage.tsx
+++ b/app/(site)/blog/category/[category]/CategoryBlogPage.tsx
@@ -7,6 +7,7 @@ import { BLOG_COMPONENTS, getBlogComponentBySlug } from '@/lib/blog/components';
 import { BLOG_CATEGORY_PAGE_SIZE, getBlogsByComponentSlug, pageCount, paginateBlogs } from '@/lib/blog/mdx';
 import { SITE_URL } from '@/lib/siteUrl';
 import { buildBreadcrumbList } from '@/lib/structured-data';
+import TrackedCtaLink from '@/components/common/TrackedCtaLink';
 
 type Props = {
   category: string;
@@ -68,9 +69,23 @@ export async function CategoryBlogPage({ category, page = 1 }: Props) {
               <p className="text-[#6C757D] roboto text-sm">
                 {posts.length} guides{totalPages > 1 ? `, page ${page} of ${totalPages}` : ''}
               </p>
-              <Link href="/contact-agent" className="rounded-custom bg-[#a81f23] px-5 py-3 text-sm font-bold text-white">
+              <TrackedCtaLink
+                href="/contact-agent"
+                className="rounded-custom bg-[#a81f23] px-5 py-3 text-sm font-bold text-white"
+                cta={{
+                  ctaId: 'blog_category_find_agent',
+                  ctaIntent: 'contact_agent',
+                  ctaPosition: 'blog_category_header',
+                  ctaComponent: 'blog_category_page',
+                  ctaLabel: 'Find an Agent',
+                  destination: '/contact-agent',
+                  pageType: 'blog_category',
+                  contentType: 'blog_category',
+                  partnerType: 'agent',
+                }}
+              >
                 Find an Agent
-              </Link>
+              </TrackedCtaLink>
             </div>
             <div className="grid grid-cols-1 gap-6 md:grid-cols-3 lg:grid-cols-4">
               {pagePosts.map((post) => (

--- a/app/(site)/contact-lender/__tests__/actions.test.ts
+++ b/app/(site)/contact-lender/__tests__/actions.test.ts
@@ -1,6 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { recordContactLenderLead } from '../actions';
+import { recordContactLenderLead, submitContactLenderLead } from '../actions';
+import { contactLenderPostForm } from '@/services/salesForcePostFormsService';
+import { logError } from '@/services/loggingService';
 import { ContactLenderFormData } from '@/types';
+
+vi.mock('@/services/salesForcePostFormsService', () => ({
+  contactLenderPostForm: vi.fn(),
+}));
+
+vi.mock('@/services/loggingService', () => ({
+  logError: vi.fn(),
+}));
 
 const payload: ContactLenderFormData = {
   firstName: 'QA',
@@ -24,5 +34,49 @@ describe('recordContactLenderLead', () => {
 
   it('does not require an email because it emits no analytics', async () => {
     await expect(recordContactLenderLead({ ...payload, email: undefined })).resolves.toBeUndefined();
+  });
+});
+
+describe('submitContactLenderLead', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves a Salesforce redirect URL', async () => {
+    vi.mocked(contactLenderPostForm).mockResolvedValueOnce({
+      redirectUrl: 'https://www.veteranpcs.com/thank-you',
+      submissionId: 'submission-test-id',
+    });
+
+    await expect(submitContactLenderLead(payload, '?id=001&state=colorado')).resolves.toEqual({
+      success: true,
+      redirectUrl: 'https://www.veteranpcs.com/thank-you',
+    });
+    expect(contactLenderPostForm).toHaveBeenCalledWith(payload, '?id=001&state=colorado');
+  });
+
+  it('normalizes message-only success to the thank-you route', async () => {
+    vi.mocked(contactLenderPostForm).mockResolvedValueOnce({
+      message: 'Form submitted successfully!',
+      submissionId: 'submission-test-id',
+    });
+
+    await expect(submitContactLenderLead(payload, '?id=001&state=colorado')).resolves.toEqual({
+      success: true,
+      redirectUrl: '/thank-you',
+    });
+  });
+
+  it('returns failure when the service throws', async () => {
+    vi.mocked(contactLenderPostForm).mockRejectedValueOnce(new Error('Salesforce failed'));
+
+    await expect(submitContactLenderLead(payload, '?id=001&state=colorado')).resolves.toEqual({
+      success: false,
+    });
+    expect(logError).toHaveBeenCalledWith(
+      'contact-lender action failed',
+      undefined,
+      expect.any(Error),
+    );
   });
 });

--- a/app/(site)/contact-lender/actions.ts
+++ b/app/(site)/contact-lender/actions.ts
@@ -1,6 +1,39 @@
 'use server';
 
+import { contactLenderPostForm } from '@/services/salesForcePostFormsService';
+import { logError } from '@/services/loggingService';
 import { ContactLenderFormData } from '@/types';
+
+export interface ContactLenderSubmitResult {
+  success: boolean;
+  redirectUrl?: string;
+}
+
+export async function submitContactLenderLead(
+  formData: ContactLenderFormData,
+  queryString: string,
+): Promise<ContactLenderSubmitResult> {
+  try {
+    const serverResponse = await contactLenderPostForm(formData, queryString);
+    const redirectUrl = serverResponse?.redirectUrl
+      ? serverResponse.redirectUrl
+      : serverResponse?.message
+        ? '/thank-you'
+        : null;
+
+    if (redirectUrl) {
+      return { success: true, redirectUrl };
+    }
+
+    logError('contact-lender action completed without a success response', {
+      hasServerResponse: !!serverResponse,
+    });
+    return { success: false };
+  } catch (error) {
+    logError('contact-lender action failed', undefined, error);
+    return { success: false };
+  }
+}
 
 /**
  * Compatibility no-op.

--- a/app/(site)/contact-lender/page.tsx
+++ b/app/(site)/contact-lender/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import ContactLender from "@/components/ContactLender/ContactLender";
-import { contactLenderPostForm } from "@/services/salesForcePostFormsService";
+import { submitContactLenderLead } from "./actions";
 import { useRouter } from 'next/navigation'
 import { sendGTMEvent } from "@next/third-parties/google";
 import { normalizeStateCode, normalizeStateSlug } from "@/lib/states";
@@ -28,21 +28,14 @@ export default function ContactLenderPage() {
         state: normalizeStateSlug(queryParams.get('state')) || "",
       });
 
-      // Enhanced contactLenderPostForm now includes:
-      // - Automatic retry logic (up to 3 attempts)
-      // - Better Salesforce response validation
-      // - Exponential backoff between retries
-      // - Proper error handling and logging
-      const server_response = await contactLenderPostForm(
+      const result = await submitContactLenderLead(
         { ...formData, ...formTrackingPayload() },
         fullQueryString,
       );
-      // Only proceed to thank-you when Salesforce returned a redirect; otherwise treat as a failed submission.
-      if (server_response?.redirectUrl) {
-        router.push(server_response.redirectUrl);
-        return { success: true, redirectUrl: server_response.redirectUrl };
+      if (result.redirectUrl) {
+        router.push(result.redirectUrl);
       }
-      return { success: false };
+      return result;
     } catch (error) {
       console.error('Error submitting form:', error);
       return { success: false };

--- a/components/About/HowVetPcsStarted/HowVetPcsStarted.tsx
+++ b/components/About/HowVetPcsStarted/HowVetPcsStarted.tsx
@@ -3,7 +3,7 @@ import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import Image from "next/image";
 import aboutService from "@/services/aboutService";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 interface ImageAsset {
   image_url?: string;
@@ -66,11 +66,23 @@ const HowVetPcsStarted = async () => {
                 </p>
               ))}
             </div>
-            <Link href="/how-it-works" className="flex justify-center">
+            <TrackedCtaLink
+              href="/how-it-works"
+              className="flex justify-center"
+              cta={{
+                ctaId: 'about_how_started_how_it_works',
+                ctaIntent: 'how_it_works_navigation',
+                ctaPosition: 'about_how_started',
+                ctaComponent: 'how_vetpcs_started',
+                ctaLabel: pageData.buttonText || 'How It Works',
+                destination: '/how-it-works',
+                pageType: 'about',
+              }}
+            >
               <Button
                 buttonText={pageData.buttonText || "Default Button"}
               />
-            </Link>
+            </TrackedCtaLink>
           </div>
         </div>
       </div>

--- a/components/About/Support/SupportOurVeterans.tsx
+++ b/components/About/Support/SupportOurVeterans.tsx
@@ -4,7 +4,7 @@ import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import Image from "next/image";
 import aboutService from "@/services/aboutService";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 interface ImageAsset {
     image_url?: string;
 }
@@ -59,11 +59,23 @@ const SupportOurVeterans = async () => {
                                         </p>
                                     </div>
                                     <div className="flex justify-start">
-                                        <Link href="/contact-agent">
+                                        <TrackedCtaLink
+                                            href="/contact-agent"
+                                            cta={{
+                                                ctaId: 'about_support_agent',
+                                                ctaIntent: 'contact_agent',
+                                                ctaPosition: 'about_support',
+                                                ctaComponent: 'support_our_veterans',
+                                                ctaLabel: pageData?.buttonText_1 || 'Contact Agent',
+                                                destination: '/contact-agent',
+                                                pageType: 'about',
+                                                partnerType: 'agent',
+                                            }}
+                                        >
                                             <Button
                                                 buttonText={pageData?.buttonText_1 || "Default Button"}
                                             />
-                                        </Link>
+                                        </TrackedCtaLink>
                                     </div>
                                 </div>
                                 <div>
@@ -91,14 +103,23 @@ const SupportOurVeterans = async () => {
                                             {pageData?.description_2}
                                         </p>
                                     </div>
-                                    <Link
+                                    <TrackedCtaLink
                                         href="/impact"
                                         className="flex lg:justify-start md:justify-start sm:justify-start justify-start items-center"
+                                        cta={{
+                                            ctaId: 'about_support_impact',
+                                            ctaIntent: 'impact_navigation',
+                                            ctaPosition: 'about_support',
+                                            ctaComponent: 'support_our_veterans',
+                                            ctaLabel: pageData?.buttonText_2 || 'Impact',
+                                            destination: '/impact',
+                                            pageType: 'about',
+                                        }}
                                     >
                                         <Button
                                             buttonText={pageData?.buttonText_2 || "Default Button"}
                                         />
-                                    </Link>
+                                    </TrackedCtaLink>
                                 </div>
                             </div>
                         </div>

--- a/components/About/aboutherosection/AboutHeroSection.tsx
+++ b/components/About/aboutherosection/AboutHeroSection.tsx
@@ -5,7 +5,7 @@ import classes from "./AboutHeroSection.module.css";
 import Image from "next/image";
 import aboutService from "@/services/aboutService";
 import { AboutVetPcsResponse } from '@/components/About/HowVetPcsStarted/HowVetPcsStarted'
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const AboutHeroSection = async () => {
   let pageData: AboutVetPcsResponse | null = null;
@@ -36,9 +36,20 @@ const AboutHeroSection = async () => {
                   This is military families, helping military families move.
                 </p>
                 <div>
-                  <Link href="/#state-map">
+                  <TrackedCtaLink
+                    href="/#state-map"
+                    cta={{
+                      ctaId: 'about_hero_state_map',
+                      ctaIntent: 'state_map',
+                      ctaPosition: 'about_hero',
+                      ctaComponent: 'about_hero',
+                      ctaLabel: pageData?.buttonText || 'Find an Agent',
+                      destination: '/#state-map',
+                      pageType: 'about',
+                    }}
+                  >
                     <Button buttonText={pageData?.buttonText || "default button"} />
-                  </Link>
+                  </TrackedCtaLink>
                 </div>
                 <div className="absolute bottom-[-15%] xl:left-[41%]  lg:left-[35%] md:left-[35%] sm:left-[26%] left-[26%] translate-[-45%] ">
                   <Image

--- a/components/BAHCalculator.tsx
+++ b/components/BAHCalculator.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { sendGTMEvent } from "@next/third-parties/google";
 import { captureAnalyticsEvent } from '@/lib/analytics/client';
 import { zipPrefix } from '@/lib/analytics/sanitizer';
+import { buildCtaProperties } from '@/lib/analytics/cta';
 
 interface FormData {
     zipCode: string;
@@ -344,7 +345,22 @@ export default function BAHCalculator() {
                             </div>
 
                             <div className="mt-6">
-                                <Link href="/contact-lender" className="w-full bg-blue-800 text-white py-3 px-6 rounded-lg hover:bg-blue-900 transition-colors font-semibold text-sm">
+                                <Link
+                                    href="/contact-lender"
+                                    className="w-full bg-blue-800 text-white py-3 px-6 rounded-lg hover:bg-blue-900 transition-colors font-semibold text-sm"
+                                    onClick={() => captureAnalyticsEvent('calculator_cta_clicked', buildCtaProperties({
+                                        ctaId: 'bah_result_lender_cta',
+                                        ctaIntent: 'contact_lender',
+                                        ctaPosition: 'bah_result',
+                                        ctaComponent: 'bah_calculator',
+                                        ctaLabel: 'Questions about VA Loan?',
+                                        destination: '/contact-lender',
+                                        pageType: 'calculator',
+                                        calculatorId: 'bah_calculator',
+                                        calculatorName: 'BAH Calculator',
+                                        partnerType: 'lender',
+                                    }))}
+                                >
                                     Questions about VA Loan?
                                 </Link>
                             </div>

--- a/components/Blog/AuthorByline.tsx
+++ b/components/Blog/AuthorByline.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image';
-import Link from 'next/link';
 import Button from '@/components/common/Button';
 import { getAuthorContactHref, resolveAuthor } from '@/lib/blog/authors';
 import type { FrontmatterAuthor, ResolvedAuthor } from '@/lib/blog/types';
+import TrackedCtaLink from '@/components/common/TrackedCtaLink';
 
 const VPCS_FALLBACK = {
   logo: '/logo-stacked.png',
@@ -66,9 +66,22 @@ export default async function AuthorByline({
           <b className="text-[#495057]">{VPCS_FALLBACK.brokerage}</b>
         </p>
         <div className="w-full flex justify-center mt-4">
-          <Link href={author.contactHref}>
+          <TrackedCtaLink
+            href={author.contactHref}
+            cta={{
+              ctaId: 'blog_author_fallback_contact',
+              ctaIntent: 'contact_agent',
+              ctaPosition: 'author_card',
+              ctaComponent: 'blog_author_byline',
+              ctaLabel: 'Get in Touch',
+              destination: author.contactHref,
+              pageType: 'blog_post',
+              stateSlug: ctaStateSlug,
+              partnerType: 'agent',
+            }}
+          >
             <Button buttonText="Get in Touch" />
-          </Link>
+          </TrackedCtaLink>
         </div>
       </div>
     );
@@ -131,9 +144,23 @@ export default async function AuthorByline({
         ) : null}
       </p>
       <div className="w-full flex justify-center mt-4">
-        <Link href={ctaHref}>
+        <TrackedCtaLink
+          href={ctaHref}
+          cta={{
+            ctaId: 'blog_author_contact',
+            ctaIntent: 'contact_agent',
+            ctaPosition: 'author_card',
+            ctaComponent: 'blog_author_byline',
+            ctaLabel: 'Get in Touch',
+            destination: ctaHref,
+            pageType: 'blog_post',
+            stateSlug: ctaStateSlug ?? frontmatterAuthor?.stateSlug,
+            partnerType: 'agent',
+            partnerSalesforceId: author.salesforceId,
+          }}
+        >
           <Button buttonText="Get in Touch" />
-        </Link>
+        </TrackedCtaLink>
       </div>
     </div>
   );

--- a/components/Blog/mdx/AgentContactLink.tsx
+++ b/components/Blog/mdx/AgentContactLink.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import Link from 'next/link';
+import TrackedCtaLink from '@/components/common/TrackedCtaLink';
 import {
   getAuthorContactHref,
   resolveAuthor,
@@ -32,8 +32,23 @@ export default async function AgentContactLink({
   const href = getAuthorContactHref(author, authorInput);
 
   return (
-    <Link href={href} className="text-[#A81F23] underline hover:text-[#871B1C]">
+    <TrackedCtaLink
+      href={href}
+      className="text-[#A81F23] underline hover:text-[#871B1C]"
+      cta={{
+        ctaId: 'blog_mdx_agent_contact',
+        ctaIntent: 'contact_agent',
+        ctaPosition: 'mdx_body',
+        ctaComponent: 'blog_mdx_agent_contact_link',
+        ctaLabel: 'Agent contact link',
+        destination: href,
+        pageType: 'blog_post',
+        stateSlug,
+        partnerType: 'agent',
+        partnerSalesforceId: salesforceId,
+      }}
+    >
       {children}
-    </Link>
+    </TrackedCtaLink>
   );
 }

--- a/components/Blog/mdx/PromoCard.tsx
+++ b/components/Blog/mdx/PromoCard.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
-import Link from 'next/link';
 import Button from '@/components/common/Button';
+import TrackedCtaLink from '@/components/common/TrackedCtaLink';
 
 type Props = {
   headline: string;
@@ -36,9 +36,20 @@ export default function PromoCard({
       ) : null}
       <div className="flex-1 text-center md:text-left">
         <h3 className="tahoma text-xl font-bold text-[#212529] mb-3">{headline}</h3>
-        <Link href={href}>
+        <TrackedCtaLink
+          href={href}
+          cta={{
+            ctaId: 'blog_mdx_promo_card',
+            ctaIntent: 'content_or_offer_navigation',
+            ctaPosition: 'mdx_body',
+            ctaComponent: 'blog_mdx_promo_card',
+            ctaLabel: cta,
+            destination: href,
+            pageType: 'blog_post',
+          }}
+        >
           <Button buttonText={cta} divClassName="!py-0" />
-        </Link>
+        </TrackedCtaLink>
       </div>
     </div>
   );

--- a/components/BlogDetails/BlogDetailsCta/BlogDetailsCta.tsx
+++ b/components/BlogDetails/BlogDetailsCta/BlogDetailsCta.tsx
@@ -1,7 +1,7 @@
 import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import classes from "./BlogDetailsCta.module.css";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const BlogDetailsCta = () => {
   return (
@@ -15,9 +15,21 @@ const BlogDetailsCta = () => {
               </h2>
             </div>
             <div>
-              <Link href="/contact-agent">
+              <TrackedCtaLink
+                href="/contact-agent"
+                cta={{
+                  ctaId: 'blog_details_find_agent',
+                  ctaIntent: 'contact_agent',
+                  ctaPosition: 'blog_details_cta_band',
+                  ctaComponent: 'blog_details_cta',
+                  ctaLabel: 'Find An Agent',
+                  destination: '/contact-agent',
+                  pageType: 'blog_post',
+                  partnerType: 'agent',
+                }}
+              >
                 <Button buttonText="Find An Agent" />
-              </Link>
+              </TrackedCtaLink>
             </div>
             <div>
               <h2 className="text-[#FFFFFF] tahoma lg:text-[40px] md:text-[40px] sm:text-[30px] text-[30px] font-bold">
@@ -25,9 +37,21 @@ const BlogDetailsCta = () => {
               </h2>
             </div>
             <div>
-              <Link href="/contact-lender">
+              <TrackedCtaLink
+                href="/contact-lender"
+                cta={{
+                  ctaId: 'blog_details_find_lender',
+                  ctaIntent: 'contact_lender',
+                  ctaPosition: 'blog_details_cta_band',
+                  ctaComponent: 'blog_details_cta',
+                  ctaLabel: 'Find A Lender',
+                  destination: '/contact-lender',
+                  pageType: 'blog_post',
+                  partnerType: 'lender',
+                }}
+              >
                 <Button buttonText="Find A Lender" />
-              </Link>
+              </TrackedCtaLink>
             </div>
           </div>
         </div>

--- a/components/BlogPage/BlogPage/BlogCTA/BlogCta.tsx
+++ b/components/BlogPage/BlogPage/BlogCTA/BlogCta.tsx
@@ -4,7 +4,7 @@ import "@/app/globals.css";
 import classes from "./BlogCts.module.css";
 import Button from "@/components/common/Button";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const StatePageHeroSecondSection = () => {
     return (
@@ -15,15 +15,37 @@ const StatePageHeroSecondSection = () => {
                         <div>
                             <h2 className="text-[#FFFFFF] tahoma lg:text-[40px] md:text-[40px] sm:text-[30px] text-[30px] font-bold">Buying Or Selling</h2>
                         </div>
-                        <Link href="/#state-map">
+                        <TrackedCtaLink
+                            href="/#state-map"
+                            cta={{
+                                ctaId: 'blog_landing_agent_cta',
+                                ctaIntent: 'state_map',
+                                ctaPosition: 'blog_landing_cta_band',
+                                ctaComponent: 'blog_cta_band',
+                                ctaLabel: 'Find An Agent',
+                                destination: '/#state-map',
+                                pageType: 'blog_landing',
+                            }}
+                        >
                             <Button buttonText="Find An Agent" />
-                        </Link>
+                        </TrackedCtaLink>
                         <div>
                             <h2 className="text-[#FFFFFF] tahoma lg:text-[40px] md:text-[40px] sm:text-[30px] text-[30px] font-bold">VA Loan Expert</h2>
                         </div>
-                        <Link href="/#state-map">
+                        <TrackedCtaLink
+                            href="/#state-map"
+                            cta={{
+                                ctaId: 'blog_landing_lender_cta',
+                                ctaIntent: 'state_map',
+                                ctaPosition: 'blog_landing_cta_band',
+                                ctaComponent: 'blog_cta_band',
+                                ctaLabel: 'Find A Lender',
+                                destination: '/#state-map',
+                                pageType: 'blog_landing',
+                            }}
+                        >
                             <Button buttonText="Find A Lender" />
-                        </Link>
+                        </TrackedCtaLink>
                     </div>
                     <div>
                         <div>

--- a/components/BlogPage/BlogPage/BlogMovingPcsingBlogPostSection/BlogCategory.tsx
+++ b/components/BlogPage/BlogPage/BlogMovingPcsingBlogPostSection/BlogCategory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 import { normalizeBlogComponentSlug } from "@/lib/blog/components";
 
 const BlogCategory = ({ categories_list }: { categories_list: Set<string> }) => {
@@ -9,9 +9,23 @@ const BlogCategory = ({ categories_list }: { categories_list: Set<string> }) => 
                 {Array.from(categories_list).map((category) => {
                     const slug = normalizeBlogComponentSlug(category);
                     return (
-                    <Link key={category} href={slug ? `/blog/category/${slug}` : "/blog"} className="text-[#292F6C] robot text-sm font-normal">
+                    <TrackedCtaLink
+                        key={category}
+                        href={slug ? `/blog/category/${slug}` : "/blog"}
+                        className="text-[#292F6C] robot text-sm font-normal"
+                        cta={{
+                            ctaId: 'blog_category_filter',
+                            ctaIntent: 'content_navigation',
+                            ctaPosition: 'blog_category_filter',
+                            ctaComponent: 'blog_category_links',
+                            ctaLabel: category,
+                            destination: slug ? `/blog/category/${slug}` : "/blog",
+                            pageType: 'blog_landing',
+                            contentType: 'blog_category',
+                        }}
+                    >
                         {category}
-                    </Link>
+                    </TrackedCtaLink>
                     );
                 })}
         </div>

--- a/components/BlogPage/BlogPage/BlogMovingPcsingBlogPostSection/BlogMovingPcsingBlogPostSection.tsx
+++ b/components/BlogPage/BlogPage/BlogMovingPcsingBlogPostSection/BlogMovingPcsingBlogPostSection.tsx
@@ -2,9 +2,9 @@ import "@/app/globals.css";
 import BlogMovingPcsingPost from "@/components/BlogPage/BlogPage/BlogMovingPcsingBlogPostSection/BlogMovingPcsingPost";
 import BlogCategory from "@/components/BlogPage/BlogPage/BlogMovingPcsingBlogPostSection/BlogCategory";
 import type { BlogPost } from "@/lib/blog/types";
-import Link from "next/link";
 import BlogSearchForm from "@/components/BlogPage/BlogSearchForm";
 import { normalizeBlogComponentSlug } from "@/lib/blog/components";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 type Props = {
   blogList: BlogPost[];
@@ -44,9 +44,22 @@ export default async function BlogMovingPcsingBlogPostSection({
           ))}
         </div>
         <div className="flex justify-end mt-5 sm:hidden ">
-          <Link href={categoryHref} className="text-[#292F6C] robot text-sm font-bold ">
+          <TrackedCtaLink
+            href={categoryHref}
+            className="text-[#292F6C] robot text-sm font-bold "
+            cta={{
+              ctaId: 'blog_section_view_all',
+              ctaIntent: 'content_navigation',
+              ctaPosition: 'blog_section_footer',
+              ctaComponent: 'blog_section',
+              ctaLabel: 'View All',
+              destination: categoryHref,
+              pageType: 'blog_landing',
+              contentType: 'blog_category',
+            }}
+          >
             View All
-          </Link>
+          </TrackedCtaLink>
         </div>
       </div>
     </div>

--- a/components/BlogPage/BlogPage/BlogMovingPcsingBlogPostSection/BlogMovingPcsingPost.tsx
+++ b/components/BlogPage/BlogPage/BlogMovingPcsingBlogPostSection/BlogMovingPcsingPost.tsx
@@ -1,10 +1,10 @@
 import "@/app/globals.css";
 import Image from "next/image";
-import Link from "next/link";
 import AuthorByline from "@/components/Blog/AuthorByline";
 import { formatDate } from "@/utils/helper";
 import { excerpt } from "@/lib/blog/mdx";
 import type { BlogPost } from "@/lib/blog/types";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 type Props = { blogDetails: BlogPost };
 
@@ -12,7 +12,21 @@ export default function BlogMovingPcsingPost({ blogDetails }: Props) {
   const heroSrc = blogDetails.mainImage?.src ?? "/assets/BlogpostImage.png";
   const heroAlt = blogDetails.mainImage?.alt ?? "Blog post image";
   return (
-    <Link href={`/blog/${blogDetails.slug}`} className="pt-12 md:px-0 px-5">
+    <TrackedCtaLink
+      href={`/blog/${blogDetails.slug}`}
+      className="pt-12 md:px-0 px-5"
+      cta={{
+        ctaId: 'blog_article_card',
+        ctaIntent: 'content_navigation',
+        ctaPosition: 'blog_article_grid',
+        ctaComponent: 'blog_article_card',
+        ctaLabel: 'Read guide',
+        destination: `/blog/${blogDetails.slug}`,
+        pageType: 'blog_landing',
+        contentSlug: blogDetails.slug,
+        contentType: 'blog_post',
+      }}
+    >
       <div className="container mx-auto">
         <div className="w-full relative">
           <div className="relative">
@@ -58,6 +72,6 @@ export default function BlogMovingPcsingPost({ blogDetails }: Props) {
           </div>
         </div>
       </div>
-    </Link>
+    </TrackedCtaLink>
   );
 }

--- a/components/BlogPage/BlogPage/BlogPageHeroSection/BlogPageHeroSection.tsx
+++ b/components/BlogPage/BlogPage/BlogPageHeroSection/BlogPageHeroSection.tsx
@@ -1,10 +1,10 @@
 import "@/app/globals.css";
 import classes from "./BlogPageHeroSection.module.css";
-import Link from "next/link";
 import { formatDate } from "@/utils/helper";
 import { excerpt } from "@/lib/blog/mdx";
 import type { BlogPost } from "@/lib/blog/types";
 import BlogSearchForm from "@/components/BlogPage/BlogSearchForm";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 type Props = { blog: BlogPost };
 
@@ -17,7 +17,21 @@ export default function BlogPageHeroSection({ blog }: Props) {
         style={{ backgroundImage: `url("${bg}")` }}
       >
         <div className="flex flex-col justify-center items-center">
-          <Link href={`/blog/${blog.slug}`} className="block">
+          <TrackedCtaLink
+            href={`/blog/${blog.slug}`}
+            className="block"
+            cta={{
+              ctaId: 'blog_landing_featured_post',
+              ctaIntent: 'content_navigation',
+              ctaPosition: 'blog_landing_hero',
+              ctaComponent: 'blog_page_hero',
+              ctaLabel: 'Featured guide',
+              destination: `/blog/${blog.slug}`,
+              pageType: 'blog_landing',
+              contentSlug: blog.slug,
+              contentType: 'blog_post',
+            }}
+          >
             <div>
               <div className="text-center">
                 {blog.categories?.[0] ? (
@@ -47,7 +61,7 @@ export default function BlogPageHeroSection({ blog }: Props) {
                 ) : null}
               </div>
             </div>
-          </Link>
+          </TrackedCtaLink>
           <div className="mt-8 w-full max-w-md px-5 md:px-0">
             <BlogSearchForm id="blog-hero-search-query" />
           </div>

--- a/components/Charity/FeaturedCharities.tsx
+++ b/components/Charity/FeaturedCharities.tsx
@@ -5,7 +5,7 @@ import "aos/dist/aos.css";
 import Image from "next/image";
 import impactService from "@/services/impactService";
 import SupportContent from "@/components/homepage/FamilySupport/SupportContent";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 type BlockStyle = "h1" | "h2" | "h3" | "normal";
 
 interface ForegroundImage {
@@ -96,9 +96,20 @@ const FeaturedCharities = async () => {
                             ))}
                         </p>
                         <div className="flex lg:justify-start md:justify-start sm:justify-center justify-center mt-4 md:mt-0">
-                            <Link href="https://www.wearblueruntoremember.org">
+                            <TrackedCtaLink
+                                href="https://www.wearblueruntoremember.org"
+                                cta={{
+                                    ctaId: 'charity_partner_wear_blue',
+                                    ctaIntent: 'charity_partner_navigation',
+                                    ctaPosition: 'charity_featured',
+                                    ctaComponent: 'featured_charities',
+                                    ctaLabel: storieDetails?.button_text || 'Read More',
+                                    destination: 'https://www.wearblueruntoremember.org',
+                                    pageType: 'charity',
+                                }}
+                            >
                                 <Button buttonText={storieDetails?.button_text || "Read More"} />
-                            </Link>
+                            </TrackedCtaLink>
                         </div>
                     </div>
                 </div>
@@ -130,9 +141,20 @@ const FeaturedCharities = async () => {
                             We transform lives by partnering people with custom-trained assistance dogs.  At Freedom Service Dogs, we believe dogs can make a profound difference in the everyday lives of people challenged by disabilities.
                         </p>
                         <div className="flex lg:justify-start md:justify-start sm:justify-center justify-center mt-4 md:mt-0">
-                            <Link href="https://freedomservicedogs.org">
+                            <TrackedCtaLink
+                                href="https://freedomservicedogs.org"
+                                cta={{
+                                    ctaId: 'charity_partner_freedom_service_dogs',
+                                    ctaIntent: 'charity_partner_navigation',
+                                    ctaPosition: 'charity_featured',
+                                    ctaComponent: 'featured_charities',
+                                    ctaLabel: 'Freedom Service Dogs',
+                                    destination: 'https://freedomservicedogs.org',
+                                    pageType: 'charity',
+                                }}
+                            >
                                 <Button buttonText="Freedom Service Dogs" />
-                            </Link>
+                            </TrackedCtaLink>
                         </div>
                     </div>
                 </div>

--- a/components/Concierge/AgentCard.tsx
+++ b/components/Concierge/AgentCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
+import TrackedCtaLink from '@/components/common/TrackedCtaLink';
 
 export interface AgentListItem {
   id: string;
@@ -87,13 +87,24 @@ export default function AgentCard({ list, kind, onSelect }: Props) {
             >
               <div className="flex min-w-0 gap-3">
                 {item.profileHref ? (
-                  <Link
+                  <TrackedCtaLink
                     href={item.profileHref}
                     className="relative mt-0.5 h-14 w-14 shrink-0 overflow-hidden rounded-full bg-primary/10 text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
                     aria-label={`View ${item.name} on the ${item.stateName || 'state'} page`}
+                    cta={{
+                      ctaId: 'concierge_partner_profile_image',
+                      ctaIntent: 'partner_profile',
+                      ctaPosition: 'concierge_agent_card',
+                      ctaComponent: 'concierge_agent_card',
+                      ctaLabel: 'View profile',
+                      destination: item.profileHref,
+                      pageType: 'concierge',
+                      partnerType: kind,
+                      partnerSalesforceId: item.id,
+                    }}
                   >
                     {photo}
-                  </Link>
+                  </TrackedCtaLink>
                 ) : (
                   <div className="relative mt-0.5 flex h-14 w-14 shrink-0 overflow-hidden rounded-full bg-primary/10 text-primary">
                     {photo}
@@ -103,12 +114,23 @@ export default function AgentCard({ list, kind, onSelect }: Props) {
                 <div className="min-w-0 flex-1">
                   <div className="flex min-w-0 flex-col">
                     {item.profileHref ? (
-                      <Link
+                      <TrackedCtaLink
                         href={item.profileHref}
                         className="break-words text-sm font-semibold leading-snug text-primary underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
+                        cta={{
+                          ctaId: 'concierge_partner_profile_name',
+                          ctaIntent: 'partner_profile',
+                          ctaPosition: 'concierge_agent_card',
+                          ctaComponent: 'concierge_agent_card',
+                          ctaLabel: 'View profile',
+                          destination: item.profileHref,
+                          pageType: 'concierge',
+                          partnerType: kind,
+                          partnerSalesforceId: item.id,
+                        }}
                       >
                         {item.name}
-                      </Link>
+                      </TrackedCtaLink>
                     ) : (
                       <span className="break-words text-sm font-semibold leading-snug text-primary">
                         {item.name}
@@ -137,12 +159,23 @@ export default function AgentCard({ list, kind, onSelect }: Props) {
 
               <div className="flex flex-col gap-2">
                 {item.contactHref ? (
-                  <Link
+                  <TrackedCtaLink
                     href={item.contactHref}
                     className="inline-flex min-h-[44px] items-center justify-center rounded-md bg-accent-red px-3 py-2 text-center text-sm font-medium text-white motion-safe:transition-colors hover:bg-accent-red-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                    cta={{
+                      ctaId: 'concierge_partner_contact',
+                      ctaIntent: kind === 'lender' ? 'contact_lender' : 'contact_agent',
+                      ctaPosition: 'concierge_agent_card',
+                      ctaComponent: 'concierge_agent_card',
+                      ctaLabel: 'Start intake',
+                      destination: item.contactHref,
+                      pageType: 'concierge',
+                      partnerType: kind,
+                      partnerSalesforceId: item.id,
+                    }}
                   >
                     {contactText}
-                  </Link>
+                  </TrackedCtaLink>
                 ) : onSelect ? (
                   <button
                     type="button"
@@ -153,12 +186,23 @@ export default function AgentCard({ list, kind, onSelect }: Props) {
                   </button>
                 ) : null}
                 {item.profileHref ? (
-                  <Link
+                  <TrackedCtaLink
                     href={item.profileHref}
                     className="inline-flex min-h-[36px] items-center justify-center rounded-md border border-gray-200 px-3 py-1.5 text-center text-xs font-medium text-primary motion-safe:transition-colors hover:bg-primary/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
+                    cta={{
+                      ctaId: 'concierge_partner_profile_details',
+                      ctaIntent: 'partner_profile',
+                      ctaPosition: 'concierge_agent_card',
+                      ctaComponent: 'concierge_agent_card',
+                      ctaLabel: 'View details',
+                      destination: item.profileHref,
+                      pageType: 'concierge',
+                      partnerType: kind,
+                      partnerSalesforceId: item.id,
+                    }}
                   >
                     {profileText}
-                  </Link>
+                  </TrackedCtaLink>
                 ) : null}
               </div>
             </li>

--- a/components/Concierge/ConciergeProvider.tsx
+++ b/components/Concierge/ConciergeProvider.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { captureAnalyticsEvent } from '@/lib/analytics/client';
 
 export interface ConciergeSeed {
   openingMessage?: string;
@@ -25,21 +27,35 @@ interface Props {
 export default function ConciergeProvider({ children }: Props) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [pendingSeed, setPendingSeed] = useState<ConciergeSeed | null>(null);
+  const pathname = usePathname();
 
   const open = useCallback((seed?: ConciergeSeed) => {
     if (seed) {
       setPendingSeed(seed);
     }
+    if (!isOpen) {
+      captureAnalyticsEvent('concierge_opened', {
+        source_page_path: pathname ?? undefined,
+        concierge_topic: seed?.topic,
+        input_origin: seed ? 'seeded_cta' : 'launcher',
+      });
+    }
     setIsOpen(true);
-  }, []);
+  }, [isOpen, pathname]);
 
   const close = useCallback(() => {
     setIsOpen(false);
   }, []);
 
   const toggle = useCallback(() => {
+    if (!isOpen) {
+      captureAnalyticsEvent('concierge_opened', {
+        source_page_path: pathname ?? undefined,
+        input_origin: 'toggle',
+      });
+    }
     setIsOpen((prev) => !prev);
-  }, []);
+  }, [isOpen, pathname]);
 
   const clearPendingSeed = useCallback(() => {
     setPendingSeed(null);

--- a/components/Concierge/ConciergeWidget.tsx
+++ b/components/Concierge/ConciergeWidget.tsx
@@ -155,9 +155,15 @@ export default function ConciergeWidget() {
     if (!pendingSeed?.openingMessage) return;
     if (messages.length > 0) return;
     seedConsumedRef.current = true;
+    captureAnalyticsEvent('concierge_message_sent', {
+      source_page_path: pathname ?? undefined,
+      input_origin: 'seeded_cta',
+      concierge_topic: pendingSeed.topic,
+      ...queryMetrics(pendingSeed.openingMessage),
+    });
     void sendMessage({ text: pendingSeed.openingMessage });
     clearPendingSeed();
-  }, [isOpen, pendingSeed, messages.length, sendMessage, clearPendingSeed]);
+  }, [isOpen, pendingSeed, messages.length, pathname, sendMessage, clearPendingSeed]);
 
   // Reset seed-consumed flag when the panel closes so a future open works.
   useEffect(() => {
@@ -286,15 +292,22 @@ export default function ConciergeWidget() {
 
   const handleSelectAgent = (item: AgentListItem) => {
     if (isStreaming) return;
-    void sendMessage({
-      text: `I want VeteranPCS to help me start intake with ${item.name} for my PCS move. Please collect any missing contact details before sending anything.`,
+    const text = `I want VeteranPCS to help me start intake with ${item.name} for my PCS move. Please collect any missing contact details before sending anything.`;
+    captureAnalyticsEvent('concierge_message_sent', {
+      source_page_path: pathname ?? undefined,
+      input_origin: 'agent_card',
+      partner_type: item.role,
+      partner_salesforce_id: item.id,
+      ...queryMetrics(text),
     });
+    void sendMessage({ text });
   };
 
   const handleApprove = useCallback(
-    (id: string, approved: boolean) => {
+    (id: string, approved: boolean, toolName?: string) => {
       captureAnalyticsEvent('concierge_tool_approval_responded', {
-        approval_response: approved ? 'approved' : 'denied',
+        tool_name: toolName,
+        approved,
       });
       void addToolApprovalResponse({ id, approved });
     },
@@ -327,10 +340,7 @@ export default function ConciergeWidget() {
       {!isOpen ? (
         <button
           type="button"
-          onClick={() => {
-            captureAnalyticsEvent('concierge_opened', { source_page_path: pathname ?? undefined });
-            open();
-          }}
+          onClick={() => open()}
           aria-label="Open chat with VeteranPCS concierge"
           className="fixed bottom-6 right-6 z-concierge h-14 w-14 rounded-full bg-primary text-white shadow-lg flex items-center justify-center motion-safe:transition-colors hover:bg-primary-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
         >

--- a/components/Concierge/MessageRenderer.tsx
+++ b/components/Concierge/MessageRenderer.tsx
@@ -14,7 +14,7 @@ import { SUCCESS_MESSAGE } from '@/lib/ai/tools/messages';
 interface Props {
   message: UIMessage;
   onSelectAgent?(item: AgentListItem): void;
-  onApprove?(id: string, approved: boolean): void;
+  onApprove?(id: string, approved: boolean, toolName?: string): void;
 }
 
 interface ToolEnvelope<T> {
@@ -66,10 +66,11 @@ function DeniedBubble() {
 
 interface ApprovalCardProps {
   approvalId: string;
-  onApprove?(id: string, approved: boolean): void;
+  toolName: string;
+  onApprove?(id: string, approved: boolean, toolName?: string): void;
 }
 
-function ApprovalCard({ approvalId, onApprove }: ApprovalCardProps) {
+function ApprovalCard({ approvalId, toolName, onApprove }: ApprovalCardProps) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-3 flex flex-col gap-2">
       <p className="text-sm text-gray-900">
@@ -78,7 +79,7 @@ function ApprovalCard({ approvalId, onApprove }: ApprovalCardProps) {
       <div className="flex gap-2">
         <button
           type="button"
-          onClick={() => onApprove?.(approvalId, true)}
+          onClick={() => onApprove?.(approvalId, true, toolName)}
           disabled={!onApprove}
           className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-white motion-safe:transition-colors hover:bg-primary-hover disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red"
         >
@@ -86,7 +87,7 @@ function ApprovalCard({ approvalId, onApprove }: ApprovalCardProps) {
         </button>
         <button
           type="button"
-          onClick={() => onApprove?.(approvalId, false)}
+          onClick={() => onApprove?.(approvalId, false, toolName)}
           disabled={!onApprove}
           className="inline-flex h-9 items-center justify-center rounded-md border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 motion-safe:transition-colors hover:bg-gray-50 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         >
@@ -166,6 +167,7 @@ export default function MessageRenderer({ message, onSelectAgent, onApprove }: P
                   <ApprovalCard
                     key={key}
                     approvalId={part.approval.id}
+                    toolName={toolName}
                     onApprove={onApprove}
                   />
                 );

--- a/components/ContactAgents/ContactAgent.tsx
+++ b/components/ContactAgents/ContactAgent.tsx
@@ -27,6 +27,7 @@ const ContactAgentForm = ({ onSubmit, derivedStateCode }: ContactFormProps) => {
     control,
     register,
     handleSubmit,
+    getValues,
     watch,
     reset,
     setValue,
@@ -68,11 +69,6 @@ const ContactAgentForm = ({ onSubmit, derivedStateCode }: ContactFormProps) => {
 
   const handleFormSubmit: SubmitHandler<ContactAgentFormData> = async (data) => {
     setIsSubmitting(true);
-    trackFormSubmitAttempted('contact_agent', {
-      has_email: Boolean(data.email),
-      has_phone: Boolean(data.phone),
-      state_code: data.state,
-    });
     try {
       const response = await onSubmit({ ...data, ...getSpamFields() });
       if (response?.success || response?.redirectUrl) {
@@ -93,6 +89,15 @@ const ContactAgentForm = ({ onSubmit, derivedStateCode }: ContactFormProps) => {
     trackFormValidationFailed('contact_agent', formErrors);
   };
 
+  const trackSubmitAttempt = () => {
+    const values = getValues();
+    trackFormSubmitAttempted('contact_agent', {
+      has_email: Boolean(values.email),
+      has_phone: Boolean(values.phone),
+      state_code: values.state,
+    });
+  };
+
   const [agentName, setAgentName] = useState('Us');
 
   useEffect(() => {
@@ -106,7 +111,10 @@ const ContactAgentForm = ({ onSubmit, derivedStateCode }: ContactFormProps) => {
     <div className="md:py-12 py-4 md:px-0 px-5">
       <div className="md:w-[456px] mx-auto my-10">
         <form
-          onSubmit={handleSubmit(handleFormSubmit, handleInvalidSubmit)}
+          onSubmit={(event) => {
+            trackSubmitAttempt();
+            void handleSubmit(handleFormSubmit, handleInvalidSubmit)(event);
+          }}
           onFocus={() => trackFormStarted('contact_agent')}
         >
           <HoneypotField ref={honeypotRef} />

--- a/components/ContactLender/ContactLender.tsx
+++ b/components/ContactLender/ContactLender.tsx
@@ -41,6 +41,7 @@ const ContactLenderForm: React.FC<ContactFormProps> = ({ onSubmit, derivedStateC
     control,
     register,
     handleSubmit,
+    getValues,
     watch,
     setValue,
     formState: { errors },
@@ -71,11 +72,6 @@ const ContactLenderForm: React.FC<ContactFormProps> = ({ onSubmit, derivedStateC
   // Form submit handler
   const handleFormSubmit: SubmitHandler<ContactLenderFormData> = async (data) => {
     setIsSubmitting(true);
-    trackFormSubmitAttempted('contact_lender', {
-      has_email: Boolean(data.email),
-      has_phone: Boolean(data.phone),
-      state_code: data.state,
-    });
     try {
       const response = await onSubmit({ ...data, ...getSpamFields() });
       if (!response?.success && !response?.redirectUrl) {
@@ -91,6 +87,15 @@ const ContactLenderForm: React.FC<ContactFormProps> = ({ onSubmit, derivedStateC
 
   const handleInvalidSubmit = (formErrors: typeof errors) => {
     trackFormValidationFailed('contact_lender', formErrors);
+  };
+
+  const trackSubmitAttempt = () => {
+    const values = getValues();
+    trackFormSubmitAttempted('contact_lender', {
+      has_email: Boolean(values.email),
+      has_phone: Boolean(values.phone),
+      state_code: values.state,
+    });
   };
 
   // Error rendering function
@@ -113,7 +118,10 @@ const ContactLenderForm: React.FC<ContactFormProps> = ({ onSubmit, derivedStateC
     <div className="md:py-12 py-4 md:px-0 px-5">
       <div className="md:w-[456px] mx-auto my-10">
         <form
-          onSubmit={handleSubmit(handleFormSubmit, handleInvalidSubmit)}
+          onSubmit={(event) => {
+            trackSubmitAttempt();
+            void handleSubmit(handleFormSubmit, handleInvalidSubmit)(event);
+          }}
           onFocus={() => trackFormStarted('contact_lender')}
         >
           <HoneypotField ref={honeypotRef} />

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classes from "./Footer.module.css";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const Locations = () => {
   const locations = [
@@ -60,12 +60,12 @@ const Locations = () => {
   const currentDate = new Date();
   const currentYear = currentDate.getFullYear();
   const exploreLinks = [
-    { href: "/how-it-works", label: "How It Works" },
-    { href: "/bah-calculator", label: "BAH Calculator" },
-    { href: "/va-loan-calculator", label: "VA Loan Calculator" },
-    { href: "/pcs-resources", label: "Guides & PCS Resources" },
-    { href: "/contact-agent", label: "Find an Agent" },
-    { href: "/contact-lender", label: "Find a Lender" },
+    { href: "/how-it-works", label: "How It Works", intent: "navigate" },
+    { href: "/bah-calculator", label: "BAH Calculator", intent: "calculator" },
+    { href: "/va-loan-calculator", label: "VA Loan Calculator", intent: "calculator" },
+    { href: "/pcs-resources", label: "Guides & PCS Resources", intent: "navigate_content" },
+    { href: "/contact-agent", label: "Find an Agent", intent: "contact_agent" },
+    { href: "/contact-lender", label: "Find a Lender", intent: "contact_lender" },
   ];
 
   const formattedLocation = (location: string) => {
@@ -83,12 +83,21 @@ const Locations = () => {
             <div className="mt-5 grid grid-cols-1 gap-2">
               {locations.map((location, index) => (
                 <div key={index} className={classes.LocationItem}>
-                  <Link
+                  <TrackedCtaLink
                     href={`/${formattedLocation(location)}`}
                     className="flex min-h-11 items-center justify-center text-center roboto text-base font-medium text-white"
+                    cta={{
+                      ctaId: 'footer_location_state',
+                      ctaIntent: 'state_page',
+                      ctaPosition: 'footer_locations_mobile',
+                      ctaComponent: 'site_footer',
+                      ctaLabel: location,
+                      destination: `/${formattedLocation(location)}`,
+                      stateSlug: formattedLocation(location),
+                    }}
                   >
                     {location}
-                  </Link>
+                  </TrackedCtaLink>
                 </div>
               ))}
             </div>
@@ -101,24 +110,41 @@ const Locations = () => {
           <div className="hidden grid-cols-1 gap-2 md:grid md:grid-cols-3 lg:grid-cols-4">
             {locations.map((location, index) => (
               <div key={index} className={classes.LocationItem}>
-                <Link
+                <TrackedCtaLink
                   href={`/${formattedLocation(location)}`}
                   className="flex min-h-11 items-center justify-center text-white text-center roboto text-base font-medium"
+                  cta={{
+                    ctaId: 'footer_location_state',
+                    ctaIntent: 'state_page',
+                    ctaPosition: 'footer_locations_desktop',
+                    ctaComponent: 'site_footer',
+                    ctaLabel: location,
+                    destination: `/${formattedLocation(location)}`,
+                    stateSlug: formattedLocation(location),
+                  }}
                 >
                   {location}
-                </Link>
+                </TrackedCtaLink>
               </div>
             ))}
           </div>
           <div className="mt-10 px-5">
             <div className="md:flex sm:block sm:justify-center sm:text-center text-center flex-wrap gap-5 md:justify-between items-center">
               <div>
-                <Link
+                <TrackedCtaLink
                   href="/terms-of-use"
                   className="text-white text-center roboto text-lg font-medium"
+                  cta={{
+                    ctaId: 'footer_terms',
+                    ctaIntent: 'legal_navigation',
+                    ctaPosition: 'footer_legal',
+                    ctaComponent: 'site_footer',
+                    ctaLabel: 'Terms Of Service',
+                    destination: '/terms-of-use',
+                  }}
                 >
                   Terms Of Service
-                </Link>
+                </TrackedCtaLink>
               </div>
               <div className="my-7 sm:my-7 md:my-0">
                 <span className="text-white text-center roboto text-lg font-medium">
@@ -126,12 +152,20 @@ const Locations = () => {
                 </span>
               </div>
               <div>
-                <Link
+                <TrackedCtaLink
                   href="/privacy-policy"
                   className="text-white text-center roboto text-lg font-medium"
+                  cta={{
+                    ctaId: 'footer_privacy',
+                    ctaIntent: 'legal_navigation',
+                    ctaPosition: 'footer_legal',
+                    ctaComponent: 'site_footer',
+                    ctaLabel: 'Privacy Policy',
+                    destination: '/privacy-policy',
+                  }}
                 >
                   Privacy Policy{" "}
-                </Link>
+                </TrackedCtaLink>
               </div>
             </div>
           </div>
@@ -185,12 +219,20 @@ const Locations = () => {
               <ul className="space-y-2">
                 {exploreLinks.map((link) => (
                   <li key={link.href}>
-                    <Link
+                    <TrackedCtaLink
                       href={link.href}
                       className="inline-flex min-h-11 items-center text-white text-[14px] font-medium roboto hover:underline"
+                      cta={{
+                        ctaId: `footer_explore_${link.label.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')}`,
+                        ctaIntent: link.intent,
+                        ctaPosition: 'footer_explore',
+                        ctaComponent: 'site_footer',
+                        ctaLabel: link.label,
+                        destination: link.href,
+                      }}
                     >
                       {link.label}
-                    </Link>
+                    </TrackedCtaLink>
                   </li>
                 ))}
               </ul>
@@ -213,7 +255,17 @@ const Locations = () => {
                 use of a VeteranPCS-introduced real estate agent. Other terms
                 and conditions may apply. This is not a solicitation if you are
                 already represented by a real estate broker. Please contact
-                <Link href='mailto:info@veteranpcs.com'> info@veteranpcs.com</Link> for details. Program terms and
+                <TrackedCtaLink
+                  href='mailto:info@veteranpcs.com'
+                  cta={{
+                    ctaId: 'footer_email',
+                    ctaIntent: 'contact_email',
+                    ctaPosition: 'footer_disclaimer',
+                    ctaComponent: 'site_footer',
+                    ctaLabel: 'info@veteranpcs.com',
+                    destination: 'mailto:info@veteranpcs.com',
+                  }}
+                > info@veteranpcs.com</TrackedCtaLink> for details. Program terms and
                 conditions are subject to change at any time without notice. By
                 using the services offered herein, you represent that you have
                 read, understood, and agree to the Platform Terms of Use.

--- a/components/GuidesHero/GuidesHero.tsx
+++ b/components/GuidesHero/GuidesHero.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import "@/app/globals.css";
 import styles from "./GuidesHero.module.css";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const GuidesHero = () => {
     const scrollToSection = (id: string) => {
@@ -25,18 +25,38 @@ const GuidesHero = () => {
                                 Resources designed to help military families navigate PCS moves, home buying, VA loans, and more
                             </p>
                             <div className="flex flex-wrap gap-4 mb-10 mt-8">
-                                <Link
+                                <TrackedCtaLink
                                     href="/guides#va-loan-guide"
                                     className="px-6 bg-[#8B2D2D] text-white rounded-lg py-3 text-base font-medium hover:bg-[#722424] transition-colors"
+                                    cta={{
+                                        ctaId: 'guides_hero_va_loan',
+                                        ctaIntent: 'guide_section_navigation',
+                                        ctaPosition: 'guides_hero',
+                                        ctaComponent: 'guides_hero',
+                                        ctaLabel: 'VA Loan',
+                                        destination: '/guides#va-loan-guide',
+                                        pageType: 'guides',
+                                        guideId: 'va_loan_guide',
+                                    }}
                                 >
                                     VA Loan
-                                </Link>
-                                <Link
+                                </TrackedCtaLink>
+                                <TrackedCtaLink
                                     href="/guides#homebuyer-guide"
                                     className="px-6 bg-[#8B2D2D] text-white rounded-lg py-3 text-base font-medium hover:bg-[#722424] transition-colors"
+                                    cta={{
+                                        ctaId: 'guides_hero_homebuyer',
+                                        ctaIntent: 'guide_section_navigation',
+                                        ctaPosition: 'guides_hero',
+                                        ctaComponent: 'guides_hero',
+                                        ctaLabel: 'First Time Home Buyer',
+                                        destination: '/guides#homebuyer-guide',
+                                        pageType: 'guides',
+                                        guideId: 'first_time_homebuyer_guide',
+                                    }}
                                 >
                                     First Time Home Buyer
-                                </Link>
+                                </TrackedCtaLink>
                             </div>
                         </div>
                         <div className="hidden lg:flex justify-end items-center">
@@ -58,4 +78,4 @@ const GuidesHero = () => {
     );
 };
 
-export default GuidesHero; 
+export default GuidesHero;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { useState, useEffect } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import AgentCtaLink from "@/components/common/AgentCtaLink";
+import LenderCtaLink from "@/components/common/LenderCtaLink";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -38,16 +39,27 @@ const Header = () => {
     <header className="fixed left-0 top-0 z-50 w-full bg-primary px-5 shadow-lg min-[1400px]:px-0">
       <div className="container mx-auto w-full">
         <nav className="flex min-h-[64px] justify-between lg:min-h-[80px]" aria-label="Primary navigation">
-          <Link className="flex w-[130px] shrink-0 items-center md:w-[190px] xl:w-[200px]" href="/">
+          <TrackedCtaLink
+            className="flex w-[130px] shrink-0 items-center md:w-[190px] xl:w-[200px]"
+            href="/"
+            onClick={isMenuOpen ? onMenuToggle : undefined}
+            cta={{
+              ctaId: 'header_logo',
+              ctaIntent: 'navigate_home',
+              ctaPosition: 'header_logo',
+              ctaComponent: 'site_header',
+              ctaLabel: 'VeteranPCS logo',
+              destination: '/',
+            }}
+          >
             <Image
               width={235}
               height={63}
               src="/icon/VeteranPCSlogo.svg"
               className="h-auto w-[200px] md:w-[205px] xl:w-[220px] 2xl:w-[235px]"
               alt="VeteranPCS logo"
-              onClick={isMenuOpen ? onMenuToggle : undefined}
             />
-          </Link>
+          </TrackedCtaLink>
           <div className="flex min-w-0 items-center lg:gap-5 xl:gap-7">
             <div
               id="primary-navigation"
@@ -58,68 +70,177 @@ const Header = () => {
                   <AgentCtaLink
                     className="inline-flex min-h-11 rounded-2xl bg-accent-red px-5 py-3 text-white transition-colors hover:bg-accent-red-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
                     onClick={onMenuToggle}
+                    ctaId="header_mobile_find_agent"
+                    ctaPosition="mobile_primary_nav"
+                    ctaComponent="site_header"
                   >
                     Find an Agent
                   </AgentCtaLink>
                 </li>
                 <li className={navItemClass}>
-                  <Link className={navLinkClass} href="/about" onClick={onMenuToggle}>
+                  <TrackedCtaLink
+                    className={navLinkClass}
+                    href="/about"
+                    onClick={onMenuToggle}
+                    cta={{
+                      ctaId: 'header_about',
+                      ctaIntent: 'navigate',
+                      ctaPosition: 'primary_nav',
+                      ctaComponent: 'site_header',
+                      ctaLabel: 'About',
+                      destination: '/about',
+                    }}
+                  >
                     About
-                  </Link>
+                  </TrackedCtaLink>
                 </li>
                 <li className={navItemClass}>
-                  <Link className={navLinkClass} href="/how-it-works" onClick={onMenuToggle}>
+                  <TrackedCtaLink
+                    className={navLinkClass}
+                    href="/how-it-works"
+                    onClick={onMenuToggle}
+                    cta={{
+                      ctaId: 'header_how_it_works',
+                      ctaIntent: 'navigate',
+                      ctaPosition: 'primary_nav',
+                      ctaComponent: 'site_header',
+                      ctaLabel: 'How It Works',
+                      destination: '/how-it-works',
+                    }}
+                  >
                     How It Works
-                  </Link>
+                  </TrackedCtaLink>
                 </li>
                 <li className={navItemClass}>
-                  <Link className={navLinkClass} href="/impact" onClick={onMenuToggle}>
+                  <TrackedCtaLink
+                    className={navLinkClass}
+                    href="/impact"
+                    onClick={onMenuToggle}
+                    cta={{
+                      ctaId: 'header_impact',
+                      ctaIntent: 'navigate',
+                      ctaPosition: 'primary_nav',
+                      ctaComponent: 'site_header',
+                      ctaLabel: 'Impact',
+                      destination: '/impact',
+                    }}
+                  >
                     Impact
-                  </Link>
+                  </TrackedCtaLink>
                 </li>
                 <li className={navItemClass}>
-                  <Link className={navLinkClass} href="/blog" onClick={onMenuToggle}>
+                  <TrackedCtaLink
+                    className={navLinkClass}
+                    href="/blog"
+                    onClick={onMenuToggle}
+                    cta={{
+                      ctaId: 'header_blog',
+                      ctaIntent: 'navigate_content',
+                      ctaPosition: 'primary_nav',
+                      ctaComponent: 'site_header',
+                      ctaLabel: 'Blog',
+                      destination: '/blog',
+                    }}
+                  >
                     Blog
-                  </Link>
+                  </TrackedCtaLink>
                 </li>
                 <li className={navItemClass}>
-                  <Link className={navLinkClass} href="/pcs-resources" onClick={onMenuToggle}>
+                  <TrackedCtaLink
+                    className={navLinkClass}
+                    href="/pcs-resources"
+                    onClick={onMenuToggle}
+                    cta={{
+                      ctaId: 'header_pcs_resources',
+                      ctaIntent: 'navigate_content',
+                      ctaPosition: 'primary_nav',
+                      ctaComponent: 'site_header',
+                      ctaLabel: 'PCS Resources',
+                      destination: '/pcs-resources',
+                    }}
+                  >
                     PCS Resources
-                  </Link>
+                  </TrackedCtaLink>
                 </li>
                 <li className={navItemClass}>
-                  <Link className={navLinkClass} href="/contact-lender" onClick={onMenuToggle}>
+                  <LenderCtaLink
+                    className={navLinkClass}
+                    onClick={onMenuToggle}
+                    ctaId="header_find_lender"
+                    ctaPosition="primary_nav"
+                    ctaComponent="site_header"
+                  >
                     Find a Lender
-                  </Link>
+                  </LenderCtaLink>
                 </li>
                 <li className={navItemClass}>
-                  <Link className={navLinkClass} href="/contact" onClick={onMenuToggle}>
+                  <TrackedCtaLink
+                    className={navLinkClass}
+                    href="/contact"
+                    onClick={onMenuToggle}
+                    cta={{
+                      ctaId: 'header_contact',
+                      ctaIntent: 'contact_general',
+                      ctaPosition: 'primary_nav',
+                      ctaComponent: 'site_header',
+                      ctaLabel: 'Contact',
+                      destination: '/contact',
+                    }}
+                  >
                     Contact
-                  </Link>
+                  </TrackedCtaLink>
                 </li>
                 <li className={navItemClass}>
-                  <Link className={navLinkClass} href="/get-listed-agents" onClick={onMenuToggle}>
+                  <TrackedCtaLink
+                    className={navLinkClass}
+                    href="/get-listed-agents"
+                    onClick={onMenuToggle}
+                    cta={{
+                      ctaId: 'header_get_listed',
+                      ctaIntent: 'partner_recruiting',
+                      ctaPosition: 'primary_nav',
+                      ctaComponent: 'site_header',
+                      ctaLabel: 'Get Listed',
+                      destination: '/get-listed-agents',
+                    }}
+                  >
                     Get Listed
-                  </Link>
+                  </TrackedCtaLink>
                   <ul className="sub-menu">
                     <li className="px-10 py-3 text-white">
-                      <Link
+                      <TrackedCtaLink
                         className="text-base font-normal"
                         href="/get-listed-agents"
                         onClick={onMenuToggle}
+                        cta={{
+                          ctaId: 'header_get_listed_agents',
+                          ctaIntent: 'partner_recruiting_agent',
+                          ctaPosition: 'primary_nav_submenu',
+                          ctaComponent: 'site_header',
+                          ctaLabel: 'Get Listed Agents',
+                          destination: '/get-listed-agents',
+                        }}
                       >
                         Get Listed Agents
-                      </Link>
+                      </TrackedCtaLink>
                     </li>
 
                     <li className="px-10 py-3 text-white">
-                      <Link
+                      <TrackedCtaLink
                         className="text-base font-normal"
                         href="/get-listed-lenders"
                         onClick={onMenuToggle}
+                        cta={{
+                          ctaId: 'header_get_listed_lenders',
+                          ctaIntent: 'partner_recruiting_lender',
+                          ctaPosition: 'primary_nav_submenu',
+                          ctaComponent: 'site_header',
+                          ctaLabel: 'Get Listed Lenders',
+                          destination: '/get-listed-lenders',
+                        }}
                       >
                         Get Listed Lenders
-                      </Link>
+                      </TrackedCtaLink>
                     </li>
                   </ul>
                 </li>
@@ -128,6 +249,9 @@ const Header = () => {
             <div className="flex items-center gap-2">
               <AgentCtaLink
                 className="hidden min-h-11 shrink-0 items-center rounded-2xl bg-accent-red px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-accent-red-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white min-[1400px]:inline-flex"
+                ctaId="header_desktop_find_agent"
+                ctaPosition="desktop_primary_cta"
+                ctaComponent="site_header"
               >
                 Find an Agent
               </AgentCtaLink>

--- a/components/Impact/AboutOurStory/AboutOurStory.tsx
+++ b/components/Impact/AboutOurStory/AboutOurStory.tsx
@@ -6,7 +6,7 @@ import classes from "./AboutOurStory.module.css";
 import Image from "next/image";
 import impactService from "@/services/impactService";
 import SupportContent from "@/components/homepage/FamilySupport/SupportContent";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 type BlockStyle = "h1" | "h2" | "h3" | "normal";
 
@@ -92,9 +92,21 @@ const FamilySupport = async () => {
                 ))}
               </p>
             </div>
-            <Link href="/about" className="sm:mt-0 mt-16">
+            <TrackedCtaLink
+              href="/about"
+              className="sm:mt-0 mt-16"
+              cta={{
+                ctaId: 'impact_about_our_story',
+                ctaIntent: 'about_navigation',
+                ctaPosition: 'impact_our_story',
+                ctaComponent: 'impact_about_our_story',
+                ctaLabel: storyDetails?.buttonText || 'OUR STORY',
+                destination: '/about',
+                pageType: 'impact',
+              }}
+            >
               <Button buttonText={storyDetails?.buttonText || "OUR STORY"} />
-            </Link>
+            </TrackedCtaLink>
           </div>
         </div>
       </div>

--- a/components/Impact/VeteranPcsGivesBack/VeteranPcsGivesBack.tsx
+++ b/components/Impact/VeteranPcsGivesBack/VeteranPcsGivesBack.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Button from "@/components/common/Button";
 import classes from "./VeteranPcsGivesBack.module.css";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const VeteranPcsGivesBack = () => {
     return (
@@ -19,9 +19,20 @@ const VeteranPcsGivesBack = () => {
                             </p>
                         </div>
                         <div className="mt-5 md:block flex justify-center">
-                            <Link href="/charity">
+                            <TrackedCtaLink
+                                href="/charity"
+                                cta={{
+                                    ctaId: 'impact_gives_back_charity',
+                                    ctaIntent: 'charity_navigation',
+                                    ctaPosition: 'impact_gives_back',
+                                    ctaComponent: 'veteranpcs_gives_back',
+                                    ctaLabel: 'Charities VeteranPCS Backs',
+                                    destination: '/charity',
+                                    pageType: 'impact',
+                                }}
+                            >
                                 <Button buttonText="Charities VeteranPCS Backs" />
-                            </Link>
+                            </TrackedCtaLink>
                         </div>
                     </div>
                     <div className="lg:ml-10 md:ml-0 sm:ml-0 ml-0 sm:order-2 order-1">
@@ -39,4 +50,4 @@ const VeteranPcsGivesBack = () => {
     );
 };
 
-export default VeteranPcsGivesBack; 
+export default VeteranPcsGivesBack;

--- a/components/Impact/WearBlueSection/WearBlueSection.tsx
+++ b/components/Impact/WearBlueSection/WearBlueSection.tsx
@@ -5,7 +5,7 @@ import "aos/dist/aos.css";
 import Image from "next/image";
 import impactService from "@/services/impactService";
 import SupportContent from "@/components/homepage/FamilySupport/SupportContent";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 type BlockStyle = "h1" | "h2" | "h3" | "normal";
 
 interface ForegroundImage {
@@ -68,9 +68,20 @@ const MilitaryHomePage = async () => {
               Our mission is to provide financial assistance, support services, and advocacy for the Army Aviation community and its Gold Star Families.
             </p>
             <div className="flex lg:justify-start md:justify-start sm:justify-center justify-center mt-4 md:mt-0">
-              <Link href="https://www.flybbsf.org/">
+              <TrackedCtaLink
+                href="https://www.flybbsf.org/"
+                cta={{
+                  ctaId: 'impact_partner_blue_skies',
+                  ctaIntent: 'charity_partner_navigation',
+                  ctaPosition: 'impact_charity_section',
+                  ctaComponent: 'wear_blue_section',
+                  ctaLabel: 'Blue Skies Foundation',
+                  destination: 'https://www.flybbsf.org/',
+                  pageType: 'impact',
+                }}
+              >
                 <Button buttonText="Blue Skies Foundation" />
-              </Link>
+              </TrackedCtaLink>
             </div>
           </div>
           <div className="w-full md:w-1/2 flex justify-center">
@@ -120,9 +131,20 @@ const MilitaryHomePage = async () => {
               ))}
             </p>
             <div className="flex lg:justify-start md:justify-start sm:justify-center justify-center mt-4 md:mt-0">
-              <Link href="https://www.wearblueruntoremember.org">
+              <TrackedCtaLink
+                href="https://www.wearblueruntoremember.org"
+                cta={{
+                  ctaId: 'impact_partner_wear_blue',
+                  ctaIntent: 'charity_partner_navigation',
+                  ctaPosition: 'impact_charity_section',
+                  ctaComponent: 'wear_blue_section',
+                  ctaLabel: storieDetails?.button_text || 'Read More',
+                  destination: 'https://www.wearblueruntoremember.org',
+                  pageType: 'impact',
+                }}
+              >
                 <Button buttonText={storieDetails?.button_text || "Read More"} />
-              </Link>
+              </TrackedCtaLink>
             </div>
           </div>
         </div>
@@ -136,9 +158,20 @@ const MilitaryHomePage = async () => {
               The Warrior Bonfire Program is designed to meet a critical need throughout the United States to provide much needed mental health and peer support to combat wounded Veterans through recreational therapy, and Post-traumatic healing. We are a 501c3 organization founded and led by Veterans to support and honor the immense number of Purple Heart recipients throughout the nation. Our signature program, the Bonfire retreat, Bonfire Retreats are recreational therapy based, multi-day events that are reserved primarily for six Purple Heart Veterans. Bonfire retreats provide opportunities for wounded veterans, in small groups of six, to enjoy a favorite activity while partaking in the camaraderie and therapeutic value of spending time around the bonfire with fellow veterans while promoting Post-Traumatic Healing and the building of support communities, fostering healing and improving lives. Each retreat is concluded with a bonfire including a U.S. Flag retirement ceremony providing participants with an opportunity to honor fallen comrades.
             </p>
             <div className="flex lg:justify-start md:justify-start sm:justify-center justify-center mt-4 md:mt-0">
-              <Link href="https://warriorbonfireprogram.org">
+              <TrackedCtaLink
+                href="https://warriorbonfireprogram.org"
+                cta={{
+                  ctaId: 'impact_partner_warrior_bonfire',
+                  ctaIntent: 'charity_partner_navigation',
+                  ctaPosition: 'impact_charity_section',
+                  ctaComponent: 'wear_blue_section',
+                  ctaLabel: 'Warrior Bonfire Program',
+                  destination: 'https://warriorbonfireprogram.org',
+                  pageType: 'impact',
+                }}
+              >
                 <Button buttonText="Warrior Bonfire Program" />
-              </Link>
+              </TrackedCtaLink>
             </div>
           </div>
           <div className="w-full md:w-1/2 flex justify-center">

--- a/components/PcsResources/PcsResourcesBlog/PcsResourcesBlog.tsx
+++ b/components/PcsResources/PcsResourcesBlog/PcsResourcesBlog.tsx
@@ -1,10 +1,10 @@
 import "@/app/globals.css";
-import Link from "next/link";
 import classes from "./PcsResourcesBlog.module.css";
 import { formatDate } from "@/utils/helper";
 import { excerpt } from "@/lib/blog/mdx";
 import type { BlogPost } from "@/lib/blog/types";
 import { normalizeBlogComponentSlug } from "@/lib/blog/components";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 type Props = {
   blogList: BlogPost[];
@@ -24,9 +24,22 @@ export default function PcsResourcesBlog({ blogList, component }: Props) {
               {component}
             </h1>
           </div>
-          <Link href={categoryHref} className="text-[#292F6C] robot text-sm font-bold">
+          <TrackedCtaLink
+            href={categoryHref}
+            className="text-[#292F6C] robot text-sm font-bold"
+            cta={{
+              ctaId: 'pcs_resources_blog_view_all',
+              ctaIntent: 'content_navigation',
+              ctaPosition: 'pcs_resources_blog_header',
+              ctaComponent: 'pcs_resources_blog',
+              ctaLabel: 'View All',
+              destination: categoryHref,
+              pageType: 'pcs_resources',
+              contentType: 'blog_category',
+            }}
+          >
             View All
-          </Link>
+          </TrackedCtaLink>
         </div>
         <div
           className={`grid ${blogList.length === 1
@@ -39,11 +52,22 @@ export default function PcsResourcesBlog({ blogList, component }: Props) {
           {blogList.map((blog) => {
             const bg = blog.mainImage?.src ?? "/assets/blogctabgimage.png";
             return (
-              <Link
+              <TrackedCtaLink
                 href={blog.slug ? `/blog/${blog.slug}` : "/blog"}
                 key={blog.slug}
                 className={classes.blogimageone}
                 style={{ backgroundImage: `url("${bg}")` }}
+                cta={{
+                  ctaId: 'pcs_resources_blog_card',
+                  ctaIntent: 'content_navigation',
+                  ctaPosition: 'pcs_resources_blog_grid',
+                  ctaComponent: 'pcs_resources_blog',
+                  ctaLabel: 'Read guide',
+                  destination: blog.slug ? `/blog/${blog.slug}` : "/blog",
+                  pageType: 'pcs_resources',
+                  contentSlug: blog.slug,
+                  contentType: 'blog_post',
+                }}
               >
                 <div className="flex items-center absolute top-4 right-4 gap-2">
                   {blog.categories?.map((category) => (
@@ -66,7 +90,7 @@ export default function PcsResourcesBlog({ blogList, component }: Props) {
                     {excerpt(blog.content, 250)}
                   </p>
                 </div>
-              </Link>
+              </TrackedCtaLink>
             );
           })}
         </div>

--- a/components/PcsResources/PcsResourcesCalculators/PcsResourcesCalculators.tsx
+++ b/components/PcsResources/PcsResourcesCalculators/PcsResourcesCalculators.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import React from "react";
 import "@/app/globals.css";
 import Image from "next/image";
 import Link from "next/link";
+import { captureAnalyticsEvent } from "@/lib/analytics/client";
+import { buildCtaProperties } from "@/lib/analytics/cta";
 
 const PcsResourcesCalculators = () => {
   return (
@@ -26,6 +30,17 @@ const PcsResourcesCalculators = () => {
               target=""
               rel="noopener noreferrer"
               className="bg-white rounded-lg shadow-lg p-8 text-center hover:shadow-xl transition-shadow duration-300 block"
+              onClick={() => captureAnalyticsEvent('calculator_cta_clicked', buildCtaProperties({
+                ctaId: 'pcs_resources_bah_calculator_card',
+                ctaIntent: 'calculator_navigation',
+                ctaPosition: 'pcs_resources_calculator_cards',
+                ctaComponent: 'pcs_resources_calculators',
+                ctaLabel: 'BAH Calculator',
+                destination: '/pcs-resources#bah-calculator',
+                pageType: 'pcs_resources',
+                calculatorId: 'bah_calculator',
+                calculatorName: 'BAH Calculator',
+              }))}
             >
               <div className="mb-6 flex justify-center">
                 <Image
@@ -51,6 +66,17 @@ const PcsResourcesCalculators = () => {
             <Link
               href="/va-loan-calculator"
               className="bg-white rounded-lg shadow-lg p-8 text-center hover:shadow-xl transition-shadow duration-300 block"
+              onClick={() => captureAnalyticsEvent('calculator_cta_clicked', buildCtaProperties({
+                ctaId: 'pcs_resources_va_loan_calculator_card',
+                ctaIntent: 'calculator_navigation',
+                ctaPosition: 'pcs_resources_calculator_cards',
+                ctaComponent: 'pcs_resources_calculators',
+                ctaLabel: 'Mortgage Calculator',
+                destination: '/va-loan-calculator',
+                pageType: 'pcs_resources',
+                calculatorId: 'va_loan_calculator',
+                calculatorName: 'VA Loan Calculator',
+              }))}
             >
               <div className="mb-6 flex justify-center">
                 <Image

--- a/components/PcsResources/PcsResourcesVaLoanGuide/PcsResourcesVaLoanGuide.tsx
+++ b/components/PcsResources/PcsResourcesVaLoanGuide/PcsResourcesVaLoanGuide.tsx
@@ -34,7 +34,7 @@ const PcsResourcesVaLoanGuide = () => {
     email: Yup.string().email('Invalid email').required('Email is required'),
   });
 
-  const { register, handleSubmit, setValue, formState: { errors } } = useForm<FormInputs>({
+  const { register, handleSubmit, getValues, setValue, formState: { errors } } = useForm<FormInputs>({
     resolver: yupResolver(validationSchema),
     defaultValues: {
       firstName: '',
@@ -50,11 +50,6 @@ const PcsResourcesVaLoanGuide = () => {
       guide_id: 'va_loan_guide',
       form_id: 'va_loan_guide',
       has_email: Boolean(data.email),
-    });
-    trackFormSubmitAttempted('va_loan_guide', {
-      guide_id: 'va_loan_guide',
-      has_email: Boolean(data.email),
-      has_phone: false,
     });
     try {
       sendGTMEvent({
@@ -101,12 +96,24 @@ const PcsResourcesVaLoanGuide = () => {
     trackFormValidationFailed('va_loan_guide', formErrors, { guide_id: 'va_loan_guide' });
   };
 
+  const trackSubmitAttempt = () => {
+    const values = getValues();
+    trackFormSubmitAttempted('va_loan_guide', {
+      guide_id: 'va_loan_guide',
+      has_email: Boolean(values.email),
+      has_phone: false,
+    });
+  };
+
   return (
     <div className={classes.pcsresourcesvaloanguide}>
       <div className="container mx-auto px-5">
         <div className="grid lg:grid-cols-2 md:grid-cols-1 sm:grid-cols-1 grid-cols-1 items-start justify-between gap-6">
           <form
-            onSubmit={handleSubmit(onSubmitHandler, handleInvalidSubmit)}
+            onSubmit={(event) => {
+              trackSubmitAttempt();
+              void handleSubmit(onSubmitHandler, handleInvalidSubmit)(event);
+            }}
             onFocus={() => trackFormStarted('va_loan_guide', { guide_id: 'va_loan_guide' })}
           >
             <HoneypotField ref={honeypotRef} />

--- a/components/Refinancing/RefinancingContent/RefinancingContent.tsx
+++ b/components/Refinancing/RefinancingContent/RefinancingContent.tsx
@@ -14,7 +14,7 @@ import HelocAndHeloan from "./HelocAndHeloan";
 import VaDisability from "./VaDisability";
 import CreditImpact from "./CreditImpact";
 import CreditChanges from "./CreditChanges";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const RefinancingContent = () => {
   return (
@@ -56,7 +56,20 @@ const RefinancingContent = () => {
         <div className="my-4">
           <p className="text-[#000000] roboto lg:text-[23px] md:text-[23px] sm:text-[15px] text-[15px] md:font-medium sm:font-normal font-normal">
             Ready to explore your refinancing options?
-            <Link href="/contact-lender" className="text-[#348BE2]"> Connect with a VA loan expert</Link> today to see how much you could save.
+            <TrackedCtaLink
+              href="/contact-lender"
+              className="text-[#348BE2]"
+              cta={{
+                ctaId: 'refinancing_content_lender',
+                ctaIntent: 'contact_lender',
+                ctaPosition: 'refinancing_content_footer',
+                ctaComponent: 'refinancing_content',
+                ctaLabel: 'Connect with a VA loan expert',
+                destination: '/contact-lender',
+                pageType: 'refinancing',
+                partnerType: 'lender',
+              }}
+            > Connect with a VA loan expert</TrackedCtaLink> today to see how much you could save.
           </p>
         </div>
       </div>

--- a/components/Refinancing/RefinancingHero/RefinancingHero.tsx
+++ b/components/Refinancing/RefinancingHero/RefinancingHero.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import "@/app/globals.css";
 import styles from "./RefinancingHero.module.css";
 import Image from "next/image";
-import Link from "next/link";
 import Button from "@/components/common/Button";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const RefinancingHero = () => {
     return (
@@ -19,15 +19,36 @@ const RefinancingHero = () => {
                                 Lower your mortgage rate with the VA Streamline IRRRL. No income verification, no appraisal, and closing costs rolled into your loan. Close in as little as 10-14 business days.
                             </p>
                             <div className="flex flex-wrap gap-4 mb-10 mt-8">
-                                <Link href="/contact-lender">
+                                <TrackedCtaLink
+                                    href="/contact-lender"
+                                    cta={{
+                                        ctaId: 'refinancing_hero_lender',
+                                        ctaIntent: 'contact_lender',
+                                        ctaPosition: 'refinancing_hero',
+                                        ctaComponent: 'refinancing_hero',
+                                        ctaLabel: 'Connect with a Lender',
+                                        destination: '/contact-lender',
+                                        pageType: 'refinancing',
+                                        partnerType: 'lender',
+                                    }}
+                                >
                                     <Button buttonText="Connect with a Lender" />
-                                </Link>
-                                <Link
+                                </TrackedCtaLink>
+                                <TrackedCtaLink
                                     href="#how-it-works"
                                     className="px-6 bg-white text-[#292F6C] rounded-lg py-3 text-base font-medium hover:bg-gray-100 transition-colors h-full my-auto"
+                                    cta={{
+                                        ctaId: 'refinancing_hero_learn_more',
+                                        ctaIntent: 'section_navigation',
+                                        ctaPosition: 'refinancing_hero',
+                                        ctaComponent: 'refinancing_hero',
+                                        ctaLabel: 'Learn More',
+                                        destination: '#how-it-works',
+                                        pageType: 'refinancing',
+                                    }}
                                 >
                                     Learn More
-                                </Link>
+                                </TrackedCtaLink>
                             </div>
                         </div>
                     </div>

--- a/components/SearchBlog/SearchBlog.tsx
+++ b/components/SearchBlog/SearchBlog.tsx
@@ -1,12 +1,12 @@
 import "@/app/globals.css";
 import Image from "next/image";
-import Link from "next/link";
 import { formatDate } from "@/utils/helper";
 import { excerpt } from "@/lib/blog/mdx";
 import type { BlogPost } from "@/lib/blog/types";
 import { BLOG_COMPONENTS } from "@/lib/blog/components";
 import BlogSearchForm from "@/components/BlogPage/BlogSearchForm";
 import { BlogSearchTracker } from "@/components/Analytics/Trackers";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 type Props = {
   searchedBlog: BlogPost[];
@@ -28,11 +28,37 @@ export default function SearchBlog({ searchedBlog, query }: Props) {
             <BlogSearchForm id="blog-empty-search-query" defaultQuery={query} />
           </div>
           <div className="mt-8 flex flex-wrap justify-center gap-4">
-            <Link href="/blog" className="text-[#292F6C] font-bold">Back to all guides</Link>
+            <TrackedCtaLink
+              href="/blog"
+              className="text-[#292F6C] font-bold"
+              cta={{
+                ctaId: 'blog_search_no_results_all_guides',
+                ctaIntent: 'content_navigation',
+                ctaPosition: 'blog_search_no_results',
+                ctaComponent: 'blog_search',
+                ctaLabel: 'Back to all guides',
+                destination: '/blog',
+                pageType: 'blog_search',
+              }}
+            >Back to all guides</TrackedCtaLink>
             {BLOG_COMPONENTS.slice(0, 3).map((component) => (
-              <Link key={component.slug} href={`/blog/category/${component.slug}`} className="text-[#292F6C] underline">
+              <TrackedCtaLink
+                key={component.slug}
+                href={`/blog/category/${component.slug}`}
+                className="text-[#292F6C] underline"
+                cta={{
+                  ctaId: 'blog_search_no_results_category',
+                  ctaIntent: 'content_navigation',
+                  ctaPosition: 'blog_search_no_results',
+                  ctaComponent: 'blog_search',
+                  ctaLabel: component.label,
+                  destination: `/blog/category/${component.slug}`,
+                  pageType: 'blog_search',
+                  contentType: 'blog_category',
+                }}
+              >
                 {component.label}
-              </Link>
+              </TrackedCtaLink>
             ))}
           </div>
         </div>
@@ -48,9 +74,21 @@ export default function SearchBlog({ searchedBlog, query }: Props) {
           {searchedBlog.length} result{searchedBlog.length === 1 ? '' : 's'}
           {trimmedQuery ? ` for "${trimmedQuery}"` : ''}
         </h1>
-        <Link href="/blog" className="mt-4 inline-block text-[#292F6C] font-bold">
+        <TrackedCtaLink
+          href="/blog"
+          className="mt-4 inline-block text-[#292F6C] font-bold"
+          cta={{
+            ctaId: 'blog_search_results_all_guides',
+            ctaIntent: 'content_navigation',
+            ctaPosition: 'blog_search_results_header',
+            ctaComponent: 'blog_search',
+            ctaLabel: 'Back to all guides',
+            destination: '/blog',
+            pageType: 'blog_search',
+          }}
+        >
           Back to all guides
-        </Link>
+        </TrackedCtaLink>
       </div>
       <div className="flex flex-wrap justify-start gap-10 my-10">
         <div className="lg:w-3/5 sm:w-full w-full xl:mr-14 lg:mr-5 md:mr-10 ">
@@ -59,7 +97,20 @@ export default function SearchBlog({ searchedBlog, query }: Props) {
             const heroAlt = blog.mainImage?.alt ?? "Blog image";
             return (
               <div className="my-10" key={blog.slug}>
-                <Link href={`/blog/${blog.slug}`}>
+                <TrackedCtaLink
+                  href={`/blog/${blog.slug}`}
+                  cta={{
+                    ctaId: 'blog_search_result_image',
+                    ctaIntent: 'content_navigation',
+                    ctaPosition: 'blog_search_results',
+                    ctaComponent: 'blog_search_result',
+                    ctaLabel: 'Search result image',
+                    destination: `/blog/${blog.slug}`,
+                    pageType: 'blog_search',
+                    contentSlug: blog.slug,
+                    contentType: 'blog_post',
+                  }}
+                >
                   {heroSrc ? (
                     <Image
                       src={heroSrc}
@@ -69,14 +120,25 @@ export default function SearchBlog({ searchedBlog, query }: Props) {
                       className="w-full h-full object-cover"
                     />
                   ) : null}
-                </Link>
+                </TrackedCtaLink>
                 <div className="mt-5">
-                  <a
+                  <TrackedCtaLink
                     href={`/blog/${blog.slug}`}
                     className="text-[#292F6C] font-bold lg:text-[48px] md:text-[29px] sm:text-[25px] text-[20px] tahoma lg:block md:block"
+                    cta={{
+                      ctaId: 'blog_search_result_title',
+                      ctaIntent: 'content_navigation',
+                      ctaPosition: 'blog_search_results',
+                      ctaComponent: 'blog_search_result',
+                      ctaLabel: 'Search result title',
+                      destination: `/blog/${blog.slug}`,
+                      pageType: 'blog_search',
+                      contentSlug: blog.slug,
+                      contentType: 'blog_post',
+                    }}
                   >
                     {blog.title}
-                  </a>
+                  </TrackedCtaLink>
                   <p className="text-[#000000] lg:text-[18px] md:text-[19px] sm:text-[16px] text-[13px] mt-5">
                     {formatDate(blog.publishedAt)}
                   </p>

--- a/components/StatePage/StatePageLetFindAgent/StatePageLetFindAgent.tsx
+++ b/components/StatePage/StatePageLetFindAgent/StatePageLetFindAgent.tsx
@@ -6,7 +6,13 @@ import Button from "@/components/common/Button";
 import Link from "next/link";
 import { trackCtaClicked } from "@/lib/analytics/client";
 
-const StatePageCityAgents = () => {
+const StatePageCityAgents = ({
+  stateSlug,
+  stateCode,
+}: {
+  stateSlug?: string;
+  stateCode?: string;
+}) => {
   return (
     <div className="bg-[#292F6C]">
       <div className="container mx-auto">
@@ -23,6 +29,8 @@ const StatePageCityAgents = () => {
                 cta_position: 'state_agent_list_footer',
                 cta_component: 'state_page_let_find_agent',
                 destination_path: '/contact-agent',
+                state_slug: stateSlug,
+                state_code: stateCode,
               })}
             >
               <Button buttonText="Let us find you an agent" />

--- a/components/StatePage/StatePageRelatedGuides/StatePageRelatedGuides.tsx
+++ b/components/StatePage/StatePageRelatedGuides/StatePageRelatedGuides.tsx
@@ -1,12 +1,14 @@
-import Link from 'next/link';
+import TrackedCtaLink from '@/components/common/TrackedCtaLink';
 import type { InternalLinkRegistryPost } from '@/lib/blog/registry';
 
 type Props = {
   stateName: string;
   guides: InternalLinkRegistryPost[];
+  stateSlug: string;
+  stateCode?: string;
 };
 
-export default function StatePageRelatedGuides({ stateName, guides }: Props) {
+export default function StatePageRelatedGuides({ stateName, guides, stateSlug, stateCode }: Props) {
   if (guides.length === 0) return null;
 
   return (
@@ -25,10 +27,23 @@ export default function StatePageRelatedGuides({ stateName, guides }: Props) {
         </div>
         <div className="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
           {guides.map((guide) => (
-            <Link
+            <TrackedCtaLink
               key={guide.slug}
               href={guide.url}
               className="group flex min-h-[210px] flex-col justify-between rounded-lg border border-[#E5E7EB] bg-[#F8F9FA] p-5 transition hover:-translate-y-1 hover:border-[#A81F23] hover:bg-white hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-[#A81F23]"
+              cta={{
+                ctaId: 'state_related_guide',
+                ctaIntent: 'content_navigation',
+                ctaPosition: 'state_related_guides',
+                ctaComponent: 'state_page_related_guides',
+                ctaLabel: 'Read guide',
+                destination: guide.url,
+                pageType: 'state_page',
+                stateCode,
+                stateSlug,
+                contentSlug: guide.slug,
+                contentType: 'blog_post',
+              }}
             >
               <div>
                 <p className="tahoma text-xs font-bold uppercase tracking-[1px] text-[#6C757D]">
@@ -46,7 +61,7 @@ export default function StatePageRelatedGuides({ stateName, guides }: Props) {
               <span className="tahoma mt-5 text-sm font-bold text-[#A81F23]">
                 Read guide
               </span>
-            </Link>
+            </TrackedCtaLink>
           ))}
         </div>
       </div>

--- a/components/StatePage/StatePaheHeroSection/StatePageHeroSection.tsx
+++ b/components/StatePage/StatePaheHeroSection/StatePageHeroSection.tsx
@@ -3,7 +3,7 @@ import "@/app/globals.css";
 import Image from "next/image";
 import Button from "@/components/common/Button";
 import CitySelection from "./CitySelection";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 import { urlForImage } from "@/sanity/lib/image";
 import { Image as SanityImage } from 'sanity';
 
@@ -15,12 +15,16 @@ interface StatePageHeroSectionProps {
   stateName: string;
   stateImage: StateImage;
   cityList: string[];
+  stateSlug: string;
+  stateCode?: string;
 }
 
 const StatePageHeroSection = ({
   stateName,
   stateImage,
   cityList,
+  stateSlug,
+  stateCode,
 }: StatePageHeroSectionProps) => {
   const imageUrl = stateImage ? urlForImage(stateImage) : "/assets/South-Carolina-map.png";
 
@@ -41,9 +45,23 @@ const StatePageHeroSection = ({
               <CitySelection cityList={cityList} />
               <div className="mt-6">
                 <p className="text-[#292F6C]">Don&apos;t want to browse?</p>
-                <Link href="/contact-agent">
+                <TrackedCtaLink
+                  href="/contact-agent"
+                  cta={{
+                    ctaId: 'state_hero_find_agent',
+                    ctaIntent: 'contact_agent',
+                    ctaPosition: 'state_hero',
+                    ctaComponent: 'state_page_hero',
+                    ctaLabel: 'Find an agent for me',
+                    destination: '/contact-agent',
+                    pageType: 'state_page',
+                    stateCode,
+                    stateSlug,
+                    partnerType: 'agent',
+                  }}
+                >
                   <Button buttonText="Find an agent for me" />
-                </Link>
+                </TrackedCtaLink>
               </div>
             </div>
           </div>

--- a/components/common/AgentCtaLink.tsx
+++ b/components/common/AgentCtaLink.tsx
@@ -1,22 +1,48 @@
-import Link from 'next/link';
+import type { ReactNode } from 'react';
+import TrackedCtaLink from '@/components/common/TrackedCtaLink';
 import { buildContactCtaHref } from '@/lib/contactAgentUrl';
 
 type Props = {
   stateSlug?: string | null;
+  stateCode?: string | null;
   className?: string;
-  children?: string;
+  children?: ReactNode;
   onClick?: () => void;
+  ctaId?: string;
+  ctaPosition?: string;
+  ctaComponent?: string;
 };
 
 export default function AgentCtaLink({
   stateSlug,
+  stateCode,
   className = '',
   children = 'Find an Agent',
   onClick,
+  ctaId = 'find_agent',
+  ctaPosition = 'shared_agent_cta',
+  ctaComponent = 'agent_cta_link',
 }: Props) {
+  const href = buildContactCtaHref({ stateSlug, form: 'agent' });
+
   return (
-    <Link href={buildContactCtaHref({ stateSlug, form: 'agent' })} className={className} onClick={onClick}>
+    <TrackedCtaLink
+      href={href}
+      className={className}
+      onClick={onClick}
+      cta={{
+        ctaId,
+        ctaIntent: 'contact_agent',
+        ctaPosition,
+        ctaComponent,
+        ctaLabel: typeof children === 'string' ? children : undefined,
+        destination: href,
+        stateCode,
+        stateSlug,
+        partnerType: 'agent',
+      }}
+    >
       {children}
-    </Link>
+    </TrackedCtaLink>
   );
 }

--- a/components/common/DownloadGuideComponent.tsx
+++ b/components/common/DownloadGuideComponent.tsx
@@ -6,7 +6,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { homebuyerGuideForm, vaLoanGuideForm } from "@/services/salesForcePostFormsService";
 import { sendGTMEvent } from "@next/third-parties/google";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 import { useHoneypot, HoneypotField } from '@/components/common/honeypot';
 import {
     captureAnalyticsEvent,
@@ -64,7 +64,7 @@ const DownloadGuideComponent: React.FC<DownloadGuideComponentProps> = ({
         email: Yup.string().email('Invalid email').required('Email is required'),
     });
 
-    const { register, handleSubmit, formState: { errors }, reset } = useForm<FormInputs>({
+    const { register, handleSubmit, getValues, formState: { errors }, reset } = useForm<FormInputs>({
         resolver: yupResolver(validationSchema),
         defaultValues: {
             firstName: '',
@@ -91,11 +91,6 @@ const DownloadGuideComponent: React.FC<DownloadGuideComponentProps> = ({
             guide_id: resolvedGuideId,
             form_id: resolvedGuideId,
             has_email: Boolean(data.email),
-        });
-        trackFormSubmitAttempted(resolvedGuideId, {
-            guide_id: resolvedGuideId,
-            has_email: Boolean(data.email),
-            has_phone: false,
         });
         try {
             if (gtmEventContent) {
@@ -148,6 +143,15 @@ const DownloadGuideComponent: React.FC<DownloadGuideComponentProps> = ({
         trackFormValidationFailed(resolvedGuideId, formErrors, { guide_id: resolvedGuideId });
     };
 
+    const trackSubmitAttempt = () => {
+        const values = getValues();
+        trackFormSubmitAttempted(resolvedGuideId, {
+            guide_id: resolvedGuideId,
+            has_email: Boolean(values.email),
+            has_phone: false,
+        });
+    };
+
     return (
         <div className={`flex justify-center items-center py-4 bg-white ${className}`}>
             <div className="w-full max-w-[800px] bg-white rounded-2xl shadow-lg p-8">
@@ -172,7 +176,10 @@ const DownloadGuideComponent: React.FC<DownloadGuideComponentProps> = ({
                 </div>
 
                 <form
-                    onSubmit={handleSubmit(onSubmitHandler, handleInvalidSubmit)}
+                    onSubmit={(event) => {
+                        trackSubmitAttempt();
+                        void handleSubmit(onSubmitHandler, handleInvalidSubmit)(event);
+                    }}
                     onFocus={() => trackFormStarted(resolvedGuideId, { guide_id: resolvedGuideId })}
                     className="mb-6"
                 >
@@ -218,12 +225,22 @@ const DownloadGuideComponent: React.FC<DownloadGuideComponentProps> = ({
                 </form>
 
                 <div className="w-full flex justify-center">
-                    <Link
+                    <TrackedCtaLink
                         className="w-auto px-8 bg-[#8B2D2D] text-white rounded-lg py-3 text-base font-medium hover:bg-[#722424]"
                         href={secondaryButtonLink}
+                        cta={{
+                            ctaId: 'guide_secondary_cta',
+                            ctaIntent: secondaryButtonLink.includes('contact-lender') ? 'contact_lender' : 'contact_agent',
+                            ctaPosition: 'guide_download_secondary',
+                            ctaComponent: 'download_guide_component',
+                            ctaLabel: secondaryButtonText,
+                            destination: secondaryButtonLink,
+                            pageType: 'guide',
+                            guideId: resolvedGuideId,
+                        }}
                     >
                         {secondaryButtonText}
-                    </Link>
+                    </TrackedCtaLink>
                 </div>
             </div>
         </div>

--- a/components/common/LenderCtaLink.tsx
+++ b/components/common/LenderCtaLink.tsx
@@ -1,22 +1,48 @@
-import Link from 'next/link';
+import type { ReactNode } from 'react';
+import TrackedCtaLink from '@/components/common/TrackedCtaLink';
 import { buildContactCtaHref } from '@/lib/contactAgentUrl';
 
 type Props = {
   stateSlug?: string | null;
+  stateCode?: string | null;
   className?: string;
-  children?: string;
+  children?: ReactNode;
   onClick?: () => void;
+  ctaId?: string;
+  ctaPosition?: string;
+  ctaComponent?: string;
 };
 
 export default function LenderCtaLink({
   stateSlug,
+  stateCode,
   className = '',
   children = 'Find a Lender',
   onClick,
+  ctaId = 'find_lender',
+  ctaPosition = 'shared_lender_cta',
+  ctaComponent = 'lender_cta_link',
 }: Props) {
+  const href = buildContactCtaHref({ stateSlug, form: 'lender' });
+
   return (
-    <Link href={buildContactCtaHref({ stateSlug, form: 'lender' })} className={className} onClick={onClick}>
+    <TrackedCtaLink
+      href={href}
+      className={className}
+      onClick={onClick}
+      cta={{
+        ctaId,
+        ctaIntent: 'contact_lender',
+        ctaPosition,
+        ctaComponent,
+        ctaLabel: typeof children === 'string' ? children : undefined,
+        destination: href,
+        stateCode,
+        stateSlug,
+        partnerType: 'lender',
+      }}
+    >
       {children}
-    </Link>
+    </TrackedCtaLink>
   );
 }

--- a/components/common/TrackedCtaLink.tsx
+++ b/components/common/TrackedCtaLink.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link, { type LinkProps } from 'next/link';
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from 'react';
+import { trackCtaClicked } from '@/lib/analytics/client';
+import { buildCtaProperties, type CtaTrackingInput } from '@/lib/analytics/cta';
+
+type Props = LinkProps
+  & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps | 'href' | 'onClick'>
+  & {
+    children: ReactNode;
+    cta: CtaTrackingInput;
+    onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+  };
+
+function hrefToPathCandidate(href: LinkProps['href']): unknown {
+  if (typeof href === 'string' || href instanceof URL) return href;
+  return href.pathname;
+}
+
+export default function TrackedCtaLink({
+  href,
+  cta,
+  onClick,
+  children,
+  ...props
+}: Props) {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    trackCtaClicked(buildCtaProperties({
+      ...cta,
+      destination: cta.destination ?? hrefToPathCandidate(href),
+    }));
+    onClick?.(event);
+  };
+
+  return (
+    <Link href={href} onClick={handleClick} {...props}>
+      {children}
+    </Link>
+  );
+}

--- a/components/contactpage/ContactForm/ContactForm.tsx
+++ b/components/contactpage/ContactForm/ContactForm.tsx
@@ -3,7 +3,6 @@ import Button from "@/components/common/Button";
 import "@/app/globals.css";
 import classes from "./ContactForm.module.css";
 import Image from "next/image";
-import Link from "next/link";
 import { useState, useEffect, useCallback } from "react";
 import { clientMediaAccountService } from "@/services/clientMediaAccountService";
 import type { MediaAccountProps } from "@/services/mediaAccountTypes";
@@ -16,6 +15,7 @@ import { sendGTMEvent } from "@next/third-parties/google";
 import { useConcierge } from "@/components/Concierge";
 import { featureFlags } from "@/lib/feature-flags";
 import { useHoneypot, HoneypotField } from '@/components/common/honeypot';
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 import {
   formTrackingPayload,
   trackFormStarted,
@@ -55,6 +55,7 @@ const ContactForm = () => {
   const {
     register,
     handleSubmit,
+    getValues,
     reset,
     formState: { errors },
   } = useForm<ContactFormData>({
@@ -71,10 +72,6 @@ const ContactForm = () => {
 
   async function onSubmit(data: ContactFormData) {
     setIsSubmitting(true);
-    trackFormSubmitAttempted('contact_form', {
-      has_email: Boolean(data.email),
-      has_phone: false,
-    });
     try {
       sendGTMEvent({
         event: 'contact_form_submission',
@@ -127,24 +124,56 @@ const ContactForm = () => {
     trackFormValidationFailed('contact_form', formErrors);
   };
 
+  const trackSubmitAttempt = () => {
+    const values = getValues();
+    trackFormSubmitAttempted('contact_form', {
+      has_email: Boolean(values.email),
+      has_phone: false,
+    });
+  };
+
   return (
     <div className="container mx-auto flex flex-wrap justify-center lg:py-12 md:py-12 sm:py-2 py-2 gap-10">
       <div className="flex flex-wrap justify-around rounded-[12.128px] bg-white shadow-[0px_0px_72.766px_36.383px_rgba(0,0,0,0.03)] p-4 w-full overflow-hidden mx-8 md:mb-0 mb-5">
         <div className="md:w-1/3 sm:w-full w-full ">
           <div className={classes.Container}>
-            <Link href="/get-listed-agents" className="block justify-start items-center gap-4 flex-wrap">
+            <TrackedCtaLink
+              href="/get-listed-agents"
+              className="block justify-start items-center gap-4 flex-wrap"
+              cta={{
+                ctaId: 'contact_page_get_listed_agents',
+                ctaIntent: 'partner_recruiting_agent',
+                ctaPosition: 'contact_page_sidebar',
+                ctaComponent: 'contact_form',
+                ctaLabel: 'Agents, Get Listed Here',
+                destination: '/get-listed-agents',
+                pageType: 'contact',
+              }}
+            >
               <Button
                 buttonText="Agents, Get Listed Here"
                 divClassName="!pb-0"
                 buttonClassName="border border-white border-2"
               />
-            </Link>
-            <Link href="/get-listed-lenders" className="block justify-start items-center gap-4 flex-wrap mb-6">
+            </TrackedCtaLink>
+            <TrackedCtaLink
+              href="/get-listed-lenders"
+              className="block justify-start items-center gap-4 flex-wrap mb-6"
+              cta={{
+                ctaId: 'contact_page_get_listed_lenders',
+                ctaIntent: 'partner_recruiting_lender',
+                ctaPosition: 'contact_page_sidebar',
+                ctaComponent: 'contact_form',
+                ctaLabel: 'Lenders, Get Listed Here',
+                destination: '/get-listed-lenders',
+                pageType: 'contact',
+              }}
+            >
               <Button
                 buttonText="Lenders, Get Listed Here"
                 buttonClassName="border border-white border-2"
               />
-            </Link>
+            </TrackedCtaLink>
 
             <div className={classes.Heading}>
               We would love to hear from you
@@ -163,7 +192,18 @@ const ContactForm = () => {
                     src="/icon/phone-call.svg"
                     alt="phone"
                   />
-                  <Link href="tel:7197825065">719-782-5065</Link>
+                  <TrackedCtaLink
+                    href="tel:7197825065"
+                    cta={{
+                      ctaId: 'contact_page_phone',
+                      ctaIntent: 'contact_phone',
+                      ctaPosition: 'contact_page_sidebar',
+                      ctaComponent: 'contact_form',
+                      ctaLabel: 'Phone',
+                      destination: 'tel:7197825065',
+                      pageType: 'contact',
+                    }}
+                  >719-782-5065</TrackedCtaLink>
                 </div>
                 <div className={classes.ContactItem}>
                   <Image
@@ -173,7 +213,18 @@ const ContactForm = () => {
                     src="/icon/sharp-email.svg"
                     alt="phone"
                   />
-                  <Link href="mailto:info@veteranpcs.com">info@veteranpcs.com</Link>
+                  <TrackedCtaLink
+                    href="mailto:info@veteranpcs.com"
+                    cta={{
+                      ctaId: 'contact_page_email',
+                      ctaIntent: 'contact_email',
+                      ctaPosition: 'contact_page_sidebar',
+                      ctaComponent: 'contact_form',
+                      ctaLabel: 'Email',
+                      destination: 'mailto:info@veteranpcs.com',
+                      pageType: 'contact',
+                    }}
+                  >info@veteranpcs.com</TrackedCtaLink>
                 </div>
               </div>
             </div>
@@ -181,14 +232,25 @@ const ContactForm = () => {
               <ul className="flex items-center md:justify-start justify-center gap-4 mt-5">
                 {mediaAccount.map((acc) => (
                   <li key={acc._id} className="bg-[#A81F23] rounded-[8px] w-8 h-8 p-2">
-                    <Link href={acc.link}>
+                    <TrackedCtaLink
+                      href={acc.link}
+                      cta={{
+                        ctaId: 'contact_page_social',
+                        ctaIntent: 'social_navigation',
+                        ctaPosition: 'contact_page_sidebar',
+                        ctaComponent: 'contact_form',
+                        ctaLabel: acc.name,
+                        destination: acc.link,
+                        pageType: 'contact',
+                      }}
+                    >
                       <Image
                         width={100}
                         height={100}
                         src={`/icon/${acc.icon}`}
                         alt={acc.name}
                       />
-                    </Link>
+                    </TrackedCtaLink>
                   </li>
                 ))}
               </ul>
@@ -198,7 +260,10 @@ const ContactForm = () => {
         <div className="md:w-2/3 sm:w-full w-full relative md:px-10 lg:px-20 mt-10 md:mt-0">
 
           <form
-            onSubmit={handleSubmit(onSubmit, handleInvalidSubmit)}
+            onSubmit={(event) => {
+              trackSubmitAttempt();
+              void handleSubmit(onSubmit, handleInvalidSubmit)(event);
+            }}
             onFocus={() => trackFormStarted('contact_form')}
           >
             <div className={classes.FormContainer}>

--- a/components/homepage/AgentLoanExpert/AgentLoanExpert.tsx
+++ b/components/homepage/AgentLoanExpert/AgentLoanExpert.tsx
@@ -1,7 +1,7 @@
 import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import classes from "./AgentLoanExpert.module.css";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const AgentLoanExpert = () => {
   return (
@@ -15,9 +15,21 @@ const AgentLoanExpert = () => {
             <p className="roboto text-[21px] italic font-medium text-white m-0 pt-5">
               Want to be featured?
             </p>
-            <Link href="/contact" className="md:mt-0 mt-7">
+            <TrackedCtaLink
+              href="/contact"
+              className="md:mt-0 mt-7"
+              cta={{
+                ctaId: 'homepage_agent_loan_expert_signup',
+                ctaIntent: 'partner_recruiting',
+                ctaPosition: 'homepage_agent_loan_expert',
+                ctaComponent: 'agent_loan_expert',
+                ctaLabel: 'Sign-up here',
+                destination: '/contact',
+                pageType: 'homepage',
+              }}
+            >
               <Button buttonText="Sign-up here" />
-            </Link>
+            </TrackedCtaLink>
           </div>
         </div>
       </div>

--- a/components/homepage/Covered/CoveredComp.tsx
+++ b/components/homepage/Covered/CoveredComp.tsx
@@ -1,9 +1,9 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import "@/app/globals.css";
-import Link from "next/link";
 import ClassNames from "./CoveredComp.module.css";
 import Image from "next/image";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 // Define the type for the 'card' prop
 interface Card {
@@ -32,7 +32,18 @@ const Covered: React.FC<CoveredProps> = ({ card }) => {
   }
 
   return (
-    <Link href={link}>
+    <TrackedCtaLink
+      href={link}
+      cta={{
+        ctaId: 'homepage_covered_card',
+        ctaIntent: 'content_navigation',
+        ctaPosition: 'homepage_covered',
+        ctaComponent: 'covered_card',
+        ctaLabel: title,
+        destination: link,
+        pageType: 'homepage',
+      }}
+    >
       <div className={ClassNames.coveredwrappercontainer}>
         <div className="xl:p-9 lg:p-9 md:p-9 sm:p-2 p-4 cover-card mx-auto">
           <div className="text-center">
@@ -72,7 +83,7 @@ const Covered: React.FC<CoveredProps> = ({ card }) => {
           </div>
         </div>
       </div>
-    </Link>
+    </TrackedCtaLink>
   );
 };
 

--- a/components/homepage/FamilySupport/FamilySupport.tsx
+++ b/components/homepage/FamilySupport/FamilySupport.tsx
@@ -4,8 +4,8 @@ import classes from "./FamilySupport.module.css";
 import Image from "next/image";
 import veterenceSupportService from "@/services/veterenceSupportService";
 import SupportContent from "./SupportContent";
-import Link from "next/link";
 import { VeteranCommunityProps } from "@/components/homepage/VeteranCommunity/VeteranCommunity";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 type BlockStyle = "h1" | "h2" | "h3" | "normal";
 
@@ -103,12 +103,21 @@ const FamilySupport = async ({ link, component_slug }: { link: string, component
               ))}
             </div>
 
-            <Link
+            <TrackedCtaLink
               href={link}
               className="flex lg:justify-start md:justify-start sm:justify-center justify-center items-center"
+              cta={{
+                ctaId: `homepage_family_support_${component_slug}`,
+                ctaIntent: 'content_navigation',
+                ctaPosition: 'homepage_family_support',
+                ctaComponent: 'family_support',
+                ctaLabel: pageData?.button_text || 'Learn More',
+                destination: link,
+                pageType: 'homepage',
+              }}
             >
               <Button buttonText={pageData?.button_text || "Learn More"} />
-            </Link>
+            </TrackedCtaLink>
           </div>
         </div>
       </div>

--- a/components/homepage/HeroSection/HeroSection.tsx
+++ b/components/homepage/HeroSection/HeroSection.tsx
@@ -2,7 +2,7 @@ import Button from "@/components/common/Button";
 import "@/app/globals.css";
 import classes from "./HeroSection.module.css";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 interface HeroSectionProps {
   title: string;
@@ -76,28 +76,71 @@ const HeroSection = ({ title, subTitle, page }: HeroSectionProps) => {
               )}
               {page == "home" && (
                 <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center lg:mb-12 lg:justify-start">
-                  <Link href="/contact-agent">
+                  <TrackedCtaLink
+                    href="/contact-agent"
+                    cta={{
+                      ctaId: 'homepage_hero_find_agent',
+                      ctaIntent: 'contact_agent',
+                      ctaPosition: 'hero_primary',
+                      ctaComponent: 'homepage_hero',
+                      ctaLabel: 'Find An Agent',
+                      destination: '/contact-agent',
+                      pageType: 'homepage',
+                    }}
+                  >
                     <Button buttonText="Find An Agent" />
-                  </Link>
-                  <Link
+                  </TrackedCtaLink>
+                  <TrackedCtaLink
                     href="#state-map"
                     className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-white/70 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white md:text-base"
+                    cta={{
+                      ctaId: 'homepage_hero_browse_state',
+                      ctaIntent: 'state_map',
+                      ctaPosition: 'hero_secondary',
+                      ctaComponent: 'homepage_hero',
+                      ctaLabel: 'Browse by State',
+                      destination: '#state-map',
+                      pageType: 'homepage',
+                    }}
                   >
                     Browse by State
-                  </Link>
+                  </TrackedCtaLink>
                 </div>
               )}
               {page == "spanish" && (
                 <div className="lg:flex md:flex justify-start items-center gap-4 flex-wrap ">
-                  <Link href="#state-map">
+                  <TrackedCtaLink
+                    href="#state-map"
+                    cta={{
+                      ctaId: 'spanish_hero_browse_state',
+                      ctaIntent: 'state_map',
+                      ctaPosition: 'hero_primary',
+                      ctaComponent: 'homepage_hero',
+                      ctaLabel: 'Explora nuestro mapa',
+                      destination: '#state-map',
+                      pageType: 'spanish',
+                    }}
+                  >
                     <Button buttonText="Explora nuestro mapa" />
-                  </Link>
+                  </TrackedCtaLink>
                   <p className="text-white font-normal xl:text-[30px] lg:text-[30px] md:text-[20px] sm:text-[20px] text-[20px] mx-10 xl:w-auto w-full hidden md:block">
                     O
                   </p>
-                  <Link href="/contact-agent" className="hidden md:block">
+                  <TrackedCtaLink
+                    href="/contact-agent"
+                    className="hidden md:block"
+                    cta={{
+                      ctaId: 'spanish_hero_find_agent',
+                      ctaIntent: 'contact_agent',
+                      ctaPosition: 'hero_secondary',
+                      ctaComponent: 'homepage_hero',
+                      ctaLabel: 'Encuentra un agente',
+                      destination: '/contact-agent',
+                      pageType: 'spanish',
+                    }}
+                  >
                     <Button buttonText="Encuentra un agente" />
-                  </Link>
+                  </TrackedCtaLink>
                 </div>
               )}
             </div>

--- a/components/homepage/KeepInTouch/KeepInTouch.tsx
+++ b/components/homepage/KeepInTouch/KeepInTouch.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback } from "react"; // No need for 
 import "@/app/globals.css";
 import classes from "./KeepInTouch.module.css";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 import { clientMediaAccountService } from "@/services/clientMediaAccountService";
 import type { MediaAccountProps } from "@/services/mediaAccountTypes";
 import { useForm } from 'react-hook-form';
@@ -44,6 +44,7 @@ const KeepInTouch = () => {
   const {
     register,
     handleSubmit,
+    getValues,
     reset,
     formState: { errors },
   } = useForm<ContactFormData>({
@@ -61,10 +62,6 @@ const KeepInTouch = () => {
 
   const handleFormSubmission = async (data: ContactFormData) => {
     setIsSubmitting(true);
-    trackFormSubmitAttempted('keep_in_touch', {
-      has_email: Boolean(data.email),
-      has_phone: false,
-    });
     try {
       sendGTMEvent({
         event: 'keep_in_touch_form_submission',
@@ -115,6 +112,14 @@ const KeepInTouch = () => {
     trackFormValidationFailed('keep_in_touch', formErrors);
   };
 
+  const trackSubmitAttempt = () => {
+    const values = getValues();
+    trackFormSubmitAttempted('keep_in_touch', {
+      has_email: Boolean(values.email),
+      has_phone: false,
+    });
+  };
+
   return (
     <div className="bg-[#EEEEEE] py-12">
       <div className="container mx-auto mb-12">
@@ -140,14 +145,25 @@ const KeepInTouch = () => {
                     key={acc._id}
                     className="bg-[#A81F23] rounded-[8px] w-8 h-8 p-2"
                   >
-                    <Link href={acc.link}>
+                    <TrackedCtaLink
+                      href={acc.link}
+                      cta={{
+                        ctaId: 'keep_in_touch_social',
+                        ctaIntent: 'social_navigation',
+                        ctaPosition: 'keep_in_touch',
+                        ctaComponent: 'keep_in_touch',
+                        ctaLabel: acc.name,
+                        destination: acc.link,
+                        pageType: 'homepage',
+                      }}
+                    >
                       <Image
                         width={50}
                         height={50}
                         src={`/icon/${acc.icon}`}
                         alt={acc.name}
                       />
-                    </Link>
+                    </TrackedCtaLink>
                   </li>
                 ))}
               </ul>
@@ -156,7 +172,10 @@ const KeepInTouch = () => {
           <div className="mt-5 lg:mt-0 md:mt-0 sm:mt-5">
             <div className={classes.CustomResponsiveCenter}>
               <form
-                onSubmit={handleSubmit(handleFormSubmission, handleInvalidSubmit)}
+                onSubmit={(event) => {
+                  trackSubmitAttempt();
+                  void handleSubmit(handleFormSubmission, handleInvalidSubmit)(event);
+                }}
                 onFocus={() => trackFormStarted('keep_in_touch')}
               >
                 <h2 className="lg:text-[36px] sm:text-[25px] text-[25px] poppins font-bold text-primary lg:text-left md:text-left sm:text-center text-center">

--- a/components/homepage/MakeItHome.tsx
+++ b/components/homepage/MakeItHome.tsx
@@ -2,7 +2,7 @@ import Button from "@/components/common/Button";
 import "@/app/globals.css";
 import "aos/dist/aos.css";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const MilitaryHomePage = () => {
   return (
@@ -41,12 +41,22 @@ const MilitaryHomePage = () => {
                 </li>
               </div>
             </ul>
-            <Link
+            <TrackedCtaLink
               href="/contact-lender"
               className="flex lg:justify-start md:justify-start sm:justify-center justify-center"
+              cta={{
+                ctaId: 'homepage_make_it_home_lender',
+                ctaIntent: 'contact_lender',
+                ctaPosition: 'homepage_make_it_home',
+                ctaComponent: 'make_it_home',
+                ctaLabel: 'Contact VA Loan Expert',
+                destination: '/contact-lender',
+                pageType: 'homepage',
+                partnerType: 'lender',
+              }}
             >
               <Button buttonText="Contact VA Loan Expert" />
-            </Link>
+            </TrackedCtaLink>
           </div>
         </div>
       </div>

--- a/components/homepage/ReviewTestimonial/ReviewTestimonial.tsx
+++ b/components/homepage/ReviewTestimonial/ReviewTestimonial.tsx
@@ -1,7 +1,7 @@
 import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import ReviewTestimonialSlider from "@/components/homepage/ReviewTestimonial/ReviewTestimonialSlider";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 interface Reviewer {
   profilePhotoUrl: string;
@@ -53,9 +53,20 @@ const ReviewTestimonial: React.FC<ReviewTestimonialProps> = ({
         </div>
 
         <div className="flex justify-center mt-12">
-          <Link href="/stories">
+          <TrackedCtaLink
+            href="/stories"
+            cta={{
+              ctaId: 'homepage_success_stories',
+              ctaIntent: 'stories_navigation',
+              ctaPosition: 'homepage_reviews',
+              ctaComponent: 'review_testimonial',
+              ctaLabel: 'More success stories',
+              destination: '/stories',
+              pageType: 'homepage',
+            }}
+          >
             <Button buttonText="More success stories" />
-          </Link>
+          </TrackedCtaLink>
         </div>
       </div>
     </div>

--- a/components/homepage/SkillsFuturesBuild/SkillsFuturesBuild.tsx
+++ b/components/homepage/SkillsFuturesBuild/SkillsFuturesBuild.tsx
@@ -1,7 +1,7 @@
 import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import classes from "./SkillsFuturesBuild.module.css";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const SkillFuturesBuild = () => {
   return (
@@ -17,9 +17,20 @@ const SkillFuturesBuild = () => {
                 Interested in Starting a Career as a Real Estate Agent or
                 Mortgage Loan Officer?
               </p>
-              <Link href="/internship">
+              <TrackedCtaLink
+                href="/internship"
+                cta={{
+                  ctaId: 'homepage_internship',
+                  ctaIntent: 'career_navigation',
+                  ctaPosition: 'homepage_skills_futures',
+                  ctaComponent: 'skills_futures_build',
+                  ctaLabel: 'Learn about our internship',
+                  destination: '/internship',
+                  pageType: 'homepage',
+                }}
+              >
                 <Button buttonText="Learn about our internship" />
-              </Link>
+              </TrackedCtaLink>
             </div>
           </div>
         </div>

--- a/components/homepage/StateMap.tsx
+++ b/components/homepage/StateMap.tsx
@@ -4,6 +4,9 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import Button from "@/components/common/Button";
 import { sendGTMEvent } from "@next/third-parties/google";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
+import { trackCtaClicked } from "@/lib/analytics/client";
+import { buildCtaProperties } from "@/lib/analytics/cta";
 
 const StateMapSvg = dynamic(() => import("@/components/homepage/StateMapSvg"), {
   ssr: false,
@@ -71,12 +74,24 @@ const StateMap = ({ title, subTitle, buttonText, buttonLink }: { title: string, 
   const handleSendGtmEvent = useCallback((event: React.MouseEvent<SVGElement> | React.MouseEvent<HTMLAnchorElement>) => {
     const target = event.currentTarget as HTMLElement;
     const href = target.getAttribute("href");
-    const dataName = target.getAttribute("data-name");
+    const dataName = target.getAttribute("data-name")
+      || target.querySelector("[data-name]")?.getAttribute("data-name");
     sendGTMEvent({
       event: "map_interaction",
       state: href || dataName || "unknown", // Use `href` first, fallback to `data-name`, default to "unknown"
     });
-  }, []);
+    const isStateLink = Boolean(dataName);
+    trackCtaClicked(buildCtaProperties({
+      ctaId: isStateLink ? 'state_map_state' : 'state_map_primary_cta',
+      ctaIntent: isStateLink ? 'state_page' : 'contact_agent',
+      ctaPosition: isStateLink ? 'desktop_state_map' : 'state_map_footer',
+      ctaComponent: 'homepage_state_map',
+      ctaLabel: dataName || buttonText,
+      destination: href || buttonLink,
+      pageType: 'homepage',
+      stateSlug: isStateLink && href ? href.replace(/^\//, '') : undefined,
+    }));
+  }, [buttonLink, buttonText]);
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -193,9 +208,23 @@ const StateMap = ({ title, subTitle, buttonText, buttonLink }: { title: string, 
                       </div>
                     ) : (
                       filteredStates.map((state) => (
-                        <a key={state.name} href={state.link} className="flex min-h-11 items-center justify-center border border-solid px-3 py-2 text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-primary">
+                        <TrackedCtaLink
+                          key={state.name}
+                          href={state.link}
+                          className="flex min-h-11 items-center justify-center border border-solid px-3 py-2 text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-primary"
+                          cta={{
+                            ctaId: 'state_map_mobile_state',
+                            ctaIntent: 'state_page',
+                            ctaPosition: 'mobile_state_dropdown',
+                            ctaComponent: 'homepage_state_map',
+                            ctaLabel: state.name,
+                            destination: state.link,
+                            pageType: 'homepage',
+                            stateSlug: state.link.replace(/^\//, ''),
+                          }}
+                        >
                           {state.name}
-                        </a>
+                        </TrackedCtaLink>
                       ))
                     )}
                   </div>

--- a/components/homepage/VaLoanGuideDownload.tsx
+++ b/components/homepage/VaLoanGuideDownload.tsx
@@ -6,7 +6,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { vaLoanGuideForm } from "@/services/salesForcePostFormsService";
 import { sendGTMEvent } from "@next/third-parties/google";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 import { useConcierge } from "@/components/Concierge";
 import { featureFlags } from "@/lib/feature-flags";
 import { useHoneypot, HoneypotField } from '@/components/common/honeypot';
@@ -44,7 +44,7 @@ const VaLoanGuideDownload = () => {
         email: Yup.string().email('Invalid email').required('Email is required'),
     });
 
-    const { register, handleSubmit, formState: { errors }, reset } = useForm<FormInputs>({
+    const { register, handleSubmit, getValues, formState: { errors }, reset } = useForm<FormInputs>({
         resolver: yupResolver(validationSchema),
         defaultValues: {
             name: '',
@@ -62,11 +62,6 @@ const VaLoanGuideDownload = () => {
             guide_id: 'va_loan_guide',
             form_id: 'va_loan_guide',
             has_email: Boolean(data.email),
-        });
-        trackFormSubmitAttempted('va_loan_guide', {
-            guide_id: 'va_loan_guide',
-            has_email: Boolean(data.email),
-            has_phone: false,
         });
         try {
             sendGTMEvent({ event: "conversion_download", content: "VA Loan Guide" });
@@ -117,6 +112,15 @@ const VaLoanGuideDownload = () => {
         trackFormValidationFailed('va_loan_guide', formErrors, { guide_id: 'va_loan_guide' });
     };
 
+    const trackSubmitAttempt = () => {
+        const values = getValues();
+        trackFormSubmitAttempted('va_loan_guide', {
+            guide_id: 'va_loan_guide',
+            has_email: Boolean(values.email),
+            has_phone: false,
+        });
+    };
+
     return (
         <div className="flex justify-center items-center py-4 bg-white">
             <div className="w-full max-w-[800px] bg-white rounded-2xl shadow-lg p-8">
@@ -133,7 +137,10 @@ const VaLoanGuideDownload = () => {
                 </div>
 
                 <form
-                    onSubmit={handleSubmit(onSubmitHandler, handleInvalidSubmit)}
+                    onSubmit={(event) => {
+                        trackSubmitAttempt();
+                        void handleSubmit(onSubmitHandler, handleInvalidSubmit)(event);
+                    }}
                     onFocus={() => trackFormStarted('va_loan_guide', { guide_id: 'va_loan_guide' })}
                     className="mb-6"
                 >
@@ -183,12 +190,23 @@ const VaLoanGuideDownload = () => {
                 </form>
 
                 <div className="w-full flex justify-center">
-                    <Link
+                    <TrackedCtaLink
                         className="w-auto px-8 bg-[#8B2D2D] text-white rounded-lg py-3 text-base font-medium hover:bg-[#722424]"
                         href="/contact-lender"
+                        cta={{
+                            ctaId: 'va_loan_guide_secondary_lender',
+                            ctaIntent: 'contact_lender',
+                            ctaPosition: 'guide_download_secondary',
+                            ctaComponent: 'va_loan_guide_download',
+                            ctaLabel: 'VA Loan Questions?',
+                            destination: '/contact-lender',
+                            pageType: 'homepage',
+                            guideId: 'va_loan_guide',
+                            partnerType: 'lender',
+                        }}
                     >
                         VA Loan Questions?
-                    </Link>
+                    </TrackedCtaLink>
                 </div>
             </div>
         </div>

--- a/components/homepage/VeteranCommunity/VeteranCommunity.tsx
+++ b/components/homepage/VeteranCommunity/VeteranCommunity.tsx
@@ -5,7 +5,7 @@ import classes from "./VeteranCommunity.module.css";
 import Image from "next/image";
 import veterenceSupportService from "@/services/veterenceSupportService";
 import SupportContent from "@/components/homepage/FamilySupport/SupportContent";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 type BlockStyle = "h1" | "h2" | "h3" | "normal";
 
@@ -122,12 +122,21 @@ const VeteranCommunity = async ({ component_slug }: { component_slug: string }) 
                 </div>
               ))}
             </div>
-            <Link
+            <TrackedCtaLink
               href="/impact"
               className="flex lg:justify-start md:justify-start sm:justify-center justify-center items-center"
+              cta={{
+                ctaId: 'homepage_veteran_community_impact',
+                ctaIntent: 'impact_navigation',
+                ctaPosition: 'homepage_veteran_community',
+                ctaComponent: 'veteran_community',
+                ctaLabel: pageData?.button_text || 'Our Impact',
+                destination: '/impact',
+                pageType: 'homepage',
+              }}
             >
               <Button buttonText={pageData?.button_text || "Our Impact"} />
-            </Link>
+            </TrackedCtaLink>
           </div>
           <div>
             <Image

--- a/components/homepage/VeteranPCSWorksComp/HomebuyerGuideDownload.tsx
+++ b/components/homepage/VeteranPCSWorksComp/HomebuyerGuideDownload.tsx
@@ -6,7 +6,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { homebuyerGuideForm } from "@/services/salesForcePostFormsService";
 import { sendGTMEvent } from "@next/third-parties/google";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 import { useHoneypot, HoneypotField } from '@/components/common/honeypot';
 import {
     captureAnalyticsEvent,
@@ -34,7 +34,7 @@ const HomebuyerGuideDownload = () => {
         email: Yup.string().email('Invalid email').required('Email is required'),
     });
 
-    const { register, handleSubmit, formState: { errors }, reset } = useForm<FormInputs>({
+    const { register, handleSubmit, getValues, formState: { errors }, reset } = useForm<FormInputs>({
         resolver: yupResolver(validationSchema),
         defaultValues: {
             name: '',
@@ -52,11 +52,6 @@ const HomebuyerGuideDownload = () => {
             guide_id: 'first_time_homebuyer_guide',
             form_id: 'first_time_homebuyer_guide',
             has_email: Boolean(data.email),
-        });
-        trackFormSubmitAttempted('first_time_homebuyer_guide', {
-            guide_id: 'first_time_homebuyer_guide',
-            has_email: Boolean(data.email),
-            has_phone: false,
         });
         try {
             sendGTMEvent({ event: "conversion_download", content: "First Time Home Buyer Guide" });
@@ -109,6 +104,15 @@ const HomebuyerGuideDownload = () => {
         });
     };
 
+    const trackSubmitAttempt = () => {
+        const values = getValues();
+        trackFormSubmitAttempted('first_time_homebuyer_guide', {
+            guide_id: 'first_time_homebuyer_guide',
+            has_email: Boolean(values.email),
+            has_phone: false,
+        });
+    };
+
     return (
         <div className="flex justify-center items-center py-4 bg-white">
             <div className="w-full max-w-[800px] bg-white rounded-2xl shadow-lg p-8">
@@ -125,7 +129,10 @@ const HomebuyerGuideDownload = () => {
                 </div>
 
                 <form
-                    onSubmit={handleSubmit(onSubmitHandler, handleInvalidSubmit)}
+                    onSubmit={(event) => {
+                        trackSubmitAttempt();
+                        void handleSubmit(onSubmitHandler, handleInvalidSubmit)(event);
+                    }}
                     onFocus={() => trackFormStarted('first_time_homebuyer_guide', {
                         guide_id: 'first_time_homebuyer_guide',
                     })}
@@ -165,12 +172,23 @@ const HomebuyerGuideDownload = () => {
                 </form>
 
                 <div className="w-full flex justify-center">
-                    <Link
+                    <TrackedCtaLink
                         className="w-auto px-8 bg-[#8B2D2D] text-white rounded-lg py-3 text-base font-medium hover:bg-[#722424]"
                         href="/contact-agent"
+                        cta={{
+                            ctaId: 'homebuyer_guide_secondary_agent',
+                            ctaIntent: 'contact_agent',
+                            ctaPosition: 'guide_download_secondary',
+                            ctaComponent: 'homebuyer_guide_download',
+                            ctaLabel: 'Contact me with an agent!',
+                            destination: '/contact-agent',
+                            pageType: 'homepage',
+                            guideId: 'first_time_homebuyer_guide',
+                            partnerType: 'agent',
+                        }}
                     >
                         Contact me with an agent!
-                    </Link>
+                    </TrackedCtaLink>
                 </div>
             </div>
         </div>

--- a/components/homepage/VeteranPCSWorksComp/VeteranPCSWorksComp.tsx
+++ b/components/homepage/VeteranPCSWorksComp/VeteranPCSWorksComp.tsx
@@ -2,7 +2,7 @@ import React from "react"; // No need for useState or useEffect
 import "@/app/globals.css";
 import classes from "./VeteranPCSWorksComp.module.css";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 // Define the type for the `veteranpcs` prop
 interface VeteranPCSWorksCompProps {
@@ -19,7 +19,19 @@ const VeteranPCSWorksComp: React.FC<VeteranPCSWorksCompProps> = ({
 }) => {
   const { img, title, subTitle, link } = veteranpcs;
   return (
-    <Link className={classes.veteranpcsworkscontainer} href={link}>
+    <TrackedCtaLink
+      className={classes.veteranpcsworkscontainer}
+      href={link}
+      cta={{
+        ctaId: 'homepage_how_it_works_card',
+        ctaIntent: 'content_navigation',
+        ctaPosition: 'homepage_veteranpcs_works',
+        ctaComponent: 'veteranpcs_works_card',
+        ctaLabel: title,
+        destination: link,
+        pageType: 'homepage',
+      }}
+    >
       <div className="xl:p-9 lg:p-9 md:p-9 sm:p-2 p-4 lg:w-[300px] lg:h-[340px] sm:w-[250px] w-[250px] sm:py-6 py-10 lg:mb-0 mb-4 flex flex-col justify-center items-center">
         <div className="text-center ">
           <div className="items-center justify-center">
@@ -47,7 +59,7 @@ const VeteranPCSWorksComp: React.FC<VeteranPCSWorksCompProps> = ({
           </div>
         </div>
       </div>
-    </Link>
+    </TrackedCtaLink>
   );
 };
 

--- a/components/homepage/WhyVeteranPCS.tsx
+++ b/components/homepage/WhyVeteranPCS.tsx
@@ -1,7 +1,7 @@
 import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const WhyVeteranPcs = () => {
   return (
@@ -113,9 +113,20 @@ const WhyVeteranPcs = () => {
               />
             </div>
             <div className="mx-auto justify-center text-center flex">
-              <Link href="/#state-map">
+              <TrackedCtaLink
+                href="/#state-map"
+                cta={{
+                  ctaId: 'homepage_why_find_agent',
+                  ctaIntent: 'state_map',
+                  ctaPosition: 'homepage_why_veteranpcs',
+                  ctaComponent: 'why_veteranpcs',
+                  ctaLabel: 'Find an Agent',
+                  destination: '/#state-map',
+                  pageType: 'homepage',
+                }}
+              >
                 <Button buttonText="Find an Agent" />
-              </Link>
+              </TrackedCtaLink>
             </div>
           </div>
         </div>

--- a/components/spanishpage/SupportSpanish/SupportSpanish.tsx
+++ b/components/spanishpage/SupportSpanish/SupportSpanish.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import "@/app/globals.css";
 import Button from "@/components/common/Button";
 import Image from "next/image";
-import Link from "next/link";
+import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 
 const SupportSpanish = async () => {
 
@@ -30,11 +30,23 @@ const SupportSpanish = async () => {
                       </p>
                     </div>
                     <div className="flex justify-start">
-                      <Link href="/contact-agent">
+                      <TrackedCtaLink
+                        href="/contact-agent"
+                        cta={{
+                          ctaId: 'spanish_support_agent',
+                          ctaIntent: 'contact_agent',
+                          ctaPosition: 'spanish_support',
+                          ctaComponent: 'support_spanish',
+                          ctaLabel: 'Descubre como conectarte con un prestamista',
+                          destination: '/contact-agent',
+                          pageType: 'spanish',
+                          partnerType: 'agent',
+                        }}
+                      >
                         <Button
                           buttonText={"Descubre cómo conectarte con un prestamista"}
                         />
-                      </Link>
+                      </TrackedCtaLink>
                     </div>
                   </div>
                   <div className="flex justify-center">

--- a/docs/analytics/posthog-implementation-context.md
+++ b/docs/analytics/posthog-implementation-context.md
@@ -1,11 +1,11 @@
 # VeteranPCS PostHog Implementation Context
 
-**Date:** 2026-06-24
+**Date:** 2026-06-26
 **Purpose:** Keep only the durable context needed to plan and extend VeteranPCS funnel telemetry. This is not the event taxonomy reference.
 
-**Status:** App-side PostHog telemetry, privacy sanitization, Customer Web-to-Lead attribution fields, and server-confirmed accepted-lead events are implemented on `main` and verified in production data. Salesforce Lead-to-Opportunity mappings and read-only FLS are configured, but record-level Opportunity propagation still needs the first attributed Lead conversion to verify. The Salesforce Opportunity outcome webhook is a later phase.
+**Status:** App-side PostHog telemetry, privacy sanitization, Customer Web-to-Lead attribution fields, server-confirmed accepted-lead events, and the explicit CTA hardening pass are implemented in the app code. Salesforce Lead-to-Opportunity mappings and read-only FLS are configured, but record-level Opportunity propagation still needs the first attributed Lead conversion to verify. The Salesforce Opportunity outcome webhook is a later phase.
 
-For the current event taxonomy, properties, PostHog queries, Salesforce joins, and GA/GTM comparator notes, see [telemetry-taxonomy.md](telemetry-taxonomy.md).
+For the current event taxonomy, properties, PostHog queries, Salesforce joins, and GA/GTM comparator notes, see [telemetry-taxonomy.md](telemetry-taxonomy.md). For the post-implementation coverage gaps and hardening sequence, see [telemetry-hardening-audit.md](telemetry-hardening-audit.md).
 
 ## Measurement Goal
 
@@ -34,15 +34,19 @@ PostHog is the primary system for new web telemetry and Salesforce outcome attri
 
 - PostHog client initialization and privacy controls live in `instrumentation-client.ts`.
 - The client analytics wrapper lives in `lib/analytics/client.ts`; the server-only wrapper lives in `lib/analytics/server.ts`.
+- Reusable CTA property construction lives in `lib/analytics/cta.ts`; tracked links live in `components/common/TrackedCtaLink.tsx`, `components/common/AgentCtaLink.tsx`, and `components/common/LenderCtaLink.tsx`.
 - `vpcs_visitor_id`, first-touch attribution, last-touch attribution, and safe pre-conversion counters live in `lib/analytics/visitor.ts`.
 - Sanitization rules live in `lib/analytics/sanitizer.ts`. Future telemetry changes should add tests there when introducing user-input-derived properties.
 - Customer Web-to-Lead forms now append only the approved additive Salesforce fields for visitor id and submission id.
 - `lead_conversion_created` is the canonical server-confirmed accepted-lead event. GA4/GTM conversion/download events are comparator signals and must not be treated as Salesforce-accepted conversions.
 - The shared guide download component now routes first-time homebuyer guide submissions through the first-time homebuyer action/source.
+- Customer forms emit `form_submit_attempted` before client validation so invalid submit attempts are counted.
 - BAH analytics uses `zip_prefix`, not full ZIP.
 - Direct email-keyed PostHog identifies/captures were removed from the Customer lead flow.
-- Contact Lender success behavior still has redirect/message nuance; preserve successful user behavior when changing analytics.
-- Concierge lead tools thread visitor/attribution context into the shared post functions.
+- Contact Lender success handling accepts either redirect-style responses or message/submission-id accepted responses, then redirects successful message-only submissions to `/thank-you`.
+- Concierge lead tools thread visitor/attribution context into the shared post functions and include safe `submission_id` values on completed tool telemetry when available.
+- Concierge open, message, and approval telemetry is explicit for launcher, seeded CTA, seeded message, manual message, agent-card selection, and tool approval paths. Do not send raw messages or prompts.
+- Server PostHog delivery failures are logged through the logging service with event/distinct-id context only; payload contents must not be logged.
 - The existing Salesforce revalidate route is not an acceptable pattern for money/outcome webhooks.
 - Record-level Lead-to-Opportunity attribution copying still needs live verification after an attributed Customer Lead is converted.
 
@@ -138,14 +142,15 @@ Use stable snake_case ids and controlled enums where possible:
 - `guide_id`
 - `state_code`, `state_slug`
 - `partner_type`, `partner_salesforce_id`
-- `cta_id`, `cta_intent`, `cta_position`, `cta_component`, `destination_path`
+- `cta_id`, `cta_intent`, `cta_position`, `cta_component`, `cta_location`, `cta_label`, `page_type`, `destination_path`
+- `content_slug`, `content_type`, `calculator_id`, `calculator_name`, `input_origin`, `concierge_topic` where applicable
 - `has_email`, `has_phone`
 - first-touch and last-touch attribution snapshots on `lead_conversion_created`
 - conversion context counters when safely available: `conversion_lag_seconds`, `pageview_count_before_conversion`, `cta_click_count_before_conversion`, `form_attempt_count_before_conversion`
 
 Never derive ids from user-entered text. For blog search, do not send raw query text; send safe derived properties such as `query_length`, `query_word_count`, `result_count`, `result_bucket`, `matched_state_code`, and controlled `matched_topic` only.
 
-Click taxonomy decision: use `cta_clicked` as the canonical event for partner cards, state CTAs, blog CTAs, popup CTAs, and generic contact links. Distinguish with `cta_id`, `cta_intent`, `cta_position`, `cta_component`, `partner_type`, `partner_salesforce_id`, `state_code`, `state_slug`, and `destination_path`. Do not add dedicated `agent_card_clicked`, `lender_card_clicked`, or `contact_click` events unless a future reporting requirement cannot be handled with `cta_clicked` properties.
+Click taxonomy decision: use `cta_clicked` as the canonical event for partner cards, state CTAs, blog CTAs, popup CTAs, and generic contact links. Distinguish with `cta_id`, `cta_intent`, `cta_position`, `cta_component`, `cta_location`, `cta_label`, `page_type`, `partner_type`, `partner_salesforce_id`, `state_code`, `state_slug`, `content_slug`, `content_type`, and `destination_path`. Do not add dedicated `agent_card_clicked`, `lender_card_clicked`, or `contact_click` events unless a future reporting requirement cannot be handled with `cta_clicked` properties.
 
 ## Resolved Salesforce Attribution Setup
 
@@ -196,8 +201,11 @@ Before implementing the closed-loop outcome webhook, confirm:
 - Test future server logs do not include raw PII/free text.
 - Test failed or abandoned submissions do not emit canonical conversions.
 - Test form failure telemetry uses safe `failure_stage` and `error_codes`, never raw messages.
+- Test invalid submissions emit both `form_submit_attempted` and `form_validation_failed`.
 - Test BAH telemetry does not include full ZIP.
 - Test concierge telemetry excludes raw messages/contact details.
+- Test reusable CTA telemetry sends path-only destinations and no raw query strings.
+- Test server PostHog delivery failures log safely without throwing.
 - Test GA4 comparator events are not treated as source-of-truth conversions.
 - Later webhook phase: test bad HMAC, stale timestamp, duplicate delivery, Redis unavailable/error, PostHog delivery failure, non-Customer Opportunity, stale `SystemModstamp`, and revenue/date corrections.
 - Run `npm run lint`, `npm run type-check`, `npm run build`, and `npm test` for touched `lib/**`, `services/**`, forms, server actions, or webhook routes.

--- a/docs/analytics/telemetry-hardening-audit.md
+++ b/docs/analytics/telemetry-hardening-audit.md
@@ -1,0 +1,167 @@
+# Telemetry Hardening Audit
+
+Last updated: 2026-06-26
+
+This document captures the post-implementation coverage audit for VeteranPCS telemetry and the remediation status from the explicit telemetry hardening pass. Use it with `docs/analytics/telemetry-taxonomy.md` when planning future telemetry changes.
+
+## Bottom Line
+
+The core lead funnel telemetry is in place, and the 2026-06-26 hardening pass added explicit CTA coverage across the highest-value header, footer, homepage, state, blog/content, guide, calculator, and marketing surfaces without enabling PostHog autocapture.
+
+Confidence levels after the hardening pass:
+
+- Core lead funnel: high. Page counters, blog/state views, Customer form lifecycle, guide downloads, accepted Salesforce lead conversions, BAH usage, moving bonus, VA calculator CTA, and state partner-card CTAs are implemented.
+- Explicit high-value CTA coverage: medium-high pending post-deploy validation. Reusable CTA infrastructure now covers the known high-value gaps from this audit; final confidence depends on deployed PostHog volume/property checks.
+- Privacy posture: high pending post-deploy validation. New telemetry uses path-only destinations, safe field-level validation codes, contact flags, query metrics, and safe submission ids instead of raw user input.
+
+Do not build final PostHog dashboards until the post-deploy SQL checks in `telemetry-taxonomy.md` confirm CTA coverage, required properties, and absence of blocked PII properties in live data.
+
+## Covered Spine
+
+- `PageviewTracker` is mounted globally in `app/layout.tsx`.
+- `content_viewed` is mounted on blog post pages in `app/(site)/blog/[slug]/page.tsx`.
+- `state_page_viewed` is mounted on state pages in `app/(site)/[state]/page.tsx`.
+- Blog search emits `blog_search_submitted` and `blog_search_results` without raw query text.
+- State agent/lender cards emit `cta_clicked` with partner and state context.
+- State CTA band emits `cta_clicked` for agent/lender paths.
+- Customer forms emit form lifecycle events and pass `formTrackingPayload()` into server submissions.
+- Guide forms emit `guide_download_requested`, `guide_download_started`, and form lifecycle events.
+- Server-confirmed `lead_conversion_created` fires only after accepted Salesforce Web-to-Lead and skips spam-quarantined leads.
+- BAH usage emits `bah_calculator_used` with `zip_prefix`, not full ZIP.
+- Moving bonus emits `moving_bonus_calculated` and its CTA emits `calculator_cta_clicked`.
+- VA loan calculator custom quote CTA emits `calculator_cta_clicked`.
+- Concierge has basic open/message/tool/completion telemetry.
+- Shared CTA tracking now lives in `lib/analytics/cta.ts` and `components/common/TrackedCtaLink.tsx`.
+- `AgentCtaLink` and `LenderCtaLink` emit canonical `cta_clicked` events.
+- Header, footer, homepage, state map, state page, blog/content, guide, calculator, and marketing CTAs have explicit PostHog coverage through `cta_clicked` or `calculator_cta_clicked`.
+- Contact-lender success handling accepts message/submission-id server responses as successful accepted submissions.
+- Form submit attempts are tracked before client validation, including invalid submissions.
+- Validation error telemetry preserves safe field-level codes while blocking raw values.
+- Concierge open, seeded/manual message, agent-card selection, approval, and lead-tool completion telemetry aligns with the taxonomy and avoids raw text.
+- Server PostHog capture failures are logged safely without throwing or leaking event payload contents.
+
+## Hardening Pass Remediation
+
+Completed in this pass:
+
+- Added reusable tracked CTA infrastructure with path-only destination sanitization and shared agent/lender wrappers.
+- Patched high-value CTA gaps across global navigation, footer links, homepage sections, state map/state pages, blog/content journeys, guide modules, calculator links, refinancing, Spanish, impact/charity, contact, and about-style marketing surfaces.
+- Preserved existing GA/GTM comparator events while adding canonical PostHog events.
+- Fixed contact-lender message-only success handling so accepted leads do not register as client-side submission failures.
+- Moved customer-form submit-attempt telemetry before client validation so invalid attempts are counted.
+- Preserved safe validation error codes for contact fields without sending raw names, email addresses, phone numbers, messages, or field values.
+- Removed server-owned concierge event names from the client analytics event union.
+- Aligned concierge approval telemetry to `tool_name` plus boolean `approved`.
+- Added explicit telemetry for seeded concierge opens/messages and agent-card selection messages without raw text.
+- Added safe `submission_id` to completed concierge lead-tool telemetry when the underlying service returns one.
+- Added safe logging for server PostHog capture failures.
+- Added focused tests for CTA sanitization, privacy regressions, contact-lender success handling, validation codes, concierge/server event boundaries, and server PostHog failure logging.
+
+Still intentionally out of scope:
+
+- Salesforce Opportunity webhook and outcome events.
+- PostHog dashboard creation or modification.
+- Salesforce metadata/admin config changes.
+- Salesforce test lead creation.
+- Historical PostHog deletion or anonymization.
+- Broad PostHog autocapture.
+- New `concierge_chat_failed` or `concierge_chat_blocked` events; add these only through a future taxonomy update and route-level implementation.
+
+## Pre-Pass High-Priority Gaps (Historical)
+
+The items below are preserved as the source audit that drove the hardening pass. Re-check code and live PostHog data before treating any historical gap as still open.
+
+### Shared And Global CTAs
+
+- `components/common/AgentCtaLink.tsx` and `components/common/LenderCtaLink.tsx` only build URLs; they do not emit `cta_clicked`.
+- `components/Header.tsx` uses those wrappers and plain links, so global navigation and primary header CTAs are under-instrumented.
+- `components/Footer/Footer.tsx` Explore links, calculator links, contact links, and state/location links do not emit canonical CTA events.
+
+### Homepage And Marketing Surfaces
+
+- Homepage hero CTAs in `components/homepage/HeroSection/HeroSection.tsx` are untracked.
+- `components/homepage/StateMap.tsx` sends GTM only; desktop map links, mobile dropdown links, and the bottom match CTA do not emit canonical `cta_clicked`.
+- Homepage/marketing cards and CTAs such as `VeteranPCSWorksComp`, `MakeItHome`, `CoveredComp`, impact/charity partner CTAs, refinancing CTAs, and Spanish-page CTAs are mostly plain links.
+- Guide modules track guide form events, but adjacent secondary CTAs are silent PostHog exits:
+  - `components/homepage/VaLoanGuideDownload.tsx`
+  - `components/homepage/VeteranPCSWorksComp/HomebuyerGuideDownload.tsx`
+  - `components/common/DownloadGuideComponent.tsx`
+
+### Blog And Content Journeys
+
+- Blog landing hero/article/category links are not tracked as content-navigation CTAs.
+- Blog CTA bands are untracked:
+  - `components/BlogPage/BlogPage/BlogCTA/BlogCta.tsx`
+  - `components/BlogDetails/BlogDetailsCta/BlogDetailsCta.tsx`
+  - mobile sticky CTA in `app/(site)/blog/[slug]/page.tsx`
+- Author and MDX CTAs are untracked:
+  - `components/Blog/AuthorByline.tsx`
+  - `components/Blog/mdx/AgentContactLink.tsx`
+  - `components/Blog/mdx/PromoCard.tsx`
+- Blog search result clicks and no-result recovery links are not canonical CTAs.
+- Category page "Find an Agent" CTA in `app/(site)/blog/category/[category]/CategoryBlogPage.tsx` is untracked.
+
+### State Pages
+
+- State hero "Find an agent for me" in `components/StatePage/StatePaheHeroSection/StatePageHeroSection.tsx` is untracked.
+- State related-guide cards in `components/StatePage/StatePageRelatedGuides/StatePageRelatedGuides.tsx` are untracked.
+- `components/StatePage/StatePageLetFindAgent/StatePageLetFindAgent.tsx` emits `cta_clicked`, but omits state context.
+
+### Forms And Calculators
+
+- `app/(site)/contact-lender/page.tsx` can mark a successful accepted lead as client-side `form_submission_failed` because it only treats `redirectUrl` as success, while the service may return `{ message, submissionId }`.
+- Invalid form submits currently emit `form_validation_failed` but not `form_submit_attempted`, so submit attempts before validation are undercounted.
+- `errorCodesFromErrors` may over-sanitize safe validation field codes for fields like email, phone, firstName, and lastName.
+- BAH result CTA "Questions about VA Loan?" in `components/BAHCalculator.tsx` should emit `calculator_cta_clicked`.
+- PCS resource calculator navigation cards are untracked.
+- Legacy GTM for moving bonus still receives raw `home_value`; PostHog is bucketed.
+- Accepted-lead tests mainly assert the contact-agent path; other canonical Customer form IDs need coverage.
+
+### Concierge
+
+- `concierge_tool_approval_responded` does not match the taxonomy: docs expect `tool_name` and boolean `approved`, while code sends `approval_response`.
+- Concierge opens from form CTAs call `openConcierge()` without telemetry, so seeded opens are undercounted.
+- `concierge_message_sent` tracks manual messages but not seeded opening messages or agent-card selection messages.
+- `concierge_chat_completed` has no failure or blocked counterpart, so guardrail/rate-limit/model failures are opaque.
+- Server-owned event names are still present in the client event union, which creates a misuse risk.
+- `concierge_tool_completed` does not include `submission_id`, even though the underlying form services return one.
+- `lib/posthog-server.ts` swallows server PostHog delivery failures without logging.
+
+## Completed Implementation Sequence
+
+1. Create a reusable tracked CTA pattern.
+   - Add a client helper/component for `Link`-based CTAs.
+   - Extend `AgentCtaLink` and `LenderCtaLink` so shared contact CTAs emit `cta_clicked` with `cta_id`, `cta_intent`, `cta_position`, `cta_component`, and path-only `destination_path`.
+
+2. Patch high-value CTA surfaces.
+   - Header, footer, homepage hero, state map, state hero, guide secondary CTAs, BAH result CTA, calculator cards, blog CTA bands, blog sticky CTA, author/MDX CTA helpers, search result clicks, and state related-guide cards.
+
+3. Fix telemetry correctness bugs.
+   - Normalize contact-lender success handling.
+   - Decide whether `form_submit_attempted` should fire before validation and implement consistently.
+   - Preserve safe validation error codes without leaking values.
+   - Align concierge approval properties with taxonomy.
+   - Track seeded concierge opens/messages.
+   - Include `submission_id` on concierge tool completion where available.
+   - Log server PostHog delivery failures safely.
+
+4. Add focused tests.
+   - CTA helper property shape and path sanitization.
+   - Shared agent/lender CTA clicks.
+   - BAH result CTA.
+   - Guide secondary CTAs.
+   - Contact-lender success handling.
+   - Validation error-code behavior.
+   - Accepted-lead telemetry for all six Customer form IDs.
+   - Concierge approval/open/message/tool completion behavior.
+
+5. Verify locally and after deploy.
+   - Run `npm run type-check`, `npm run lint`, `npm test`, and `npm run build`.
+   - After deployment, use the SQL snippets in `telemetry-taxonomy.md` to verify event counts, required property coverage, blocked PII checks, form lifecycle, and accepted conversions.
+
+## Planning Notes
+
+- Keep PostHog autocapture disabled unless there is an explicit privacy-reviewed decision to change it.
+- Prefer properties on `cta_clicked` over creating new click events.
+- Do not send names, email, phone, raw messages, raw search queries, full URL queries, or full ZIP codes to PostHog.
+- Dashboard work should wait until this hardening pass is deployed and the SQL checks in `telemetry-taxonomy.md` confirm live event coverage and privacy safety.

--- a/docs/analytics/telemetry-taxonomy.md
+++ b/docs/analytics/telemetry-taxonomy.md
@@ -1,6 +1,6 @@
 # VeteranPCS Telemetry Taxonomy
 
-Last updated: 2026-06-24
+Last updated: 2026-06-26
 
 This is the durable reference for VeteranPCS web telemetry. Use it when changing analytics code, troubleshooting PostHog, comparing against Google Analytics, or planning Salesforce closed-loop reporting.
 
@@ -18,6 +18,7 @@ Salesforce remains the business source of truth for Leads, Customer Opportunitie
 | Server analytics wrapper | `lib/analytics/server.ts` |
 | Visitor id and attribution state | `lib/analytics/visitor.ts` |
 | Property sanitizer | `lib/analytics/sanitizer.ts` |
+| Reusable CTA tracking | `lib/analytics/cta.ts`, `components/common/TrackedCtaLink.tsx`, `components/common/AgentCtaLink.tsx`, `components/common/LenderCtaLink.tsx` |
 | PostHog browser SDK config | `instrumentation-client.ts` |
 | Page/content/search trackers | `components/Analytics/Trackers.tsx` |
 | Salesforce Web-to-Lead attribution fields | `services/salesforceLeadParams.ts`, `services/salesForcePostFormsService.tsx` |
@@ -71,8 +72,12 @@ Common optional properties:
 | `state_code`, `state_slug` | State pages, partner CTAs, lead intent |
 | `partner_type` | `agent` or `lender` |
 | `partner_salesforce_id` | Salesforce Account/partner id, not a person name |
-| `cta_id`, `cta_intent`, `cta_position`, `cta_component` | Click reporting dimensions |
+| `cta_id`, `cta_intent`, `cta_position`, `cta_component`, `cta_location`, `cta_label` | Click reporting dimensions |
 | `destination_path` | Path only, no query string |
+| `page_type` | Route/content surface grouping for CTA coverage |
+| `content_slug`, `content_type` | Content-navigation CTA context |
+| `calculator_id`, `calculator_name` | Calculator-specific CTA context |
+| `input_origin`, `concierge_topic` | Concierge open/message context; controlled enums only |
 | `has_email`, `has_phone` | Boolean contact coverage flags only |
 | `first_touch_attribution`, `last_touch_attribution` | Snapshotted onto `lead_conversion_created` |
 | `pageview_count_before_conversion` | Safe pre-conversion counter |
@@ -97,19 +102,19 @@ Common optional properties:
 
 | Event | Emitted By | Key Properties |
 |---|---|---|
-| `cta_clicked` | State CTAs, partner cards, blog CTAs, popup CTAs | `cta_id`, `cta_intent`, `cta_position`, `cta_component`, `destination_path`, optional partner/state fields |
-| `calculator_cta_clicked` | VA loan calculator, moving bonus calculator | `calculator_id`, `cta_id`, `cta_intent`, `destination_path`, calculator-specific buckets |
+| `cta_clicked` | Shared tracked CTA links, state CTAs, partner cards, blog CTAs, popup CTAs | `cta_id`, `cta_intent`, `cta_position`, `cta_component`, `cta_location`, `cta_label`, `page_type`, `destination_path`, optional partner/state/content fields |
+| `calculator_cta_clicked` | VA loan calculator, moving bonus calculator, BAH result CTA, PCS calculator cards | `calculator_id`, `calculator_name`, `cta_id`, `cta_intent`, `destination_path`, calculator-specific buckets |
 | `form_started` | Customer forms | `form_id`, optional `guide_id` |
-| `form_submit_attempted` | Customer forms | `form_id`, `has_email`, `has_phone`, optional `guide_id`, state fields |
-| `form_validation_failed` | Customer forms | `form_id`, `failure_stage`, `error_codes` |
+| `form_submit_attempted` | Customer forms before client validation | `form_id`, `has_email`, `has_phone`, optional `guide_id`, state fields |
+| `form_validation_failed` | Customer forms | `form_id`, `failure_stage`, safe field-level `error_codes` |
 | `form_submission_failed` | Customer forms | `form_id`, `failure_stage`, `error_codes` |
 | `guide_download_requested` | Guide forms | `guide_id`, `form_id`, `has_email` |
 | `guide_download_started` | Guide forms after accepted server response | `guide_id`, `form_id` |
-| `concierge_opened` | Concierge widget | `source_page_path` |
-| `concierge_message_sent` | Concierge widget | `query_length`, `query_word_count` |
+| `concierge_opened` | Concierge provider open paths | `source_page_path`, optional `input_origin`, `concierge_topic` |
+| `concierge_message_sent` | Concierge widget manual sends, seeded messages, agent-card selections | `query_length`, `query_word_count`, optional `input_origin`, no raw text |
 | `concierge_tool_approval_responded` | Concierge approval UI | `tool_name`, `approved` |
 | `concierge_tool_submitted` | Server-side concierge lead tools | `tool_name`, `form_id`, `lead_source`, optional state/guide fields |
-| `concierge_tool_completed` | Server-side concierge lead tools | same as submitted |
+| `concierge_tool_completed` | Server-side concierge lead tools | same as submitted plus optional `submission_id` |
 | `concierge_tool_failed` | Server-side concierge lead tools | same as submitted plus `failure_stage`, `error_codes` |
 | `concierge_chat_completed` | Chat route finish | `tokens_used`, `source_page_path` |
 
@@ -141,10 +146,15 @@ Use `cta_clicked` as the canonical event for partner cards, state CTAs, blog CTA
 - `cta_intent`
 - `cta_position`
 - `cta_component`
+- `cta_location`
+- `cta_label`
+- `page_type`
 - `partner_type`
 - `partner_salesforce_id`
 - `state_code`
 - `state_slug`
+- `content_slug`
+- `content_type`
 - `destination_path`
 
 Do not add dedicated events like `agent_card_clicked`, `lender_card_clicked`, or `contact_click` unless a future reporting requirement cannot be handled with `cta_clicked` properties.
@@ -203,6 +213,7 @@ Allowed substitutes:
 | ZIP code | `zip_prefix`, MHA, state, or controlled bucket |
 | Full URL | `source_page_path`, `destination_path` |
 | Partner name | `partner_salesforce_id`, `partner_type` |
+| Validation error message/value | safe field-level `error_codes` only |
 
 ## Google Analytics / GTM Comparator Events
 
@@ -268,6 +279,38 @@ ORDER BY events DESC
 LIMIT 100
 ```
 
+### Check CTA Coverage By Surface
+
+```sql
+SELECT properties.cta_location AS cta_location,
+       properties.page_type AS page_type,
+       properties.destination_path AS destination_path,
+       count() AS clicks,
+       uniqExact(distinct_id) AS distinct_ids
+FROM events
+WHERE timestamp >= toDateTime('YYYY-MM-DD HH:MM:SS')
+  AND timestamp < toDateTime('YYYY-MM-DD HH:MM:SS')
+  AND event = 'cta_clicked'
+GROUP BY cta_location, page_type, destination_path
+ORDER BY clicks DESC
+LIMIT 200
+```
+
+### Check CTA Required Properties
+
+```sql
+SELECT count() AS clicks,
+       countIf(properties.cta_id IS NOT NULL) AS with_cta_id,
+       countIf(properties.cta_intent IS NOT NULL) AS with_cta_intent,
+       countIf(properties.cta_location IS NOT NULL OR properties.cta_component IS NOT NULL) AS with_location,
+       countIf(properties.destination_path IS NOT NULL) AS with_destination_path,
+       countIf(position(toString(properties.destination_path), '?') > 0) AS rows_with_query_strings
+FROM events
+WHERE timestamp >= toDateTime('YYYY-MM-DD HH:MM:SS')
+  AND timestamp < toDateTime('YYYY-MM-DD HH:MM:SS')
+  AND event = 'cta_clicked'
+```
+
 ### Check Required Property Coverage
 
 ```sql
@@ -300,15 +343,37 @@ SELECT event,
          OR properties['firstName'] IS NOT NULL
          OR properties['lastName'] IS NOT NULL
          OR properties.message IS NOT NULL
+         OR properties.query IS NOT NULL
+         OR properties.search_query IS NOT NULL
+         OR properties.raw_text IS NOT NULL
          OR properties.zip_code IS NOT NULL
          OR properties.zipCode IS NOT NULL
          OR properties.bah_zip_code IS NOT NULL
+         OR position(toString(properties.source_page_path), '?') > 0
+         OR position(toString(properties.destination_path), '?') > 0
        ) AS rows_with_blocked_properties
 FROM events
 WHERE timestamp >= toDateTime('YYYY-MM-DD HH:MM:SS')
   AND timestamp < toDateTime('YYYY-MM-DD HH:MM:SS')
 GROUP BY event
 ORDER BY rows_with_blocked_properties DESC, events DESC
+LIMIT 100
+```
+
+### Check Lead Join Properties
+
+```sql
+SELECT event,
+       properties.form_id AS form_id,
+       count() AS events,
+       countIf(properties.submission_id IS NOT NULL) AS with_submission_id,
+       countIf(properties.vpcs_visitor_id IS NOT NULL) AS with_visitor_id
+FROM events
+WHERE timestamp >= toDateTime('YYYY-MM-DD HH:MM:SS')
+  AND timestamp < toDateTime('YYYY-MM-DD HH:MM:SS')
+  AND event IN ('lead_conversion_created', 'concierge_tool_completed')
+GROUP BY event, form_id
+ORDER BY event ASC, form_id ASC
 LIMIT 100
 ```
 

--- a/lib/__tests__/posthog-server.test.ts
+++ b/lib/__tests__/posthog-server.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureServerEvent } from '@/lib/posthog-server';
+import { logError } from '@/services/loggingService';
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  flush: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock('posthog-node', () => ({
+  PostHog: vi.fn(function PostHogMock() {
+    return {
+    capture: mocks.capture,
+    flush: mocks.flush,
+    };
+  }),
+}));
+
+vi.mock('@/services/loggingService', () => ({
+  logError: mocks.logError,
+}));
+
+describe('PostHog server delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs capture failures without leaking event properties', async () => {
+    const error = new Error('network down');
+    mocks.flush.mockRejectedValueOnce(error);
+
+    await expect(captureServerEvent({
+      distinctId: 'vpcs_test',
+      event: 'lead_conversion_created',
+      properties: {
+        form_id: 'contact_agent',
+        email: 'alex@example.com',
+      },
+    })).resolves.toBeUndefined();
+
+    expect(logError).toHaveBeenCalledWith(
+      'PostHog server capture failed',
+      { distinctId: 'vpcs_test', event: 'lead_conversion_created' },
+      error,
+    );
+    expect(mocks.logError.mock.calls[0][1]).not.toHaveProperty('properties');
+  });
+});

--- a/lib/ai/tools/lead-tools.ts
+++ b/lib/ai/tools/lead-tools.ts
@@ -32,6 +32,12 @@ function errorMessage(error: unknown): string {
   return 'Submission failed.';
 }
 
+function submissionIdFromResponse(response: unknown): string | undefined {
+  if (!response || typeof response !== 'object') return undefined;
+  const submissionId = (response as { submissionId?: unknown }).submissionId;
+  return typeof submissionId === 'string' ? submissionId : undefined;
+}
+
 // Overwrites SF additionalComments on each call — fine for single-submit flows;
 // a retry within one conversation will replace prior context.
 function composeAdditionalComments(parts: Array<[string, string | undefined]>): string {
@@ -119,12 +125,13 @@ const submitAgentRequestTool = tool({
         destinationState: input.destinationState,
         hasMessage: Boolean(input.message),
       });
-      await contactAgentPostForm(formData, '', { internalCallToken: INTERNAL_CALL_TOKEN });
+      const serverResponse = await contactAgentPostForm(formData, '', { internalCallToken: INTERNAL_CALL_TOKEN });
       await captureToolTelemetry('concierge_tool_completed', toolName, {
         form_id: 'contact_agent',
         lead_source: 'Contact Agent',
         state_code: stateCode,
         state_slug: stateSlug,
+        submission_id: submissionIdFromResponse(serverResponse),
       });
       return {
         ok: true,
@@ -186,12 +193,13 @@ const submitLenderRequestTool = tool({
         destinationState: input.destinationState,
         hasMessage: Boolean(input.message),
       });
-      await contactLenderPostForm(formData, '', { internalCallToken: INTERNAL_CALL_TOKEN });
+      const serverResponse = await contactLenderPostForm(formData, '', { internalCallToken: INTERNAL_CALL_TOKEN });
       await captureToolTelemetry('concierge_tool_completed', toolName, {
         form_id: 'contact_lender',
         lead_source: 'Contact Lender',
         state_code: stateCode,
         state_slug: stateSlug,
+        submission_id: submissionIdFromResponse(serverResponse),
       });
       return {
         ok: true,
@@ -245,10 +253,11 @@ const submitGeneralInquiryTool = tool({
       logInfo('Concierge tool: submitGeneralInquiry', {
         hasSubject: Boolean(input.subject),
       });
-      await contactPostForm(formData, { internalCallToken: INTERNAL_CALL_TOKEN });
+      const serverResponse = await contactPostForm(formData, { internalCallToken: INTERNAL_CALL_TOKEN });
       await captureToolTelemetry('concierge_tool_completed', toolName, {
         form_id: 'contact_form',
         lead_source: 'Contact Form',
+        submission_id: submissionIdFromResponse(serverResponse),
       });
       return {
         ok: true,
@@ -301,13 +310,14 @@ const submitVALoanGuideRequestTool = tool({
       logInfo('Concierge tool: submitVALoanGuideRequest', {
         hasState: Boolean(input.destinationState),
       });
-      await vaLoanGuideForm(formData, { internalCallToken: INTERNAL_CALL_TOKEN });
+      const serverResponse = await vaLoanGuideForm(formData, { internalCallToken: INTERNAL_CALL_TOKEN });
       await captureToolTelemetry('concierge_tool_completed', toolName, {
         form_id: 'va_loan_guide',
         lead_source: 'VA Loan Guide',
         guide_id: 'va_loan_guide',
         state_code: stateCode,
         state_slug: stateSlug,
+        submission_id: submissionIdFromResponse(serverResponse),
       });
       return {
         ok: true,

--- a/lib/analytics/__tests__/client.test.ts
+++ b/lib/analytics/__tests__/client.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  captureAnalyticsEvent,
+  trackCtaClicked,
+  trackFormSubmitAttempted,
+} from '@/lib/analytics/client';
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  captureAttributionFromLocation: vi.fn(),
+  getClientAnalyticsContext: vi.fn(() => ({
+    vpcs_visitor_id: 'vpcs_test_visitor',
+    source_page_path: '/contact-agent',
+    pageview_count_before_conversion: 1,
+    cta_click_count_before_conversion: 0,
+    form_attempt_count_before_conversion: 0,
+  })),
+  getOrCreateVisitorId: vi.fn(() => 'vpcs_test_visitor'),
+  incrementAnalyticsCounter: vi.fn(),
+}));
+
+vi.mock('posthog-js', () => ({
+  default: {
+    capture: mocks.capture,
+  },
+}));
+
+vi.mock('@/lib/analytics/visitor', () => ({
+  captureAttributionFromLocation: mocks.captureAttributionFromLocation,
+  getClientAnalyticsContext: mocks.getClientAnalyticsContext,
+  getOrCreateVisitorId: mocks.getOrCreateVisitorId,
+  incrementAnalyticsCounter: mocks.incrementAnalyticsCounter,
+}));
+
+describe('client analytics wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getClientAnalyticsContext.mockReturnValue({
+      vpcs_visitor_id: 'vpcs_test_visitor',
+      source_page_path: '/contact-agent',
+      pageview_count_before_conversion: 1,
+      cta_click_count_before_conversion: 0,
+      form_attempt_count_before_conversion: 0,
+    });
+  });
+
+  it('captures sanitized events with shared analytics context', () => {
+    captureAnalyticsEvent('cta_clicked', {
+      cta_id: 'test_cta',
+      destination_path: '/contact-agent?email=alex@example.com',
+    });
+
+    expect(mocks.capture).toHaveBeenCalledWith('cta_clicked', expect.objectContaining({
+      analytics_schema_version: 1,
+      journey_stage: 'mid',
+      vpcs_visitor_id: 'vpcs_test_visitor',
+      source_page_path: '/contact-agent',
+      cta_id: 'test_cta',
+      destination_path: '/contact-agent',
+    }));
+  });
+
+  it('does not throw when the PostHog SDK throws', () => {
+    mocks.capture.mockImplementationOnce(() => {
+      throw new Error('sdk unavailable');
+    });
+
+    expect(() => captureAnalyticsEvent('cta_clicked', {
+      cta_id: 'test_cta',
+    })).not.toThrow();
+  });
+
+  it('does not throw when context collection fails', () => {
+    mocks.getClientAnalyticsContext.mockImplementationOnce(() => {
+      throw new Error('storage unavailable');
+    });
+
+    expect(() => captureAnalyticsEvent('cta_clicked', {
+      cta_id: 'test_cta',
+    })).not.toThrow();
+    expect(mocks.capture).not.toHaveBeenCalled();
+  });
+
+  it('keeps CTA and form helpers best-effort when capture fails', () => {
+    mocks.capture.mockImplementation(() => {
+      throw new Error('sdk unavailable');
+    });
+
+    expect(() => trackCtaClicked({ cta_id: 'test_cta' })).not.toThrow();
+    expect(() => trackFormSubmitAttempted('contact_agent', {
+      has_email: false,
+      has_phone: false,
+    })).not.toThrow();
+    expect(mocks.incrementAnalyticsCounter).toHaveBeenCalledWith('cta_click_count_before_conversion');
+    expect(mocks.incrementAnalyticsCounter).toHaveBeenCalledWith('form_attempt_count_before_conversion');
+  });
+});

--- a/lib/analytics/__tests__/cta.test.ts
+++ b/lib/analytics/__tests__/cta.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildCtaProperties } from '@/lib/analytics/cta';
+import { sanitizeAnalyticsProperties } from '@/lib/analytics/sanitizer';
+
+describe('CTA analytics helpers', () => {
+  it('builds canonical CTA properties with path-only destinations', () => {
+    const clean = sanitizeAnalyticsProperties(buildCtaProperties({
+      ctaId: 'test_agent_cta',
+      ctaIntent: 'contact_agent',
+      ctaPosition: 'hero',
+      ctaComponent: 'test_component',
+      ctaLabel: 'Find an Agent',
+      destination: '/contact-agent?fn=Alex&id=001xx000003DGSW&state=texas',
+      stateCode: 'tx',
+      stateSlug: 'texas',
+      partnerType: 'agent',
+      partnerSalesforceId: '001xx000003DGSW',
+    }));
+
+    expect(clean).toMatchObject({
+      cta_id: 'test_agent_cta',
+      cta_intent: 'contact_agent',
+      cta_position: 'hero',
+      cta_component: 'test_component',
+      cta_label: 'Find an Agent',
+      destination_path: '/contact-agent',
+      state_code: 'TX',
+      state_slug: 'texas',
+      partner_type: 'agent',
+      partner_salesforce_id: '001xx000003DGSW',
+    });
+  });
+
+  it('does not retain raw query strings or PII-looking destinations', () => {
+    const clean = sanitizeAnalyticsProperties(buildCtaProperties({
+      ctaId: 'test_external',
+      ctaIntent: 'navigate',
+      ctaPosition: 'footer',
+      ctaComponent: 'test_component',
+      destination: 'https://www.veteranpcs.com/contact-lender?email=alex@example.com',
+    }));
+
+    expect(clean.destination_path).toBe('/contact-lender');
+    expect(JSON.stringify(clean)).not.toContain('alex@example.com');
+    expect(JSON.stringify(clean)).not.toContain('?email=');
+  });
+});

--- a/lib/analytics/__tests__/privacy-regression.test.ts
+++ b/lib/analytics/__tests__/privacy-regression.test.ts
@@ -28,6 +28,8 @@ describe('analytics privacy regressions', () => {
     expect(trackingProperties).toContain('zip_prefix: zipPrefix(formData.zipCode)');
     expect(trackingProperties).not.toMatch(/zip(?:Code|_code):/);
     expect(bahCalculator).not.toContain('bah_zip_code');
+    expect(bahCalculator).toContain("captureAnalyticsEvent('calculator_cta_clicked'");
+    expect(bahCalculator).toContain('bah_result_lender_cta');
   });
 
   it('routes first-time homebuyer guide downloads to their own server action', async () => {
@@ -44,6 +46,34 @@ describe('analytics privacy regressions', () => {
 
     expect(conciergeWidget).not.toContain('posthog');
     expect(conciergeWidget).toContain('queryMetrics(text)');
+    expect(conciergeWidget).toContain('queryMetrics(pendingSeed.openingMessage)');
     expect(conciergeWidget).not.toMatch(/\b(message_text|raw_text|query|search_query):\s*text\b/);
+  });
+
+  it('routes shared CTA wrappers through explicit tracked links', async () => {
+    const agentCta = await source('components/common/AgentCtaLink.tsx');
+    const lenderCta = await source('components/common/LenderCtaLink.tsx');
+    const stateMap = await source('components/homepage/StateMap.tsx');
+
+    expect(agentCta).toContain('TrackedCtaLink');
+    expect(lenderCta).toContain('TrackedCtaLink');
+    expect(stateMap).toContain('state_map_mobile_state');
+    expect(stateMap).toContain('state_map_state');
+  });
+
+  it('keeps server-owned PostHog events out of the client event union', async () => {
+    const clientAnalytics = await source('lib/analytics/client.ts');
+
+    expect(clientAnalytics).not.toContain("| 'concierge_tool_submitted'");
+    expect(clientAnalytics).not.toContain("| 'concierge_tool_completed'");
+    expect(clientAnalytics).not.toContain("| 'concierge_tool_failed'");
+    expect(clientAnalytics).not.toContain("| 'lead_conversion_created'");
+  });
+
+  it('adds safe submission ids to concierge tool completion telemetry', async () => {
+    const leadTools = await source('lib/ai/tools/lead-tools.ts');
+
+    expect(leadTools).toContain('function submissionIdFromResponse');
+    expect(leadTools).toContain('submission_id: submissionIdFromResponse(serverResponse)');
   });
 });

--- a/lib/analytics/__tests__/sanitizer.test.ts
+++ b/lib/analytics/__tests__/sanitizer.test.ts
@@ -64,4 +64,38 @@ describe('analytics sanitizer', () => {
     });
     expect(zipPrefix('80920-1234')).toBe('809');
   });
+
+  it('drops exception/autocapture non-scalar property values without throwing', () => {
+    const clean = sanitizeAnalyticsProperties({
+      $lib: 'posthog-js',
+      source_page_path: '/pcs-resources?utm_campaign=telemetry_hardening_smoke',
+      $exception_list: [
+        { type: 'Error', value: 'Hydration failed' },
+        { type: 'TypeError', value: 'value.trim is not a function' },
+      ],
+      $exception_frames: [
+        { filename: 'components/example.tsx', line: 57, column: 14 },
+      ],
+      $sdk_debug_extensions: {
+        exception_autocapture: { enabled: true },
+      },
+      $active_feature_flags: ['concierge', { key: 'unsafe_object' }, 42, true],
+      first_touch_attribution: {
+        utm_source: 'codex',
+        landing_page_path: '/pcs-resources?email=alex@example.com',
+        nested_payload: { unsafe: true },
+      },
+    });
+
+    expect(clean.$lib).toBe('posthog-js');
+    expect(clean.source_page_path).toBe('/pcs-resources');
+    expect(clean.$exception_list).toBeUndefined();
+    expect(clean.$exception_frames).toBeUndefined();
+    expect(clean.$sdk_debug_extensions).toBeUndefined();
+    expect(clean.$active_feature_flags).toEqual(['concierge', 42, true]);
+    expect(clean.first_touch_attribution).toEqual({
+      utm_source: 'codex',
+      landing_page_path: '/pcs-resources',
+    });
+  });
 });

--- a/lib/analytics/__tests__/sanitizer.test.ts
+++ b/lib/analytics/__tests__/sanitizer.test.ts
@@ -46,13 +46,15 @@ describe('analytics sanitizer', () => {
     });
   });
 
-  it('turns validation errors into field codes without contact fields', () => {
+  it('turns validation errors into safe field codes including contact field names', () => {
     expect(errorCodesFromErrors({
       email: { message: 'Invalid email' },
       phone: { message: 'Invalid phone' },
+      firstName: { message: 'Required' },
+      lastName: { message: 'Required' },
       currentBase: { message: 'Required' },
       state: { message: 'Required' },
-    })).toEqual(['currentbase', 'state']);
+    })).toEqual(['email', 'phone', 'firstname', 'lastname', 'currentbase', 'state']);
   });
 
   it('keeps only aggregate query and ZIP values for analytics', () => {

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -66,16 +66,22 @@ export function captureAnalyticsEvent(
   event: AnalyticsEventName,
   properties: AnalyticsProperties = {},
 ): void {
-  const context = getClientAnalyticsContext();
-  const props = sanitizeAnalyticsProperties({
-    analytics_schema_version: ANALYTICS_SCHEMA_VERSION,
-    journey_stage: EVENT_STAGE[event],
-    vpcs_visitor_id: context.vpcs_visitor_id,
-    source_page_path: context.source_page_path,
-    ...properties,
-  });
+  try {
+    const context = getClientAnalyticsContext();
+    const props = sanitizeAnalyticsProperties({
+      analytics_schema_version: ANALYTICS_SCHEMA_VERSION,
+      journey_stage: EVENT_STAGE[event],
+      vpcs_visitor_id: context.vpcs_visitor_id,
+      source_page_path: context.source_page_path,
+      ...properties,
+    });
 
-  posthog.capture(event, props);
+    posthog.capture(event, props);
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('PostHog client capture failed', event, error);
+    }
+  }
 }
 
 export function formTrackingPayload(): Record<string, unknown> {

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -32,11 +32,7 @@ export type AnalyticsEventName =
   | 'guide_download_started'
   | 'concierge_opened'
   | 'concierge_message_sent'
-  | 'concierge_tool_approval_responded'
-  | 'concierge_tool_submitted'
-  | 'concierge_tool_completed'
-  | 'concierge_tool_failed'
-  | 'lead_conversion_created';
+  | 'concierge_tool_approval_responded';
 
 const EVENT_STAGE: Record<AnalyticsEventName, JourneyStage> = {
   content_viewed: 'top',
@@ -56,10 +52,6 @@ const EVENT_STAGE: Record<AnalyticsEventName, JourneyStage> = {
   concierge_opened: 'mid',
   concierge_message_sent: 'mid',
   concierge_tool_approval_responded: 'mid',
-  concierge_tool_submitted: 'mid',
-  concierge_tool_completed: 'mid',
-  concierge_tool_failed: 'mid',
-  lead_conversion_created: 'bottom',
 };
 
 const startedForms = new Set<string>();

--- a/lib/analytics/cta.ts
+++ b/lib/analytics/cta.ts
@@ -1,0 +1,43 @@
+import { safePath, type AnalyticsProperties } from '@/lib/analytics/sanitizer';
+
+export type CtaTrackingInput = {
+  ctaId: string;
+  ctaIntent: string;
+  ctaPosition?: string;
+  ctaComponent: string;
+  ctaLocation?: string;
+  destination?: unknown;
+  ctaLabel?: string;
+  pageType?: string;
+  stateCode?: string | null;
+  stateSlug?: string | null;
+  contentSlug?: string | null;
+  contentType?: string | null;
+  guideId?: string | null;
+  calculatorId?: string | null;
+  calculatorName?: string | null;
+  partnerType?: 'agent' | 'lender' | null;
+  partnerSalesforceId?: string | null;
+};
+
+export function buildCtaProperties(input: CtaTrackingInput): AnalyticsProperties {
+  return {
+    cta_id: input.ctaId,
+    cta_intent: input.ctaIntent,
+    cta_position: input.ctaPosition,
+    cta_component: input.ctaComponent,
+    cta_location: input.ctaLocation ?? input.ctaComponent,
+    cta_label: input.ctaLabel,
+    page_type: input.pageType,
+    destination_path: safePath(input.destination),
+    state_code: input.stateCode ?? undefined,
+    state_slug: input.stateSlug ?? undefined,
+    content_slug: input.contentSlug ?? undefined,
+    content_type: input.contentType ?? undefined,
+    guide_id: input.guideId ?? undefined,
+    calculator_id: input.calculatorId ?? undefined,
+    calculator_name: input.calculatorName ?? undefined,
+    partner_type: input.partnerType ?? undefined,
+    partner_salesforce_id: input.partnerSalesforceId ?? undefined,
+  };
+}

--- a/lib/analytics/sanitizer.ts
+++ b/lib/analytics/sanitizer.ts
@@ -3,7 +3,7 @@ export const ANALYTICS_SCHEMA_VERSION = 1;
 export type JourneyStage = 'top' | 'mid' | 'bottom' | 'outcome';
 
 export type AnalyticsValue = string | number | boolean | null | undefined;
-export type AnalyticsProperties = Record<string, AnalyticsValue | AnalyticsValue[] | Record<string, AnalyticsValue>>;
+export type AnalyticsProperties = Record<string, unknown>;
 
 const BLOCKED_KEY_RE =
   /(^|_)(name|first_name|firstname|last_name|lastname|email|e_mail|phone|mobile|tel|street|address|captcha|message|comment|comments|free_text|payload|form_data|query|search_query|raw_text|text|zip_code|zipcode|zip)$/i;
@@ -101,9 +101,10 @@ export function hasPii(value: unknown): boolean {
     || UNSAFE_URL_RE.test(trimmed);
 }
 
-function cleanScalar(key: string, value: AnalyticsValue): AnalyticsValue {
+function cleanScalar(key: string, value: unknown): AnalyticsValue {
   if (value === undefined) return undefined;
   if (value === null || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return undefined;
 
   const trimmed = value.trim();
   if (!trimmed) return undefined;

--- a/lib/analytics/sanitizer.ts
+++ b/lib/analytics/sanitizer.ts
@@ -30,6 +30,17 @@ const ALLOWED_ATTRIBUTION_KEYS = new Set([
   'captured_at',
 ]);
 
+const SAFE_ERROR_CODE_FIELDS = new Set([
+  'email',
+  'phone',
+  'firstName',
+  'firstname',
+  'first_name',
+  'lastName',
+  'lastname',
+  'last_name',
+]);
+
 function isBlockedKey(key: string): boolean {
   return !SAFE_CONTACT_FLAG_KEYS.has(key) && BLOCKED_KEY_RE.test(key);
 }
@@ -153,7 +164,7 @@ export function sanitizeAnalyticsProperties(
 export function errorCodesFromErrors(errors: unknown): string[] {
   if (!errors || typeof errors !== 'object') return ['unknown'];
   return Object.keys(errors as Record<string, unknown>)
-    .filter((key) => !isBlockedKey(key))
+    .filter((key) => SAFE_ERROR_CODE_FIELDS.has(key) || !isBlockedKey(key))
     .map((key) => key.replace(/[^a-zA-Z0-9_]/g, '_').toLowerCase())
     .slice(0, 12);
 }

--- a/lib/posthog-server.ts
+++ b/lib/posthog-server.ts
@@ -1,4 +1,5 @@
 import { PostHog } from 'posthog-node';
+import { logError } from '@/services/loggingService';
 
 let posthogClient: PostHog | null = null;
 
@@ -31,7 +32,8 @@ interface ServerEvent {
 export async function captureServerEvent({ distinctId, event, properties }: ServerEvent): Promise<void> {
   try {
     await captureServerEventStrict({ distinctId, event, properties });
-  } catch {
+  } catch (error) {
+    logError('PostHog server capture failed', { distinctId, event }, error);
     // best-effort: never surface analytics errors to the caller
   }
 }

--- a/services/__tests__/salesforceLeadOwnerService.test.ts
+++ b/services/__tests__/salesforceLeadOwnerService.test.ts
@@ -213,7 +213,7 @@ describe('salesforceLeadOwnerService', () => {
     vi.mocked(salesForceAPI)
       .mockResolvedValueOnce(queryResponse([{ Id: '00QCONFIRM', OwnerId: '005WRONG' }]) as any)
       .mockResolvedValueOnce({ status: 204 } as any)
-      .mockResolvedValueOnce(
+      .mockResolvedValue(
         queryResponse([{ Id: '00QCONFIRM', OwnerId: '005STILLWRONG', Owner: { Name: 'Stephanie Guree' } }]) as any,
       );
 


### PR DESCRIPTION
## Summary
- Add reusable privacy-safe CTA tracking infrastructure and wire high-value CTAs across header, footer, homepage, state, blog/content, guide, calculator, and marketing surfaces.
- Fix telemetry correctness for contact-lender success handling, invalid submit attempts, validation error codes, concierge open/message/approval/tool completion events, and server PostHog failure logging.
- Harden analytics sanitization for exception/autocapture-style non-scalar properties discovered during live smoke testing.

## Validation
- npm run type-check
- npm run lint
- npm test
- npm run build
- Live localhost PostHog smoke test verified cta_clicked, calculator_cta_clicked, form_submit_attempted, and form_validation_failed ingestion with zero blocked PII/free-text keys and zero query strings in safe path properties.

## Notes
- No Salesforce Opportunity webhook, dashboards, Salesforce metadata changes, Salesforce test leads, historical PostHog deletion, or PostHog autocapture changes are included.
- No valid Salesforce lead submission was performed during smoke testing.