### PR TITLE
[codex] Fix analytics validation gaps

### DIFF
--- a/app/(site)/va-loan-calculator/page.tsx
+++ b/app/(site)/va-loan-calculator/page.tsx
@@ -476,7 +476,8 @@ export default function VaLoanCalculatorPage() {
                             <Link
                                 href="/contact-lender"
                                 onClick={() => captureAnalyticsEvent('calculator_cta_clicked', {
-                                    calculator_id: 'va_loan',
+                                    calculator_id: 'va_loan_calculator',
+                                    calculator_name: 'VA Loan Calculator',
                                     cta_id: 'va_loan_custom_quote',
                                     cta_intent: 'contact_lender',
                                     cta_position: 'calculator',

--- a/components/AgentFinderPopup/AgentFinderPopup.tsx
+++ b/components/AgentFinderPopup/AgentFinderPopup.tsx
@@ -7,7 +7,7 @@ import { sendGTMEvent } from "@next/third-parties/google";
 import type { StateList } from '@/services/stateService';
 import { clientAreaService, type AreaAssignment } from '@/services/clientAreaService';
 import { clientStateService } from '@/services/clientStateService';
-import { captureAnalyticsEvent, trackCtaClicked } from '@/lib/analytics/client';
+import { trackCtaClicked } from '@/lib/analytics/client';
 import './AgentFinderPopup.css';
 
 
@@ -101,12 +101,6 @@ const AgentFinderPopup: React.FC<AgentFinderPopupProps> = ({ isVisible, onClose 
             sendGTMEvent({
                 event: "agent_finder_popup_shown",
                 trigger_type: "scroll_trigger", // You could make this dynamic if needed
-            });
-            captureAnalyticsEvent('cta_clicked', {
-                cta_id: 'agent_finder_popup_viewed',
-                cta_intent: 'agent_finder_popup',
-                cta_position: 'scroll_trigger',
-                cta_component: 'agent_finder_popup',
             });
         }
     }, [isVisible]);

--- a/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx
+++ b/components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx
@@ -129,6 +129,7 @@ const MovingBonusCalculator = () => {
         });
         captureAnalyticsEvent('calculator_cta_clicked', {
             calculator_id: 'moving_bonus',
+            calculator_name: 'Moving Bonus Calculator',
             cta_id: 'moving_bonus_find_agent',
             cta_intent: 'contact_agent',
             cta_position: 'calculator',

--- a/lib/analytics/__tests__/cta.test.ts
+++ b/lib/analytics/__tests__/cta.test.ts
@@ -44,4 +44,23 @@ describe('CTA analytics helpers', () => {
     expect(JSON.stringify(clean)).not.toContain('alex@example.com');
     expect(JSON.stringify(clean)).not.toContain('?email=');
   });
+
+  it('keeps calculator CTA context complete', () => {
+    const clean = sanitizeAnalyticsProperties(buildCtaProperties({
+      ctaId: 'test_calculator_cta',
+      ctaIntent: 'contact_lender',
+      ctaPosition: 'calculator_result',
+      ctaComponent: 'test_calculator',
+      destination: '/contact-lender?loan=va',
+      calculatorId: 'va_loan_calculator',
+      calculatorName: 'VA Loan Calculator',
+    }));
+
+    expect(clean).toMatchObject({
+      cta_id: 'test_calculator_cta',
+      calculator_id: 'va_loan_calculator',
+      calculator_name: 'VA Loan Calculator',
+      destination_path: '/contact-lender',
+    });
+  });
 });

--- a/lib/analytics/__tests__/privacy-regression.test.ts
+++ b/lib/analytics/__tests__/privacy-regression.test.ts
@@ -61,6 +61,43 @@ describe('analytics privacy regressions', () => {
     expect(stateMap).toContain('state_map_state');
   });
 
+  it('does not treat agent finder popup impressions as CTA clicks', async () => {
+    const agentFinderPopup = await source('components/AgentFinderPopup/AgentFinderPopup.tsx');
+
+    expect(agentFinderPopup).toContain('agent_finder_popup_shown');
+    expect(agentFinderPopup).not.toContain('agent_finder_popup_viewed');
+    expect(agentFinderPopup).toContain('agent_finder_popup_submit');
+    expect(agentFinderPopup).not.toContain("captureAnalyticsEvent('cta_clicked'");
+  });
+
+  it('keeps calculator CTA payloads complete', async () => {
+    const movingBonus = await source('components/PcsResources/MovingBonusCalculator/MovingBonusCalculator.tsx');
+    const vaLoanCalculator = await source('app/(site)/va-loan-calculator/page.tsx');
+
+    expect(movingBonus).toContain("captureAnalyticsEvent('calculator_cta_clicked'");
+    expect(movingBonus).toContain("calculator_id: 'moving_bonus'");
+    expect(movingBonus).toContain("calculator_name: 'Moving Bonus Calculator'");
+    expect(vaLoanCalculator).toContain("captureAnalyticsEvent('calculator_cta_clicked'");
+    expect(vaLoanCalculator).toContain("calculator_id: 'va_loan_calculator'");
+    expect(vaLoanCalculator).toContain("calculator_name: 'VA Loan Calculator'");
+    expect(vaLoanCalculator).not.toContain("calculator_id: 'va_loan'");
+  });
+
+  it('keeps guide download telemetry wired on all guide surfaces', async () => {
+    const guideSources = await Promise.all([
+      source('components/common/DownloadGuideComponent.tsx'),
+      source('components/homepage/VaLoanGuideDownload.tsx'),
+      source('components/homepage/VeteranPCSWorksComp/HomebuyerGuideDownload.tsx'),
+      source('components/PcsResources/PcsResourcesVaLoanGuide/PcsResourcesVaLoanGuide.tsx'),
+    ]);
+
+    for (const guideSource of guideSources) {
+      expect(guideSource).toContain("captureAnalyticsEvent('guide_download_requested'");
+      expect(guideSource).toContain("captureAnalyticsEvent('guide_download_started'");
+      expect(guideSource).toContain('formTrackingPayload()');
+    }
+  });
+
   it('keeps server-owned PostHog events out of the client event union', async () => {
     const clientAnalytics = await source('lib/analytics/client.ts');
 

--- a/lib/analytics/__tests__/sanitizer.test.ts
+++ b/lib/analytics/__tests__/sanitizer.test.ts
@@ -65,6 +65,20 @@ describe('analytics sanitizer', () => {
     expect(zipPrefix('80920-1234')).toBe('809');
   });
 
+  it('keeps controlled taxonomy name keys without allowing person names', () => {
+    const clean = sanitizeAnalyticsProperties({
+      name: 'Alex Example',
+      firstName: 'Alex',
+      calculator_name: 'VA Loan Calculator',
+      tool_name: 'submitLenderRequest',
+    });
+
+    expect(clean).not.toHaveProperty('name');
+    expect(clean).not.toHaveProperty('firstName');
+    expect(clean.calculator_name).toBe('VA Loan Calculator');
+    expect(clean.tool_name).toBe('submitLenderRequest');
+  });
+
   it('drops exception/autocapture non-scalar property values without throwing', () => {
     const clean = sanitizeAnalyticsProperties({
       $lib: 'posthog-js',

--- a/lib/analytics/sanitizer.ts
+++ b/lib/analytics/sanitizer.ts
@@ -7,7 +7,13 @@ export type AnalyticsProperties = Record<string, unknown>;
 
 const BLOCKED_KEY_RE =
   /(^|_)(name|first_name|firstname|last_name|lastname|email|e_mail|phone|mobile|tel|street|address|captcha|message|comment|comments|free_text|payload|form_data|query|search_query|raw_text|text|zip_code|zipcode|zip)$/i;
-const SAFE_CONTACT_FLAG_KEYS = new Set(['has_name', 'has_email', 'has_phone']);
+const SAFE_BLOCKED_KEY_EXCEPTIONS = new Set([
+  'has_name',
+  'has_email',
+  'has_phone',
+  'calculator_name',
+  'tool_name',
+]);
 
 const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
 const LONG_PHONE_RE = /(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}/;
@@ -42,7 +48,7 @@ const SAFE_ERROR_CODE_FIELDS = new Set([
 ]);
 
 function isBlockedKey(key: string): boolean {
-  return !SAFE_CONTACT_FLAG_KEYS.has(key) && BLOCKED_KEY_RE.test(key);
+  return !SAFE_BLOCKED_KEY_EXCEPTIONS.has(key) && BLOCKED_KEY_RE.test(key);
 }
 
 export function safePath(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- Stop sending agent-finder popup impressions as cta_clicked while keeping popup submit CTA telemetry intact.
- Add complete calculator CTA taxonomy fields for moving bonus and VA loan calculator CTAs.
- Allow controlled taxonomy keys calculator_name and tool_name through the analytics sanitizer without allowing person-name properties.
- Add source-level regressions for popup CTA semantics, calculator CTA completeness, guide telemetry wiring, and sanitizer behavior.

## Validation
- npm test -- lib/analytics/__tests__/cta.test.ts lib/analytics/__tests__/privacy-regression.test.ts lib/analytics/__tests__/sanitizer.test.ts
- npm run type-check
- npm run lint
- npm test
- npm run build
- Pre-commit hook also ran lint, type-check, and build successfully during commit.

No Salesforce leads, PostHog historical data, dashboards, or env settings were changed.