### PR TITLE
[codex] Fix PCS resources hydration warning

### DIFF
--- a/components/Impact/AboutOurStory/AboutOurStory.tsx
+++ b/components/Impact/AboutOurStory/AboutOurStory.tsx
@@ -80,7 +80,7 @@ const FamilySupport = async () => {
               <h1 className="text-white poppins lg:text-[35px] md:text-[35px] sm:text-[31px] text-[31px] font-bold mt-5 md:text-left sm:text-center text-center sm:px-0 px-0">
                 {storyDetails?.header}
               </h1>
-              <p className="text-white roboto lg:text-[16px] md:text-[16px] sm:text-[16px] text-[16px] font-medium mt-4 lg:w-[500px] md:w-[500px] sm:w-full w-full">
+              <div className="text-white roboto lg:text-[16px] md:text-[16px] sm:text-[16px] text-[16px] font-medium mt-4 lg:w-[500px] md:w-[500px] sm:w-full w-full">
                 {storyDetails?.description?.map((point, index) => (
                   <SupportContent
                     key={point._id || index}
@@ -90,7 +90,7 @@ const FamilySupport = async () => {
                     }}
                   />
                 ))}
-              </p>
+              </div>
             </div>
             <TrackedCtaLink
               href="/about"

--- a/components/homepage/FamilySupport/FamilySupport.tsx
+++ b/components/homepage/FamilySupport/FamilySupport.tsx
@@ -90,7 +90,7 @@ const FamilySupport = async ({ link, component_slug }: { link: string, component
                     src="/icon/checkred.svg"
                     alt=""
                   />
-                  <h6 className="text-white roboto lg:text-[18px] md:text-[19px] sm:text-[16px] text-[16px] font-medium leading-[41px]">
+                  <div className="text-white roboto lg:text-[18px] md:text-[19px] sm:text-[16px] text-[16px] font-medium leading-[41px]">
                     <SupportContent
                       key={point._id || index}
                       block={{
@@ -98,7 +98,7 @@ const FamilySupport = async ({ link, component_slug }: { link: string, component
                         style: validateBlockStyle(point.style || "normal"),
                       }}
                     />
-                  </h6>
+                  </div>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

- Replaces invalid rich-text wrapper markup on PCS Resources shared sections so rendered paragraph blocks are not nested inside paragraphs or headings.
- Preserves existing text styling and rich-text paragraph semantics.

## Root Cause

SupportContent renders normal Sanity blocks as paragraphs. On /pcs-resources, those blocks were being placed inside invalid parent text elements: a paragraph in AboutOurStory and an h6 in FamilySupport. The browser repaired that invalid HTML differently than React expected, causing the hydration warning.

## Validation

- npm run type-check
- npm run lint
- npm test
- npm run build
- Browser smoke: http://127.0.0.1:3000/pcs-resources loaded with meaningful page content and zero hydration / DOM-nesting console warnings.

## Notes

No analytics, Salesforce, dashboard, environment, or data behavior changed.