### PR TITLE
Backdate queued drip: 149 posts spread over the past year

### DIFF
--- a/content/_registry/internal-links.json
+++ b/content/_registry/internal-links.json
@@ -1,5 +1,5 @@
 {
-  "contentHash": "e6bc600562eddc197a494e2a9dd138457b8bcd38c3242becbbc6cb9bd91a842f",
+  "contentHash": "503053eb3f0b76a0ab160480dcc044fb25f9febbcdc90926a291ee48bb8fafe6",
   "totalPosts": 332,
   "byComponent": {
     "Financial Guidance": [
@@ -1363,7 +1363,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Alabama's full property tax exemption for totally disabled veterans and surviving spouses, plus how the state treats military retirement and active-duty pay.",
-      "publishedAt": "2026-10-05T09:00:00.000Z",
+      "publishedAt": "2025-11-30T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "alabama veteran property tax exemption",
       "secondaryKeywords": [
@@ -1395,7 +1395,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Alaska's $150,000 disabled-veteran property tax exemption, how boroughs administer it, and what no state income tax means for military pay.",
-      "publishedAt": "2026-10-19T09:00:00.000Z",
+      "publishedAt": "2025-12-22T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "alaska veteran property tax exemption",
       "secondaryKeywords": [
@@ -1463,7 +1463,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Arizona's property tax exemption for disabled veterans, including the full home exemption for 100 percent rated veterans, plus how the state taxes military pay and retirement.",
-      "publishedAt": "2026-09-21T09:00:00.000Z",
+      "publishedAt": "2025-11-06T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "arizona veteran property tax exemption",
       "secondaryKeywords": [
@@ -1494,7 +1494,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Arkansas's full property tax exemption for 100% disabled veterans, the homestead credit, and how the state treats military pay.",
-      "publishedAt": "2026-10-16T09:00:00.000Z",
+      "publishedAt": "2025-12-20T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "arkansas veteran property tax exemption",
       "secondaryKeywords": [
@@ -1930,7 +1930,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at how California veterans can cut their property tax bill, how the homeowners exemption fits in, and how the state taxes military pay.",
-      "publishedAt": "2026-09-11T09:00:00.000Z",
+      "publishedAt": "2025-10-22T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "california veteran property tax exemption",
       "secondaryKeywords": [
@@ -2085,7 +2085,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at the Colorado property tax exemption for disabled veterans and Gold Star spouses, plus how military pay is treated by the state.",
-      "publishedAt": "2026-09-17T09:00:00.000Z",
+      "publishedAt": "2025-11-01T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "colorado disabled veteran property tax exemption",
       "secondaryKeywords": [
@@ -2187,7 +2187,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Connecticut's new full property tax exemption for 100% disabled veterans, the rating-based and local-option exemptions, and how the state treats military pay.",
-      "publishedAt": "2026-10-22T09:00:00.000Z",
+      "publishedAt": "2025-12-30T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "connecticut veteran property tax exemption",
       "secondaryKeywords": [
@@ -2306,7 +2306,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Delaware's disabled veterans school property tax credit, the senior credit, and how the state treats military pensions and pay.",
-      "publishedAt": "2026-10-26T09:00:00.000Z",
+      "publishedAt": "2026-01-04T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "delaware veteran property tax exemption",
       "secondaryKeywords": [
@@ -2568,7 +2568,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at the Florida property tax breaks that veterans and military families may qualify for, and how they fit with the state homestead exemption.",
-      "publishedAt": "2026-09-10T09:00:00.000Z",
+      "publishedAt": "2025-10-19T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "florida veteran property tax exemption",
       "secondaryKeywords": [
@@ -2659,7 +2659,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at Georgia property tax relief for disabled veterans and surviving spouses, plus how military pay and retirement pay are treated by the state.",
-      "publishedAt": "2026-09-15T09:00:00.000Z",
+      "publishedAt": "2025-10-27T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "georgia veteran property tax exemption",
       "secondaryKeywords": [
@@ -2719,7 +2719,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at how each Hawaii county exempts totally disabled veterans from property tax, plus how the state treats military pay.",
-      "publishedAt": "2026-09-18T09:00:00.000Z",
+      "publishedAt": "2025-11-03T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "hawaii veteran property tax exemption",
       "secondaryKeywords": [
@@ -3096,7 +3096,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Idaho's property tax benefit for 100% disabled veterans, the income-based Property Tax Reduction, and how the state treats military pay.",
-      "publishedAt": "2026-10-23T09:00:00.000Z",
+      "publishedAt": "2026-01-01T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "idaho veteran property tax exemption",
       "secondaryKeywords": [
@@ -3128,7 +3128,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Illinois's Standard Homestead Exemption for Veterans with Disabilities, how the EAV reduction scales by rating, and how the state treats military pay.",
-      "publishedAt": "2026-10-20T09:00:00.000Z",
+      "publishedAt": "2025-12-25T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "illinois veteran property tax exemption",
       "secondaryKeywords": [
@@ -3159,7 +3159,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Indiana's disabled-veteran property tax deductions, the assessed-value rules behind them, and how the state treats military pay.",
-      "publishedAt": "2026-10-14T09:00:00.000Z",
+      "publishedAt": "2025-12-15T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "indiana veteran property tax exemption",
       "secondaryKeywords": [
@@ -3214,7 +3214,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Iowa's disabled veteran homestead tax credit, who qualifies at a 100 percent rating, and how the state treats military pay.",
-      "publishedAt": "2026-11-04T09:00:00.000Z",
+      "publishedAt": "2026-01-21T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "iowa veteran property tax exemption",
       "secondaryKeywords": [
@@ -3245,7 +3245,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Kansas property tax relief for disabled veterans through the K-40SVR refund, plus how the state treats military retirement and active-duty pay.",
-      "publishedAt": "2026-10-01T09:00:00.000Z",
+      "publishedAt": "2025-11-25T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "kansas veteran property tax exemption",
       "secondaryKeywords": [
@@ -3277,7 +3277,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Kentucky's homestead exemption for totally disabled veterans, plus how the state treats military retirement and active-duty pay.",
-      "publishedAt": "2026-10-02T09:00:00.000Z",
+      "publishedAt": "2025-11-28T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "kentucky veteran property tax exemption",
       "secondaryKeywords": [
@@ -3308,7 +3308,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Louisiana's tiered disabled-veteran property tax exemption, the homestead exemption, and how the state treats military pay.",
-      "publishedAt": "2026-10-09T09:00:00.000Z",
+      "publishedAt": "2025-12-10T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "louisiana veteran property tax exemption",
       "secondaryKeywords": [
@@ -3339,7 +3339,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Maine's $6,000 veteran property tax exemption, the $50,000 adapted-housing exemption, and why the state does not tax military retirement pay.",
-      "publishedAt": "2026-11-05T09:00:00.000Z",
+      "publishedAt": "2026-01-23T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "maine veteran property tax exemption",
       "secondaryKeywords": [
@@ -3402,7 +3402,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at Maryland's full property tax exemption for 100 percent disabled veterans and surviving spouses, plus how the state taxes military retirement pay.",
-      "publishedAt": "2026-09-22T09:00:00.000Z",
+      "publishedAt": "2025-11-08T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "maryland veteran property tax exemption",
       "secondaryKeywords": [
@@ -3433,7 +3433,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Massachusetts' clause-based veteran property tax exemptions, who qualifies, how towns administer them, and how the state treats military pay.",
-      "publishedAt": "2026-11-12T09:00:00.000Z",
+      "publishedAt": "2026-02-02T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "massachusetts veteran property tax exemption",
       "secondaryKeywords": [
@@ -3464,7 +3464,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Michigan's full property tax exemption for 100% disabled veterans, the surviving-spouse rules, and how the state treats military pay.",
-      "publishedAt": "2026-10-28T09:00:00.000Z",
+      "publishedAt": "2026-01-08T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "michigan veteran property tax exemption",
       "secondaryKeywords": [
@@ -3592,7 +3592,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Minnesota's market value exclusion for veterans with a disability, the surviving-spouse rules, and how the state treats military pay.",
-      "publishedAt": "2026-10-30T09:00:00.000Z",
+      "publishedAt": "2026-01-13T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "minnesota veteran property tax exemption",
       "secondaryKeywords": [
@@ -3623,7 +3623,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Mississippi's full property tax exemption for totally disabled veterans and surviving spouses, plus how the state treats military pay.",
-      "publishedAt": "2026-10-13T09:00:00.000Z",
+      "publishedAt": "2025-12-12T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "mississippi veteran property tax exemption",
       "secondaryKeywords": [
@@ -3654,7 +3654,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Missouri's narrow property tax exemption for disabled former prisoners of war, the property tax credit, and how the state treats military pay.",
-      "publishedAt": "2026-09-30T09:00:00.000Z",
+      "publishedAt": "2025-11-23T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "missouri veteran property tax exemption",
       "secondaryKeywords": [
@@ -3686,7 +3686,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Montana's income-tested Disabled Veterans (MDV) property tax program, the sliding-scale rate reduction, and how the state treats military pay.",
-      "publishedAt": "2026-11-06T09:00:00.000Z",
+      "publishedAt": "2026-01-26T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "montana veteran property tax exemption",
       "secondaryKeywords": [
@@ -3779,7 +3779,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Nebraska's Homestead Exemption for totally disabled veterans and surviving spouses, plus how the state treats military retirement and active-duty pay.",
-      "publishedAt": "2026-10-08T09:00:00.000Z",
+      "publishedAt": "2025-12-08T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "nebraska veteran property tax exemption",
       "secondaryKeywords": [
@@ -3810,7 +3810,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Nevada's Disabled Veteran's Exemption, how it lowers your assessed value, and what having no state income tax means for military pay.",
-      "publishedAt": "2026-10-07T09:00:00.000Z",
+      "publishedAt": "2025-12-05T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "nevada veteran property tax exemption",
       "secondaryKeywords": [
@@ -3871,7 +3871,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to New Hampshire's veterans' property tax credits, the full exemption for specially adapted homes, and why the state now taxes no income.",
-      "publishedAt": "2026-11-13T09:00:00.000Z",
+      "publishedAt": "2026-02-04T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "new hampshire veteran property tax credit",
       "secondaryKeywords": [
@@ -3950,7 +3950,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to New Jersey's full property tax exemption for 100% disabled veterans, the $250 veterans deduction, and how the state treats military pay.",
-      "publishedAt": "2026-10-21T09:00:00.000Z",
+      "publishedAt": "2025-12-27T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "new jersey veteran property tax exemption",
       "secondaryKeywords": [
@@ -3981,7 +3981,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to New Mexico's expanded veteran property tax exemptions, including the new proportional disabled-veteran exemption, plus how the state treats military pay.",
-      "publishedAt": "2026-10-06T09:00:00.000Z",
+      "publishedAt": "2025-12-03T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "new mexico veteran property tax exemption",
       "secondaryKeywords": [
@@ -4036,7 +4036,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to New York's alternative veterans exemption, the new exemption for 100 percent disabled veterans, and how the state treats military pay and pensions.",
-      "publishedAt": "2026-09-29T09:00:00.000Z",
+      "publishedAt": "2025-11-20T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "new york veteran property tax exemption",
       "secondaryKeywords": [
@@ -4067,7 +4067,7 @@
         "Financial Guidance"
       ],
       "description": "A clear, plain-language look at how disabled veterans and military families in North Carolina can lower their property taxes, plus how the state treats military pay.",
-      "publishedAt": "2026-09-14T09:00:00.000Z",
+      "publishedAt": "2025-10-24T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "north carolina veteran property tax exemption",
       "secondaryKeywords": [
@@ -4098,7 +4098,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to North Dakota's disabled veterans property tax credit, how it scales with your VA rating, and how the state treats military pay.",
-      "publishedAt": "2026-10-27T09:00:00.000Z",
+      "publishedAt": "2026-01-06T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "north dakota veteran property tax exemption",
       "secondaryKeywords": [
@@ -4169,7 +4169,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at Ohio's enhanced homestead exemption for disabled veterans and surviving spouses, plus how the state treats military retirement and active-duty pay.",
-      "publishedAt": "2026-09-25T09:00:00.000Z",
+      "publishedAt": "2025-11-15T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "ohio veteran property tax exemption",
       "secondaryKeywords": [
@@ -4233,7 +4233,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Oregon's disabled veteran property tax exemption, who qualifies at 40 percent, and how the state treats military pay.",
-      "publishedAt": "2026-11-02T09:00:00.000Z",
+      "publishedAt": "2026-01-16T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "oregon veteran property tax exemption",
       "secondaryKeywords": [
@@ -4333,7 +4333,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Aberdeen Proving Ground, covering where to live, BAH, schools, healthcare, and life in Harford County, Maryland.",
-      "publishedAt": "2026-12-23T09:00:00.000Z",
+      "publishedAt": "2026-04-12T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to aberdeen proving ground",
       "secondaryKeywords": [
@@ -4367,7 +4367,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families PCSing to the U.S. Air Force Academy, covering where to live in north Colorado Springs and Monument, BAH, schools, healthcare, and life at elevation.",
-      "publishedAt": "2026-12-28T09:00:00.000Z",
+      "publishedAt": "2026-04-17T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to air force academy",
       "secondaryKeywords": [
@@ -4438,7 +4438,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Barksdale AFB, covering where to live, BAH, schools, healthcare, and life in the Shreveport-Bossier area.",
-      "publishedAt": "2026-12-14T09:00:00.000Z",
+      "publishedAt": "2026-03-25T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to barksdale afb",
       "secondaryKeywords": [
@@ -4472,7 +4472,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Beale AFB, covering where to live, BAH, schools, healthcare, and life near Marysville and Yuba City, California.",
-      "publishedAt": "2027-01-08T09:00:00.000Z",
+      "publishedAt": "2026-05-06T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to beale afb",
       "secondaryKeywords": [
@@ -4542,7 +4542,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Buckley Space Force Base, covering where to live, BAH, schools, healthcare, and life in the Denver-Aurora metro.",
-      "publishedAt": "2026-12-30T09:00:00.000Z",
+      "publishedAt": "2026-04-21T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to buckley space force base",
       "secondaryKeywords": [
@@ -4576,7 +4576,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Cannon AFB, covering where to live, BAH, schools, healthcare, and life on the eastern New Mexico high plains.",
-      "publishedAt": "2027-01-28T09:00:00.000Z",
+      "publishedAt": "2026-06-07T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to cannon afb",
       "secondaryKeywords": [
@@ -4644,7 +4644,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Davis-Monthan AFB, covering where to live, BAH, schools, healthcare, and life in Tucson, Arizona.",
-      "publishedAt": "2026-12-03T09:00:00.000Z",
+      "publishedAt": "2026-03-08T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to davis-monthan afb",
       "secondaryKeywords": [
@@ -4678,7 +4678,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Dyess AFB, covering where to live, BAH, schools, healthcare, and life in Abilene, Texas.",
-      "publishedAt": "2027-01-22T09:00:00.000Z",
+      "publishedAt": "2026-05-28T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to dyess afb",
       "secondaryKeywords": [
@@ -4712,7 +4712,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Edwards Air Force Base, covering where to live, BAH, schools, healthcare, and life in the high desert Antelope Valley.",
-      "publishedAt": "2027-01-06T09:00:00.000Z",
+      "publishedAt": "2026-05-01T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to edwards afb",
       "secondaryKeywords": [
@@ -4746,7 +4746,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to Eielson Air Force Base, covering where to live near Fairbanks, BAH, schools, healthcare, and life in interior Alaska.",
-      "publishedAt": "2027-01-13T09:00:00.000Z",
+      "publishedAt": "2026-05-13T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to eielson afb",
       "secondaryKeywords": [
@@ -4780,7 +4780,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Ellsworth AFB, covering where to live, BAH, schools, healthcare, and life near Rapid City, South Dakota.",
-      "publishedAt": "2027-02-04T09:00:00.000Z",
+      "publishedAt": "2026-06-19T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to ellsworth afb",
       "secondaryKeywords": [
@@ -4814,7 +4814,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fairchild AFB, covering where to live, BAH, schools, healthcare, and life in the Spokane area.",
-      "publishedAt": "2026-12-17T09:00:00.000Z",
+      "publishedAt": "2026-04-02T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to fairchild afb",
       "secondaryKeywords": [
@@ -4848,7 +4848,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to F.E. Warren AFB, covering where to live, BAH, schools, healthcare, and life in Cheyenne, Wyoming.",
-      "publishedAt": "2027-02-08T09:00:00.000Z",
+      "publishedAt": "2026-06-24T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to fe warren afb",
       "secondaryKeywords": [
@@ -4915,7 +4915,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Belvoir, covering where to live, BAH, schools, healthcare, and life in Northern Virginia.",
-      "publishedAt": "2026-08-24T09:00:00.000Z",
+      "publishedAt": "2025-09-20T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort belvoir",
       "secondaryKeywords": [
@@ -4949,7 +4949,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Benning, Georgia (formerly Fort Moore), covering where to live, BAH, schools, healthcare, and life near Columbus.",
-      "publishedAt": "2026-08-27T09:00:00.000Z",
+      "publishedAt": "2025-09-27T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort benning",
       "secondaryKeywords": [
@@ -4983,7 +4983,7 @@
         "US Military Bases"
       ],
       "description": "A friendly, plain-language guide to moving your family to Fort Bliss in El Paso, Texas, from neighborhoods and BAH to schools, healthcare, and the desert weather.",
-      "publishedAt": "2026-07-27T09:00:00.000Z",
+      "publishedAt": "2025-08-02T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "pcs to fort bliss",
       "secondaryKeywords": [
@@ -5017,7 +5017,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Bragg, North Carolina (formerly Fort Liberty), covering where to live, BAH, schools, healthcare, and life near Fayetteville.",
-      "publishedAt": "2026-08-26T09:00:00.000Z",
+      "publishedAt": "2025-09-25T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort bragg",
       "secondaryKeywords": [
@@ -5051,7 +5051,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Carson, covering where to live, BAH, schools, healthcare, and life in Colorado Springs.",
-      "publishedAt": "2026-07-31T09:00:00.000Z",
+      "publishedAt": "2025-08-12T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "pcs to fort carson",
       "secondaryKeywords": [
@@ -5085,7 +5085,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Drum, covering where to live, BAH, schools, healthcare, and life in New York North Country.",
-      "publishedAt": "2026-08-07T09:00:00.000Z",
+      "publishedAt": "2025-08-24T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort drum",
       "secondaryKeywords": [
@@ -5156,7 +5156,7 @@
         "US Military Bases"
       ],
       "description": "A plain-language 2026 guide to moving to Fort Hood near Killeen, Texas (formerly Fort Cavazos), covering housing, BAH, schools, healthcare, and things to do.",
-      "publishedAt": "2026-07-28T09:00:00.000Z",
+      "publishedAt": "2025-08-04T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort hood",
       "secondaryKeywords": [
@@ -5190,7 +5190,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Huachuca, covering where to live, BAH, schools, healthcare, and high-desert life in southeastern Arizona.",
-      "publishedAt": "2026-08-21T09:00:00.000Z",
+      "publishedAt": "2025-09-18T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort huachuca",
       "secondaryKeywords": [
@@ -5224,7 +5224,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Irwin, the Army National Training Center, covering on-post housing, BAH, schools, healthcare, and Mojave Desert life.",
-      "publishedAt": "2026-08-18T09:00:00.000Z",
+      "publishedAt": "2025-09-10T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort irwin",
       "secondaryKeywords": [
@@ -5258,7 +5258,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Jackson, covering where to live, BAH, schools, healthcare, and life in Columbia, South Carolina.",
-      "publishedAt": "2026-08-12T09:00:00.000Z",
+      "publishedAt": "2025-08-31T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort jackson",
       "secondaryKeywords": [
@@ -5292,7 +5292,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Knox, covering where to live, BAH, schools, healthcare, and life in north-central Kentucky.",
-      "publishedAt": "2026-08-13T09:00:00.000Z",
+      "publishedAt": "2025-09-03T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort knox",
       "secondaryKeywords": [
@@ -5361,7 +5361,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Lee, Virginia (formerly Fort Gregg-Adams), covering where to live, BAH, schools, healthcare, and life in the Tri-Cities.",
-      "publishedAt": "2026-08-20T09:00:00.000Z",
+      "publishedAt": "2025-09-15T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort lee",
       "secondaryKeywords": [
@@ -5395,7 +5395,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Leonard Wood, covering where to live, BAH, schools, healthcare, and life in the Missouri Ozarks.",
-      "publishedAt": "2026-08-05T09:00:00.000Z",
+      "publishedAt": "2025-08-19T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort leonard wood",
       "secondaryKeywords": [
@@ -5429,7 +5429,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Meade, covering where to live, BAH, schools, healthcare, and life between Baltimore and Washington.",
-      "publishedAt": "2026-09-04T09:00:00.000Z",
+      "publishedAt": "2025-10-12T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "pcs to fort meade",
       "secondaryKeywords": [
@@ -5463,7 +5463,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Polk, home of the Joint Readiness Training Center, covering where to live, BAH, schools, healthcare, and life in west-central Louisiana.",
-      "publishedAt": "2026-08-19T09:00:00.000Z",
+      "publishedAt": "2025-09-13T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort polk",
       "secondaryKeywords": [
@@ -5497,7 +5497,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Riley, Kansas, covering where to live, BAH, schools, healthcare, and life in the Flint Hills.",
-      "publishedAt": "2026-08-17T09:00:00.000Z",
+      "publishedAt": "2025-09-08T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort riley",
       "secondaryKeywords": [
@@ -5531,7 +5531,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Rucker, covering where to live, BAH, schools, healthcare, and life in southeast Alabama's Wiregrass region.",
-      "publishedAt": "2026-12-31T09:00:00.000Z",
+      "publishedAt": "2026-04-24T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to fort rucker",
       "secondaryKeywords": [
@@ -5566,7 +5566,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Sill, covering where to live, BAH, schools, healthcare, and life around Lawton, Oklahoma.",
-      "publishedAt": "2026-08-04T09:00:00.000Z",
+      "publishedAt": "2025-08-17T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort sill",
       "secondaryKeywords": [
@@ -5600,7 +5600,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Fort Stewart and Hunter Army Airfield, covering where to live, BAH, schools, healthcare, and coastal Georgia life.",
-      "publishedAt": "2026-08-11T09:00:00.000Z",
+      "publishedAt": "2025-08-29T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to fort stewart",
       "secondaryKeywords": [
@@ -5634,7 +5634,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to Fort Wainwright, covering where to live, BAH, schools, healthcare, and life in Fairbanks, Alaska.",
-      "publishedAt": "2027-01-12T09:00:00.000Z",
+      "publishedAt": "2026-05-11T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to fort wainwright",
       "secondaryKeywords": [
@@ -5668,7 +5668,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Goodfellow AFB, covering where to live, BAH, schools, healthcare, and life in San Angelo, Texas.",
-      "publishedAt": "2027-01-25T09:00:00.000Z",
+      "publishedAt": "2026-05-31T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to goodfellow afb",
       "secondaryKeywords": [
@@ -5702,7 +5702,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Grand Forks Air Force Base, covering where to live, BAH, schools, healthcare, and life in the Red River Valley.",
-      "publishedAt": "2027-02-03T09:00:00.000Z",
+      "publishedAt": "2026-06-17T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to grand forks afb",
       "secondaryKeywords": [
@@ -5736,7 +5736,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Hanscom AFB, covering where to live, BAH, schools, healthcare, and life near Boston in Bedford, Massachusetts.",
-      "publishedAt": "2027-02-11T09:00:00.000Z",
+      "publishedAt": "2026-07-02T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to hanscom afb",
       "secondaryKeywords": [
@@ -5829,7 +5829,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Hill AFB, covering where to live, BAH, schools, healthcare, and life near Ogden and Layton, Utah.",
-      "publishedAt": "2026-12-04T09:00:00.000Z",
+      "publishedAt": "2026-03-11T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to hill afb",
       "secondaryKeywords": [
@@ -5863,7 +5863,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to Holloman AFB, covering where to live near Alamogordo, BAH, schools, the 49th Medical Group, and White Sands.",
-      "publishedAt": "2027-01-29T09:00:00.000Z",
+      "publishedAt": "2026-06-09T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to holloman afb",
       "secondaryKeywords": [
@@ -5897,7 +5897,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Joint Base Andrews, covering where to live, BAH, schools, healthcare, and life in Prince George's County, Maryland.",
-      "publishedAt": "2026-11-25T09:00:00.000Z",
+      "publishedAt": "2026-02-24T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to joint base andrews",
       "secondaryKeywords": [
@@ -5931,7 +5931,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Joint Base Elmendorf-Richardson, covering where to live, BAH, schools, healthcare, and life in Anchorage, Alaska.",
-      "publishedAt": "2026-11-20T09:00:00.000Z",
+      "publishedAt": "2026-02-17T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to jber",
       "secondaryKeywords": [
@@ -5965,7 +5965,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Joint Base Langley-Eustis, covering where to live, BAH, schools, healthcare, and life on the Virginia Peninsula.",
-      "publishedAt": "2026-09-01T09:00:00.000Z",
+      "publishedAt": "2025-10-05T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "pcs to joint base langley-eustis",
       "secondaryKeywords": [
@@ -6034,7 +6034,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Joint Base McGuire-Dix-Lakehurst, covering where to live, BAH, schools, healthcare, and life in central New Jersey.",
-      "publishedAt": "2026-11-24T09:00:00.000Z",
+      "publishedAt": "2026-02-22T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to joint base mcguire-dix-lakehurst",
       "secondaryKeywords": [
@@ -6068,7 +6068,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Joint Base Pearl Harbor-Hickam, covering where to live, BAH, schools, healthcare, and life on Oahu, Hawaii.",
-      "publishedAt": "2026-11-19T09:00:00.000Z",
+      "publishedAt": "2026-02-14T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to pearl harbor",
       "secondaryKeywords": [
@@ -6102,7 +6102,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Joint Base San Antonio, covering where to live, BAH, schools, healthcare, and life in South Texas.",
-      "publishedAt": "2026-08-25T09:00:00.000Z",
+      "publishedAt": "2025-09-22T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to joint base san antonio",
       "secondaryKeywords": [
@@ -6136,7 +6136,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Keesler AFB, covering where to live, BAH, schools, healthcare, and life on the Mississippi Gulf Coast.",
-      "publishedAt": "2026-12-02T09:00:00.000Z",
+      "publishedAt": "2026-03-06T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to keesler afb",
       "secondaryKeywords": [
@@ -6170,7 +6170,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Kirtland AFB, covering where to live, BAH, schools, healthcare, and life in Albuquerque, New Mexico.",
-      "publishedAt": "2026-12-16T09:00:00.000Z",
+      "publishedAt": "2026-03-30T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to kirtland afb",
       "secondaryKeywords": [
@@ -6273,7 +6273,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to MacDill Air Force Base, covering where to live, BAH, schools, healthcare, and life in Tampa, Florida.",
-      "publishedAt": "2026-09-02T09:00:00.000Z",
+      "publishedAt": "2025-10-07T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "pcs to macdill afb",
       "secondaryKeywords": [
@@ -6307,7 +6307,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Malmstrom Air Force Base, covering where to live, BAH, schools, healthcare, and life in Great Falls, Montana.",
-      "publishedAt": "2027-02-05T09:00:00.000Z",
+      "publishedAt": "2026-06-22T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to malmstrom afb",
       "secondaryKeywords": [
@@ -6341,7 +6341,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Maxwell AFB, covering where to live, BAH, schools, healthcare, and life in Montgomery, Alabama.",
-      "publishedAt": "2026-12-07T09:00:00.000Z",
+      "publishedAt": "2026-03-13T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to maxwell afb",
       "secondaryKeywords": [
@@ -6375,7 +6375,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to MCAS Beaufort, covering where to live, BAH, schools, healthcare, and life in the South Carolina Lowcountry.",
-      "publishedAt": "2027-01-21T09:00:00.000Z",
+      "publishedAt": "2026-05-26T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to mcas beaufort",
       "secondaryKeywords": [
@@ -6409,7 +6409,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to MCAS Cherry Point, covering where to live, BAH, schools, healthcare, and life on the North Carolina Crystal Coast.",
-      "publishedAt": "2026-12-18T09:00:00.000Z",
+      "publishedAt": "2026-04-04T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to mcas cherry point",
       "secondaryKeywords": [
@@ -6443,7 +6443,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to MCB Camp Pendleton, covering where to live, BAH, schools, healthcare, and coastal Southern California life.",
-      "publishedAt": "2026-08-14T09:00:00.000Z",
+      "publishedAt": "2025-09-05T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to camp pendleton",
       "secondaryKeywords": [
@@ -6477,7 +6477,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Marine Corps Base Hawaii at Kaneohe Bay, covering where to live, BAH, schools, healthcare, and life on windward Oahu.",
-      "publishedAt": "2026-12-01T09:00:00.000Z",
+      "publishedAt": "2026-03-03T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to mcb hawaii",
       "secondaryKeywords": [
@@ -6511,7 +6511,7 @@
         "US Military Bases"
       ],
       "description": "A plain-language guide to moving your family to Marine Corps Base Quantico in Northern Virginia, covering housing, schools, healthcare, and the I-95 commute.",
-      "publishedAt": "2026-07-29T09:00:00.000Z",
+      "publishedAt": "2025-08-07T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "pcs to mcb quantico",
       "secondaryKeywords": [
@@ -6545,7 +6545,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to McConnell AFB, covering where to live, BAH, schools, healthcare, and life in Wichita, Kansas.",
-      "publishedAt": "2026-12-15T09:00:00.000Z",
+      "publishedAt": "2026-03-28T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to mcconnell afb",
       "secondaryKeywords": [
@@ -6579,7 +6579,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to MCRD Parris Island, covering where to live, BAH, schools, healthcare, and life in the South Carolina Lowcountry.",
-      "publishedAt": "2026-08-06T09:00:00.000Z",
+      "publishedAt": "2025-08-22T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to mcrd parris island",
       "secondaryKeywords": [
@@ -6613,7 +6613,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Minot AFB, covering where to live, BAH, schools, healthcare, climate, and life in North Dakota.",
-      "publishedAt": "2027-02-02T09:00:00.000Z",
+      "publishedAt": "2026-06-14T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to minot afb",
       "secondaryKeywords": [
@@ -6647,7 +6647,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to Moody Air Force Base, covering where to live, BAH, schools, healthcare, and life near Valdosta, Georgia.",
-      "publishedAt": "2027-01-19T09:00:00.000Z",
+      "publishedAt": "2026-05-21T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to moody afb",
       "secondaryKeywords": [
@@ -6681,7 +6681,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to Mountain Home AFB, covering where to live, BAH, schools, healthcare, and life on the Snake River Plain.",
-      "publishedAt": "2027-02-01T09:00:00.000Z",
+      "publishedAt": "2026-06-12T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to mountain home afb",
       "secondaryKeywords": [
@@ -6715,7 +6715,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to NAS Corpus Christi, covering where to live, BAH, schools, healthcare, and life on the Texas Gulf Coast.",
-      "publishedAt": "2027-01-26T09:00:00.000Z",
+      "publishedAt": "2026-06-02T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to nas corpus christi",
       "secondaryKeywords": [
@@ -6749,7 +6749,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to Naval Air Station Lemoore, covering where to live, BAH, schools, healthcare, and life in the San Joaquin Valley.",
-      "publishedAt": "2027-01-04T09:00:00.000Z",
+      "publishedAt": "2026-04-26T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to nas lemoore",
       "secondaryKeywords": [
@@ -6783,7 +6783,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to NAS Oceana or JEB Little Creek-Fort Story, covering where to live, BAH, schools, healthcare, and life in Virginia Beach.",
-      "publishedAt": "2026-11-30T09:00:00.000Z",
+      "publishedAt": "2026-03-01T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to nas oceana",
       "secondaryKeywords": [
@@ -6817,7 +6817,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to NAS Pensacola, covering where to live, BAH, schools, healthcare, and life on the Gulf Coast.",
-      "publishedAt": "2026-08-28T09:00:00.000Z",
+      "publishedAt": "2025-09-30T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to nas pensacola",
       "secondaryKeywords": [
@@ -6851,7 +6851,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to NAS Whidbey Island, covering where to live, BAH, schools, healthcare, and life on Washington's Whidbey Island.",
-      "publishedAt": "2027-01-27T09:00:00.000Z",
+      "publishedAt": "2026-06-05T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to nas whidbey island",
       "secondaryKeywords": [
@@ -6885,7 +6885,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to the Naval Academy and NSA Annapolis, covering where to live, BAH, schools, healthcare, and life on the Chesapeake Bay.",
-      "publishedAt": "2026-12-24T09:00:00.000Z",
+      "publishedAt": "2026-04-14T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to naval academy",
       "secondaryKeywords": [
@@ -6919,7 +6919,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Naval Base Ventura County, covering where to live, BAH, schools, healthcare, and life on the Southern California coast.",
-      "publishedAt": "2027-01-05T09:00:00.000Z",
+      "publishedAt": "2026-04-29T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to naval base ventura county",
       "secondaryKeywords": [
@@ -6953,7 +6953,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Naval Station Great Lakes, covering where to live, BAH, schools, healthcare, and life on the North Shore of Lake Michigan.",
-      "publishedAt": "2026-11-23T09:00:00.000Z",
+      "publishedAt": "2026-02-19T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to naval station great lakes",
       "secondaryKeywords": [
@@ -6987,7 +6987,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Naval Station Mayport or NAS Jacksonville, covering where to live, BAH, schools, healthcare, and life in northeast Florida.",
-      "publishedAt": "2026-11-27T09:00:00.000Z",
+      "publishedAt": "2026-02-26T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to mayport",
       "secondaryKeywords": [
@@ -7021,7 +7021,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Naval Station Newport, covering where to live, BAH, schools, healthcare, and life on the Rhode Island coast.",
-      "publishedAt": "2027-02-10T09:00:00.000Z",
+      "publishedAt": "2026-06-29T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to naval station newport",
       "secondaryKeywords": [
@@ -7055,7 +7055,7 @@
         "US Military Bases"
       ],
       "description": "A plain-language 2026 guide to moving your family to Naval Station Norfolk, from where to live to BAH and schools.",
-      "publishedAt": "2026-07-30T09:00:00.000Z",
+      "publishedAt": "2025-08-09T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "pcs to naval station norfolk",
       "secondaryKeywords": [
@@ -7089,7 +7089,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Naval Submarine Base Kings Bay, covering where to live, BAH, schools, healthcare, and life on the Georgia coast.",
-      "publishedAt": "2027-01-20T09:00:00.000Z",
+      "publishedAt": "2026-05-23T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to kings bay",
       "secondaryKeywords": [
@@ -7123,7 +7123,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Nellis Air Force Base, covering where to live, BAH, schools, healthcare, and life in the Las Vegas area.",
-      "publishedAt": "2026-09-03T09:00:00.000Z",
+      "publishedAt": "2025-10-10T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "pcs to nellis afb",
       "secondaryKeywords": [
@@ -7225,7 +7225,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Patrick Space Force Base, covering where to live, BAH, schools, healthcare, and life on Florida Space Coast near Cocoa Beach.",
-      "publishedAt": "2027-01-15T09:00:00.000Z",
+      "publishedAt": "2026-05-18T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to patrick space force base",
       "secondaryKeywords": [
@@ -7259,7 +7259,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 PCS guide for Peterson and Schriever Space Force Base, covering where to live on the east side of Colorado Springs, BAH, schools, healthcare, and the Space Force mission.",
-      "publishedAt": "2026-12-29T09:00:00.000Z",
+      "publishedAt": "2026-04-19T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to peterson space force base",
       "secondaryKeywords": [
@@ -7293,7 +7293,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Portsmouth Naval Shipyard, covering where to live in Maine and New Hampshire, BAH, schools, healthcare, and Seacoast life.",
-      "publishedAt": "2027-02-12T09:00:00.000Z",
+      "publishedAt": "2026-07-04T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to portsmouth naval shipyard",
       "secondaryKeywords": [
@@ -7327,7 +7327,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to the Presidio of Monterey and the Defense Language Institute, covering where to live, BAH, schools, healthcare, and life on the California coast.",
-      "publishedAt": "2027-01-11T09:00:00.000Z",
+      "publishedAt": "2026-05-09T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to presidio of monterey",
       "secondaryKeywords": [
@@ -7361,7 +7361,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Robins AFB, covering where to live, BAH, schools, healthcare, and life in Middle Georgia.",
-      "publishedAt": "2026-12-08T09:00:00.000Z",
+      "publishedAt": "2026-03-16T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to robins afb",
       "secondaryKeywords": [
@@ -7395,7 +7395,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to the San Diego military bases, covering where to live, BAH, schools, healthcare, and life in Southern California.",
-      "publishedAt": "2026-11-18T09:00:00.000Z",
+      "publishedAt": "2026-02-12T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to san diego",
       "secondaryKeywords": [
@@ -7429,7 +7429,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Schofield Barracks, covering where to live, BAH, schools, healthcare, and life on Oahu, Hawaii.",
-      "publishedAt": "2026-08-31T09:00:00.000Z",
+      "publishedAt": "2025-10-02T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "pcs to schofield barracks",
       "secondaryKeywords": [
@@ -7463,7 +7463,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Scott AFB, covering where to live, BAH, schools, healthcare, and life in the Metro East area near St. Louis.",
-      "publishedAt": "2026-12-10T09:00:00.000Z",
+      "publishedAt": "2026-03-21T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to scott afb",
       "secondaryKeywords": [
@@ -7497,7 +7497,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to Selfridge Air National Guard Base, covering where to live, BAH, schools, healthcare, and life in metro Detroit.",
-      "publishedAt": "2027-02-09T09:00:00.000Z",
+      "publishedAt": "2026-06-27T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to selfridge angb",
       "secondaryKeywords": [
@@ -7531,7 +7531,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Seymour Johnson AFB, covering where to live, BAH, schools, healthcare, and life in Goldsboro, North Carolina.",
-      "publishedAt": "2026-12-21T09:00:00.000Z",
+      "publishedAt": "2026-04-07T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to seymour johnson afb",
       "secondaryKeywords": [
@@ -7565,7 +7565,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Shaw AFB, covering where to live, BAH, schools, healthcare, and life in the South Carolina Midlands.",
-      "publishedAt": "2026-12-11T09:00:00.000Z",
+      "publishedAt": "2026-03-23T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to shaw afb",
       "secondaryKeywords": [
@@ -7599,7 +7599,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Travis AFB, covering where to live, BAH, schools, healthcare, and life in Solano County, California.",
-      "publishedAt": "2026-08-10T09:00:00.000Z",
+      "publishedAt": "2025-08-27T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to travis afb",
       "secondaryKeywords": [
@@ -7633,7 +7633,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Tyndall Air Force Base, covering where to live, BAH, schools, healthcare, and life on the Florida Gulf coast.",
-      "publishedAt": "2027-01-14T09:00:00.000Z",
+      "publishedAt": "2026-05-16T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to tyndall afb",
       "secondaryKeywords": [
@@ -7667,7 +7667,7 @@
         "US Military Bases"
       ],
       "description": "A 2027 guide for military families moving to Vandenberg Space Force Base, covering where to live, BAH, schools, healthcare, and life on California's Central Coast.",
-      "publishedAt": "2027-01-07T09:00:00.000Z",
+      "publishedAt": "2026-05-04T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to vandenberg",
       "secondaryKeywords": [
@@ -7736,7 +7736,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to West Point, covering where to live, BAH, schools, healthcare, and life in New York's Hudson Valley.",
-      "publishedAt": "2026-12-09T09:00:00.000Z",
+      "publishedAt": "2026-03-18T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to west point",
       "secondaryKeywords": [
@@ -7770,7 +7770,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Whiteman Air Force Base, covering where to live, BAH, schools, healthcare, and life near Knob Noster, Missouri.",
-      "publishedAt": "2026-12-22T09:00:00.000Z",
+      "publishedAt": "2026-04-09T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "pcs to whiteman afb",
       "secondaryKeywords": [
@@ -7839,7 +7839,7 @@
         "US Military Bases"
       ],
       "description": "A 2026 guide for military families moving to Wright-Patterson AFB, covering where to live, BAH, schools, healthcare, and life around Dayton, Ohio.",
-      "publishedAt": "2026-08-03T09:00:00.000Z",
+      "publishedAt": "2025-08-14T09:00:00.000Z",
       "updatedAt": "2026-06-20T00:00:00.000Z",
       "primaryKeyword": "pcs to wright-patterson afb",
       "secondaryKeywords": [
@@ -8167,7 +8167,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Pennsylvania's need-based real estate tax exemption for 100 percent disabled wartime veterans and surviving spouses, plus how the state treats military pay.",
-      "publishedAt": "2026-09-28T09:00:00.000Z",
+      "publishedAt": "2025-11-18T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "pennsylvania veteran property tax exemption",
       "secondaryKeywords": [
@@ -8442,7 +8442,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Rhode Island's local veteran property tax exemptions, the larger amounts for disabled veterans, and how the state exempts military pay.",
-      "publishedAt": "2026-11-16T09:00:00.000Z",
+      "publishedAt": "2026-02-07T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "rhode island veteran property tax exemption",
       "secondaryKeywords": [
@@ -8623,7 +8623,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at South Carolina's total property tax exemption for disabled veterans and surviving spouses, plus the state's full military retirement income tax break.",
-      "publishedAt": "2026-09-23T09:00:00.000Z",
+      "publishedAt": "2025-11-11T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "south carolina veteran property tax exemption",
       "secondaryKeywords": [
@@ -8654,7 +8654,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to South Dakota's disabled veteran property tax exemption, the paraplegic exemption, and why the state taxes no military pay.",
-      "publishedAt": "2026-10-29T09:00:00.000Z",
+      "publishedAt": "2026-01-11T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "south dakota veteran property tax exemption",
       "secondaryKeywords": [
@@ -8788,7 +8788,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at Tennessee's property tax relief for disabled veterans and surviving spouses, plus what having no state income tax means for military pay.",
-      "publishedAt": "2026-09-24T09:00:00.000Z",
+      "publishedAt": "2025-11-13T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "tennessee veteran property tax exemption",
       "secondaryKeywords": [
@@ -8819,7 +8819,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at the property tax breaks Texas offers veterans and military families, from partial exemptions by disability rating to the full homestead exemption for 100% disabled veterans.",
-      "publishedAt": "2026-09-08T09:00:00.000Z",
+      "publishedAt": "2025-10-15T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "texas veteran property tax exemption",
       "secondaryKeywords": [
@@ -9396,7 +9396,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Utah's rating-scaled veteran property tax exemption, the active-duty exemption, and how the state credits military retirement pay.",
-      "publishedAt": "2026-10-15T09:00:00.000Z",
+      "publishedAt": "2025-12-17T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "utah veteran property tax exemption",
       "secondaryKeywords": [
@@ -9819,7 +9819,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Vermont's town-set veteran property tax exemption, who qualifies, and the new Act 71 exclusion for military retirement pay.",
-      "publishedAt": "2026-11-09T09:00:00.000Z",
+      "publishedAt": "2026-01-28T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "vermont veteran property tax exemption",
       "secondaryKeywords": [
@@ -9912,7 +9912,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at Virginia property tax relief for disabled veterans and surviving spouses, plus how military pay and retirement pay are treated by the state.",
-      "publishedAt": "2026-09-09T09:00:00.000Z",
+      "publishedAt": "2025-10-17T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "virginia veteran property tax exemption",
       "secondaryKeywords": [
@@ -9943,7 +9943,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language look at Washington property tax relief for disabled veterans, how the income-based exemption works by county, and how the state treats military pay.",
-      "publishedAt": "2026-09-16T09:00:00.000Z",
+      "publishedAt": "2025-10-29T09:00:00.000Z",
       "updatedAt": "2026-06-21T00:00:00.000Z",
       "primaryKeyword": "washington veteran property tax exemption",
       "secondaryKeywords": [
@@ -9974,7 +9974,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to West Virginia's refundable disabled-veteran property tax credit, the homestead exemption, and how the state treats military pay.",
-      "publishedAt": "2026-11-17T09:00:00.000Z",
+      "publishedAt": "2026-02-09T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "west virginia veteran property tax credit",
       "secondaryKeywords": [
@@ -10596,7 +10596,7 @@
         "US Military Bases"
       ],
       "description": "Massachusetts has a small but important military footprint. The state is home to five major active installations, supporting the Air Force, Army, and Coast Guard, plus Air Force Reserve and National Guard units that train and fly alongsi...",
-      "publishedAt": "2026-07-09T09:00:00.000Z",
+      "publishedAt": "2025-07-13T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in massachusetts",
       "secondaryKeywords": [
@@ -10627,7 +10627,7 @@
         "US Military Bases"
       ],
       "description": "Michigan has a smaller military footprint than some states, but the installations it does have carry important missions. The state is home to four major active installations, supporting the Air Force, Army, and Coast Guard, with much of ...",
-      "publishedAt": "2026-07-10T09:00:00.000Z",
+      "publishedAt": "2025-07-16T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in michigan",
       "secondaryKeywords": [
@@ -10681,7 +10681,7 @@
         "US Military Bases"
       ],
       "description": "Mississippi has a strong and steady military presence, much of it along the Gulf Coast. The state is home to six major active installations, supporting the Air Force, Navy, and Army National Guard, plus reserve and tenant units that trai...",
-      "publishedAt": "2026-07-08T09:00:00.000Z",
+      "publishedAt": "2025-07-11T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in mississippi",
       "secondaryKeywords": [
@@ -10789,7 +10789,7 @@
         "US Military Bases"
       ],
       "description": "Nevada plays a quiet but important role in how the military trains for war. The state is home to four major active installations, supporting the Air Force, Navy, and Army, plus the vast ranges where pilots and aircrews sharpen their skil...",
-      "publishedAt": "2026-07-06T09:00:00.000Z",
+      "publishedAt": "2025-07-06T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in nevada",
       "secondaryKeywords": [
@@ -10820,7 +10820,7 @@
         "US Military Bases"
       ],
       "description": "New Hampshire has a small but important military footprint. The state is home to two major active installations, supporting the Air National Guard (part of the Air Force) and the Space Force. Whether you are PCSing to New Hampshire (Perm...",
-      "publishedAt": "2026-07-17T09:00:00.000Z",
+      "publishedAt": "2025-07-28T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in new hampshire",
       "secondaryKeywords": [
@@ -11057,7 +11057,7 @@
         "US Military Bases"
       ],
       "description": "Oregon has a smaller military footprint than many states, but the bases here carry important national missions. The state is home to five major active installations, supporting the Air National Guard, Coast Guard, and Army National Guard...",
-      "publishedAt": "2026-07-13T09:00:00.000Z",
+      "publishedAt": "2025-07-18T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in oregon",
       "secondaryKeywords": [
@@ -11088,7 +11088,7 @@
         "US Military Bases"
       ],
       "description": "Pennsylvania has a long and proud military history. The state is home to seven major active installations, supporting the Army, Navy, and Air Force, plus a major Defense Logistics Agency site and reserve and Guard units that train alongs...",
-      "publishedAt": "2026-07-07T09:00:00.000Z",
+      "publishedAt": "2025-07-08T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in pennsylvania",
       "secondaryKeywords": [
@@ -11120,7 +11120,7 @@
         "US Military Bases"
       ],
       "description": "Rhode Island is the smallest state, but it carries a big role in the military. The state is home to one major active installation, Naval Station Newport, plus Air National Guard and Coast Guard units. The Navy leads the way here, with Ne...",
-      "publishedAt": "2026-07-14T09:00:00.000Z",
+      "publishedAt": "2025-07-21T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in rhode island",
       "secondaryKeywords": [
@@ -11182,7 +11182,7 @@
         "US Military Bases"
       ],
       "description": "South Dakota has a small but important military footprint. The state is home to one major active-duty installation, Ellsworth Air Force Base, plus key Air National Guard and Army National Guard sites that train and support the force. The...",
-      "publishedAt": "2026-07-15T09:00:00.000Z",
+      "publishedAt": "2025-07-23T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in south dakota",
       "secondaryKeywords": [
@@ -11244,7 +11244,7 @@
         "US Military Bases"
       ],
       "description": "Utah has a smaller but very busy military footprint. The state is home to five major active installations, supporting the Air Force and Army, plus National Guard units that train alongside them. Whether you are PCSing to Utah (Permanent ...",
-      "publishedAt": "2026-07-16T09:00:00.000Z",
+      "publishedAt": "2025-07-26T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in utah",
       "secondaryKeywords": [
@@ -11275,7 +11275,7 @@
         "US Military Bases"
       ],
       "description": "Vermont has a small but important military footprint, built almost entirely on the National Guard. The state is home to two major active installations, one supporting the Air National Guard and one supporting the Army National Guard. Whe...",
-      "publishedAt": "2026-07-20T09:00:00.000Z",
+      "publishedAt": "2025-07-31T09:00:00.000Z",
       "updatedAt": "2026-06-19T00:00:00.000Z",
       "primaryKeyword": "military bases in vermont",
       "secondaryKeywords": [
@@ -11556,7 +11556,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Wisconsin's refundable veterans property tax credit, who qualifies at a 100 percent rating, and how the state treats military pay.",
-      "publishedAt": "2026-11-03T09:00:00.000Z",
+      "publishedAt": "2026-01-18T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "wisconsin veteran property tax credit",
       "secondaryKeywords": [
@@ -11587,7 +11587,7 @@
         "Financial Guidance"
       ],
       "description": "A plain-language guide to Wyoming's veteran property tax exemption, who qualifies, the vehicle-fee option, and why the state taxes no military pay.",
-      "publishedAt": "2026-11-10T09:00:00.000Z",
+      "publishedAt": "2026-01-30T09:00:00.000Z",
       "updatedAt": "2026-06-22T00:00:00.000Z",
       "primaryKeyword": "wyoming veteran property tax exemption",
       "secondaryKeywords": [

--- a/content/blog/alabama-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/alabama-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Alabama Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Alabama fully exempts disabled veterans from property tax, plus how the state taxes military pay. Talk with a VeteranPCS agent in Alabama to plan your move.'
 description: "A plain-language guide to Alabama's full property tax exemption for totally disabled veterans and surviving spouses, plus how the state treats military retirement and active-duty pay."
 slug: alabama-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-05T09:00:00.000Z'
+publishedAt: '2025-11-30T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/alaska-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/alaska-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Alaska Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Alaska exempts the first $150,000 of a disabled veteran home value, plus why no income tax helps military pay. Talk with a VeteranPCS agent in Alaska.'
 description: "A plain-language guide to Alaska's $150,000 disabled-veteran property tax exemption, how boroughs administer it, and what no state income tax means for military pay."
 slug: alaska-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-19T09:00:00.000Z'
+publishedAt: '2025-12-22T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/arizona-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/arizona-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Arizona Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Arizona veterans and military families can cut property taxes, plus military pay and retirement tax rules. Talk with a VeteranPCS agent in Arizona today.'
 description: "A plain-language guide to Arizona's property tax exemption for disabled veterans, including the full home exemption for 100 percent rated veterans, plus how the state taxes military pay and retirement."
 slug: arizona-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-21T09:00:00.000Z'
+publishedAt: '2025-11-06T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/arkansas-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/arkansas-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Arkansas Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Arkansas fully exempts 100% disabled veterans from property tax, plus how it taxes military pay. Connect with a VeteranPCS agent in Arkansas today.'
 description: "A plain-language guide to Arkansas's full property tax exemption for 100% disabled veterans, the homestead credit, and how the state treats military pay."
 slug: arkansas-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-16T09:00:00.000Z'
+publishedAt: '2025-12-20T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/california-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/california-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'California Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How California veterans and military families can lower property taxes, plus homestead and military pay tax rules. Talk with a VeteranPCS agent in California.'
 description: 'A plain-language look at how California veterans can cut their property tax bill, how the homeowners exemption fits in, and how the state taxes military pay.'
 slug: california-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-11T09:00:00.000Z'
+publishedAt: '2025-10-22T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/colorado-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/colorado-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Colorado Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Colorado veterans and military families can lower property taxes, plus military retirement and income tax rules. Talk with a VeteranPCS agent today.'
 description: 'A plain-language look at the Colorado property tax exemption for disabled veterans and Gold Star spouses, plus how military pay is treated by the state.'
 slug: colorado-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-17T09:00:00.000Z'
+publishedAt: '2025-11-01T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/connecticut-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/connecticut-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Connecticut Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Connecticut now fully exempts 100% disabled veterans from property tax and exempts military retirement pay. Talk to a VeteranPCS agent in Connecticut.'
 description: "A plain-language guide to Connecticut's new full property tax exemption for 100% disabled veterans, the rating-based and local-option exemptions, and how the state treats military pay."
 slug: connecticut-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-22T09:00:00.000Z'
+publishedAt: '2025-12-30T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/delaware-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/delaware-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Delaware Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Delaware's disabled veterans school property tax credit covers 100% of school taxes, plus its military pension break. Connect with a VeteranPCS agent."
 description: "A plain-language guide to Delaware's disabled veterans school property tax credit, the senior credit, and how the state treats military pensions and pay."
 slug: delaware-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-26T09:00:00.000Z'
+publishedAt: '2026-01-04T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/florida-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/florida-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Florida Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Florida veterans and military families can lower property taxes, plus homestead and no-income-tax rules. Connect with a VeteranPCS agent in Florida today.'
 description: 'A plain-language look at the Florida property tax breaks that veterans and military families may qualify for, and how they fit with the state homestead exemption.'
 slug: florida-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-10T09:00:00.000Z'
+publishedAt: '2025-10-19T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/georgia-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/georgia-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Georgia Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Georgia veterans and military families can cut property taxes, plus military pay and retirement tax rules. Talk with a VeteranPCS agent in Georgia today.'
 description: 'A plain-language look at Georgia property tax relief for disabled veterans and surviving spouses, plus how military pay and retirement pay are treated by the state.'
 slug: georgia-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-15T09:00:00.000Z'
+publishedAt: '2025-10-27T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/hawaii-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/hawaii-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Hawaii Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Hawaii veterans and military families can erase property tax through their county, plus how military pay is taxed. Talk with a VeteranPCS agent in Hawaii.'
 description: 'A plain-language look at how each Hawaii county exempts totally disabled veterans from property tax, plus how the state treats military pay.'
 slug: hawaii-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-18T09:00:00.000Z'
+publishedAt: '2025-11-03T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/idaho-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/idaho-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Idaho Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Idaho lowers property tax for 100% disabled veterans by up to $1,500, runs an income-based reduction, and taxes military pay. Ask a VeteranPCS agent.'
 description: "A plain-language guide to Idaho's property tax benefit for 100% disabled veterans, the income-based Property Tax Reduction, and how the state treats military pay."
 slug: idaho-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-23T09:00:00.000Z'
+publishedAt: '2026-01-01T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/illinois-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/illinois-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Illinois Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Illinois lowers property tax for disabled veterans with an EAV reduction that scales by rating, plus how it taxes military pay. Talk to a VeteranPCS agent.'
 description: "A plain-language guide to Illinois's Standard Homestead Exemption for Veterans with Disabilities, how the EAV reduction scales by rating, and how the state treats military pay."
 slug: illinois-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-20T09:00:00.000Z'
+publishedAt: '2025-12-25T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/indiana-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/indiana-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Indiana Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Indiana cuts disabled veteran property taxes with two deductions, plus how the state taxes military pay. Talk with a VeteranPCS agent in Indiana today.'
 description: "A plain-language guide to Indiana's disabled-veteran property tax deductions, the assessed-value rules behind them, and how the state treats military pay."
 slug: indiana-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-14T09:00:00.000Z'
+publishedAt: '2025-12-15T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/iowa-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/iowa-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Iowa Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Iowa's disabled veteran credit can cover 100% of a qualifying veteran's property tax, plus how it treats military pay. Connect with a VeteranPCS agent."
 description: "A plain-language guide to Iowa's disabled veteran homestead tax credit, who qualifies at a 100 percent rating, and how the state treats military pay."
 slug: iowa-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-04T09:00:00.000Z'
+publishedAt: '2026-01-21T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/kansas-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/kansas-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Kansas Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Kansas disabled veterans can cut property taxes with the K-40SVR refund, plus how the state taxes military pay. Talk with a VeteranPCS agent in Kansas.'
 description: "A plain-language guide to Kansas property tax relief for disabled veterans through the K-40SVR refund, plus how the state treats military retirement and active-duty pay."
 slug: kansas-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-01T09:00:00.000Z'
+publishedAt: '2025-11-25T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/kentucky-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/kentucky-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Kentucky Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Kentucky disabled veterans use the homestead exemption to cut property taxes, plus how the state taxes military pay. Talk with a VeteranPCS agent today.'
 description: "A plain-language guide to Kentucky's homestead exemption for totally disabled veterans, plus how the state treats military retirement and active-duty pay."
 slug: kentucky-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-02T09:00:00.000Z'
+publishedAt: '2025-11-28T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/louisiana-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/louisiana-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Louisiana Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Louisiana exempts disabled veterans from property tax in tiers, plus how the state taxes military pay. Connect with a VeteranPCS agent in Louisiana today.'
 description: "A plain-language guide to Louisiana's tiered disabled-veteran property tax exemption, the homestead exemption, and how the state treats military pay."
 slug: louisiana-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-09T09:00:00.000Z'
+publishedAt: '2025-12-10T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/maine-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/maine-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Maine Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Maine exempts $6,000 of a veteran's home value, adds up to $50,000 for adapted housing, and fully exempts military retirement pay. Ask a VeteranPCS agent."
 description: "A plain-language guide to Maine's $6,000 veteran property tax exemption, the $50,000 adapted-housing exemption, and why the state does not tax military retirement pay."
 slug: maine-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-05T09:00:00.000Z'
+publishedAt: '2026-01-23T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/maryland-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/maryland-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Maryland Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Maryland veterans and military families can cut property taxes, plus military retirement tax rules. Talk with a VeteranPCS agent in Maryland today.'
 description: "A plain-language look at Maryland's full property tax exemption for 100 percent disabled veterans and surviving spouses, plus how the state taxes military retirement pay."
 slug: maryland-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-22T09:00:00.000Z'
+publishedAt: '2025-11-08T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/massachusetts-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/massachusetts-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Massachusetts Veteran Property Tax Exemptions 2026'
 metaDescription: "How Massachusetts cities and towns exempt part of a disabled veteran's property tax bill, and how the state treats military pay. Talk with a VeteranPCS agent."
 description: "A plain-language guide to Massachusetts' clause-based veteran property tax exemptions, who qualifies, how towns administer them, and how the state treats military pay."
 slug: massachusetts-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-12T09:00:00.000Z'
+publishedAt: '2026-02-02T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/michigan-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/michigan-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Michigan Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Michigan fully exempts 100% disabled veterans from property tax, plus how it treats military pay. Connect with a VeteranPCS agent in Michigan today.'
 description: "A plain-language guide to Michigan's full property tax exemption for 100% disabled veterans, the surviving-spouse rules, and how the state treats military pay."
 slug: michigan-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-28T09:00:00.000Z'
+publishedAt: '2026-01-08T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/minnesota-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/minnesota-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Minnesota Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Minnesota excludes up to $300,000 of a disabled veteran's home value from property tax, plus how it treats military pay. Connect with a VeteranPCS agent."
 description: "A plain-language guide to Minnesota's market value exclusion for veterans with a disability, the surviving-spouse rules, and how the state treats military pay."
 slug: minnesota-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-30T09:00:00.000Z'
+publishedAt: '2026-01-13T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/mississippi-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/mississippi-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Mississippi Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Mississippi exempts totally disabled veterans from property tax, plus how the state taxes military pay. Talk with a VeteranPCS agent in Mississippi today.'
 description: "A plain-language guide to Mississippi's full property tax exemption for totally disabled veterans and surviving spouses, plus how the state treats military pay."
 slug: mississippi-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-13T09:00:00.000Z'
+publishedAt: '2025-12-12T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/missouri-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/missouri-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Missouri Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Missouri veterans can lower property taxes through the tax credit and POW exemption, plus military pay rules. Talk with a VeteranPCS agent in Missouri.'
 description: "A plain-language guide to Missouri's narrow property tax exemption for disabled former prisoners of war, the property tax credit, and how the state treats military pay."
 slug: missouri-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-30T09:00:00.000Z'
+publishedAt: '2025-11-23T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/montana-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/montana-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Montana Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Montana cuts property tax for 100% disabled veterans on an income-based sliding scale, and how the state taxes military pay. Ask a VeteranPCS Montana agent.'
 description: "A plain-language guide to Montana's income-tested Disabled Veterans (MDV) property tax program, the sliding-scale rate reduction, and how the state treats military pay."
 slug: montana-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-06T09:00:00.000Z'
+publishedAt: '2026-01-26T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/nebraska-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/nebraska-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Nebraska Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Nebraska exempts disabled veterans from property tax through its Homestead Exemption, plus how it taxes military pay. Talk with a VeteranPCS agent today.'
 description: "A plain-language guide to Nebraska's Homestead Exemption for totally disabled veterans and surviving spouses, plus how the state treats military retirement and active-duty pay."
 slug: nebraska-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-08T09:00:00.000Z'
+publishedAt: '2025-12-08T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/nevada-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/nevada-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Nevada Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Nevada lowers property taxes for disabled veterans and what no state income tax means for military pay. Talk with a VeteranPCS agent in Nevada today.'
 description: "A plain-language guide to Nevada's Disabled Veteran's Exemption, how it lowers your assessed value, and what having no state income tax means for military pay."
 slug: nevada-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-07T09:00:00.000Z'
+publishedAt: '2025-12-05T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/new-hampshire-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/new-hampshire-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'New Hampshire Veteran Property Tax Exemptions 2026'
 metaDescription: "How New Hampshire gives disabled veterans a property tax credit and, after repealing its last tax, now taxes no income at all. Talk with a VeteranPCS agent."
 description: "A plain-language guide to New Hampshire's veterans' property tax credits, the full exemption for specially adapted homes, and why the state now taxes no income."
 slug: new-hampshire-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-13T09:00:00.000Z'
+publishedAt: '2026-02-04T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/new-jersey-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/new-jersey-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'New Jersey Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How New Jersey fully exempts 100% disabled veterans from property tax, adds a $250 deduction, and shields military pension pay. Talk to a VeteranPCS agent.'
 description: "A plain-language guide to New Jersey's full property tax exemption for 100% disabled veterans, the $250 veterans deduction, and how the state treats military pay."
 slug: new-jersey-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-21T09:00:00.000Z'
+publishedAt: '2025-12-27T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/new-mexico-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/new-mexico-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'New Mexico Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How New Mexico expanded veteran property tax exemptions for 2025 and 2026, plus how the state taxes military pay. Talk with a VeteranPCS agent in New Mexico.'
 description: "A plain-language guide to New Mexico's expanded veteran property tax exemptions, including the new proportional disabled-veteran exemption, plus how the state treats military pay."
 slug: new-mexico-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-06T09:00:00.000Z'
+publishedAt: '2025-12-03T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/new-york-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/new-york-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'New York Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How New York veterans can lower property taxes with the alternative veterans exemption, plus military pay tax rules. Talk with a VeteranPCS agent in New York.'
 description: "A plain-language guide to New York's alternative veterans exemption, the new exemption for 100 percent disabled veterans, and how the state treats military pay and pensions."
 slug: new-york-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-29T09:00:00.000Z'
+publishedAt: '2025-11-20T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/north-carolina-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/north-carolina-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'North Carolina Veteran Property Tax Exemptions 2026'
 metaDescription: 'How North Carolina veterans and military families can cut property taxes, plus homestead and military pay rules. Connect with a VeteranPCS agent in NC today.'
 description: 'A clear, plain-language look at how disabled veterans and military families in North Carolina can lower their property taxes, plus how the state treats military pay.'
 slug: north-carolina-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-14T09:00:00.000Z'
+publishedAt: '2025-10-24T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/north-dakota-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/north-dakota-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'North Dakota Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How North Dakota's disabled veterans property tax credit scales with your VA rating, plus how it taxes military pay. Ask a VeteranPCS agent in North Dakota."
 description: "A plain-language guide to North Dakota's disabled veterans property tax credit, how it scales with your VA rating, and how the state treats military pay."
 slug: north-dakota-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-27T09:00:00.000Z'
+publishedAt: '2026-01-06T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/ohio-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/ohio-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Ohio Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Ohio veterans can cut property taxes with the enhanced homestead exemption, plus how the state taxes military pay. Talk with a VeteranPCS agent in Ohio.'
 description: "A plain-language look at Ohio's enhanced homestead exemption for disabled veterans and surviving spouses, plus how the state treats military retirement and active-duty pay."
 slug: ohio-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-25T09:00:00.000Z'
+publishedAt: '2025-11-15T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/oregon-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/oregon-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Oregon Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Oregon exempts part of a disabled veteran's home value at 40 percent disability, plus how it taxes military pay. Ask a VeteranPCS agent in Oregon."
 description: "A plain-language guide to Oregon's disabled veteran property tax exemption, who qualifies at 40 percent, and how the state treats military pay."
 slug: oregon-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-02T09:00:00.000Z'
+publishedAt: '2026-01-16T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/pcs-to-aberdeen-proving-ground-2026-guide.mdx
+++ b/content/blog/pcs-to-aberdeen-proving-ground-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Aberdeen Proving Ground: 2026 Maryland Guide'
 metaDescription: 'Planning a PCS to Aberdeen Proving Ground in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live in Harford County, MD.'
 description: 'A 2026 guide for military families moving to Aberdeen Proving Ground, covering where to live, BAH, schools, healthcare, and life in Harford County, Maryland.'
 slug: pcs-to-aberdeen-proving-ground-2026-guide
-publishedAt: '2026-12-23T09:00:00.000Z'
+publishedAt: '2026-04-12T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-23'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-air-force-academy-colorado-springs-2026-guide.mdx
+++ b/content/blog/pcs-to-air-force-academy-colorado-springs-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Air Force Academy: 2026 North Colorado Springs Guide'
 metaDescription: 'PCSing to the Air Force Academy in 2026? A plain-language guide for permanent-party families: where to live near USAFA, BAH rates, schools, and healthcare.'
 description: 'A 2026 guide for military families PCSing to the U.S. Air Force Academy, covering where to live in north Colorado Springs and Monument, BAH, schools, healthcare, and life at elevation.'
 slug: pcs-to-air-force-academy-colorado-springs-2026-guide
-publishedAt: '2026-12-28T09:00:00.000Z'
+publishedAt: '2026-04-17T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-28'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-barksdale-afb-bossier-city-2026-guide.mdx
+++ b/content/blog/pcs-to-barksdale-afb-bossier-city-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Barksdale AFB: 2026 Bossier City Move Guide'
 metaDescription: 'Planning a PCS to Barksdale AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Bossier City, Louisiana.'
 description: 'A 2026 guide for military families moving to Barksdale AFB, covering where to live, BAH, schools, healthcare, and life in the Shreveport-Bossier area.'
 slug: pcs-to-barksdale-afb-bossier-city-2026-guide
-publishedAt: '2026-12-14T09:00:00.000Z'
+publishedAt: '2026-03-25T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-14'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-beale-afb-2026-guide.mdx
+++ b/content/blog/pcs-to-beale-afb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Beale AFB: 2026 Military Family PCS Move Guide'
 metaDescription: 'Planning a PCS to Beale AFB? Get a plain-language 2026 guide to housing, BAH, schools, healthcare, and where to live near Yuba City, California. Start here.'
 description: 'A 2026 guide for military families moving to Beale AFB, covering where to live, BAH, schools, healthcare, and life near Marysville and Yuba City, California.'
 slug: pcs-to-beale-afb-2026-guide
-publishedAt: '2027-01-08T09:00:00.000Z'
+publishedAt: '2026-05-06T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-08'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-buckley-sfb-aurora-2026-guide.mdx
+++ b/content/blog/pcs-to-buckley-sfb-aurora-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Buckley Space Force Base: 2026 Aurora Guide'
 metaDescription: 'Planning a PCS to Buckley Space Force Base in 2026? Plain-language guide to housing, BAH, schools, healthcare, and where to live near Aurora, CO. Start here.'
 description: 'A 2026 guide for military families moving to Buckley Space Force Base, covering where to live, BAH, schools, healthcare, and life in the Denver-Aurora metro.'
 slug: pcs-to-buckley-sfb-aurora-2026-guide
-publishedAt: '2026-12-30T09:00:00.000Z'
+publishedAt: '2026-04-21T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-30'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-cannon-afb-clovis-2026-guide.mdx
+++ b/content/blog/pcs-to-cannon-afb-clovis-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Cannon AFB: 2026 Clovis, New Mexico Move Guide'
 metaDescription: 'Planning a PCS to Cannon AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Clovis, New Mexico. Start here.'
 description: 'A 2026 guide for military families moving to Cannon AFB, covering where to live, BAH, schools, healthcare, and life on the eastern New Mexico high plains.'
 slug: pcs-to-cannon-afb-clovis-2026-guide
-publishedAt: '2027-01-28T09:00:00.000Z'
+publishedAt: '2026-06-07T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-28'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-davis-monthan-afb-tucson-2026-guide.mdx
+++ b/content/blog/pcs-to-davis-monthan-afb-tucson-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Davis-Monthan AFB: 2026 Tucson Arizona Move Guide'
 metaDescription: 'Planning a PCS to Davis-Monthan AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Tucson, Arizona. Read now.'
 description: 'A 2026 guide for military families moving to Davis-Monthan AFB, covering where to live, BAH, schools, healthcare, and life in Tucson, Arizona.'
 slug: pcs-to-davis-monthan-afb-tucson-2026-guide
-publishedAt: '2026-12-03T09:00:00.000Z'
+publishedAt: '2026-03-08T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-03'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-dyess-afb-abilene-2026-guide.mdx
+++ b/content/blog/pcs-to-dyess-afb-abilene-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Dyess AFB: 2026 Abilene, Texas Military Guide'
 metaDescription: 'Planning a PCS to Dyess AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Abilene, Texas. Start here.'
 description: 'A 2026 guide for military families moving to Dyess AFB, covering where to live, BAH, schools, healthcare, and life in Abilene, Texas.'
 slug: pcs-to-dyess-afb-abilene-2026-guide
-publishedAt: '2027-01-22T09:00:00.000Z'
+publishedAt: '2026-05-28T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-22'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-edwards-afb-2026-guide.mdx
+++ b/content/blog/pcs-to-edwards-afb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Edwards AFB: 2026 Antelope Valley Move Guide'
 metaDescription: 'Planning a PCS to Edwards AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live in the Antelope Valley. Start here.'
 description: 'A 2026 guide for military families moving to Edwards Air Force Base, covering where to live, BAH, schools, healthcare, and life in the high desert Antelope Valley.'
 slug: pcs-to-edwards-afb-2026-guide
-publishedAt: '2027-01-06T09:00:00.000Z'
+publishedAt: '2026-05-01T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-06'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-eielson-afb-fairbanks-2026-guide.mdx
+++ b/content/blog/pcs-to-eielson-afb-fairbanks-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Eielson AFB: 2027 Fairbanks Alaska Move Guide'
 metaDescription: 'Planning a PCS to Eielson AFB near Fairbanks, Alaska? Get a plain-language guide to housing, BAH, schools, healthcare, climate, and where to live in 2027.'
 description: 'A 2027 guide for military families moving to Eielson Air Force Base, covering where to live near Fairbanks, BAH, schools, healthcare, and life in interior Alaska.'
 slug: pcs-to-eielson-afb-fairbanks-2026-guide
-publishedAt: '2027-01-13T09:00:00.000Z'
+publishedAt: '2026-05-13T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-13'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-ellsworth-afb-rapid-city-2026-guide.mdx
+++ b/content/blog/pcs-to-ellsworth-afb-rapid-city-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Ellsworth AFB: 2026 Rapid City, SD Move Guide'
 metaDescription: 'Planning a PCS to Ellsworth AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Rapid City, South Dakota.'
 description: 'A 2026 guide for military families moving to Ellsworth AFB, covering where to live, BAH, schools, healthcare, and life near Rapid City, South Dakota.'
 slug: pcs-to-ellsworth-afb-rapid-city-2026-guide
-publishedAt: '2027-02-04T09:00:00.000Z'
+publishedAt: '2026-06-19T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-04'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-fairchild-afb-spokane-2026-guide.mdx
+++ b/content/blog/pcs-to-fairchild-afb-spokane-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fairchild AFB: 2026 Spokane, WA Military Move Guide'
 metaDescription: 'Planning a PCS to Fairchild AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Spokane, Washington. Start here'
 description: 'A 2026 guide for military families moving to Fairchild AFB, covering where to live, BAH, schools, healthcare, and life in the Spokane area.'
 slug: pcs-to-fairchild-afb-spokane-2026-guide
-publishedAt: '2026-12-17T09:00:00.000Z'
+publishedAt: '2026-04-02T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-17'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-fe-warren-afb-cheyenne-2026-guide.mdx
+++ b/content/blog/pcs-to-fe-warren-afb-cheyenne-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to F.E. Warren AFB: 2026 Cheyenne, Wyoming Guide'
 metaDescription: 'Planning a PCS to F.E. Warren AFB in Cheyenne, Wyoming? Get a plain-language guide to housing, BAH rates, schools, healthcare, and daily life. Start here.'
 description: 'A 2026 guide for military families moving to F.E. Warren AFB, covering where to live, BAH, schools, healthcare, and life in Cheyenne, Wyoming.'
 slug: pcs-to-fe-warren-afb-cheyenne-2026-guide
-publishedAt: '2027-02-08T09:00:00.000Z'
+publishedAt: '2026-06-24T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-08'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-fort-belvoir-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-belvoir-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Belvoir: 2026 Northern Virginia Move Guide'
 metaDescription: 'Planning a PCS to Fort Belvoir in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Northern Virginia. Start here.'
 description: 'A 2026 guide for military families moving to Fort Belvoir, covering where to live, BAH, schools, healthcare, and life in Northern Virginia.'
 slug: pcs-to-fort-belvoir-2026-guide
-publishedAt: '2026-08-24T09:00:00.000Z'
+publishedAt: '2025-09-20T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-benning-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-benning-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Benning: 2026 Columbus, Georgia Move Guide'
 metaDescription: 'Planning a PCS to Fort Benning (formerly Fort Moore) in 2026? Get a plain guide to housing, BAH, schools, and where to live near Columbus, GA. Start here.'
 description: 'A 2026 guide for military families moving to Fort Benning, Georgia (formerly Fort Moore), covering where to live, BAH, schools, healthcare, and life near Columbus.'
 slug: pcs-to-fort-benning-2026-guide
-publishedAt: '2026-08-27T09:00:00.000Z'
+publishedAt: '2025-09-27T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-bliss-el-paso-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-bliss-el-paso-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Bliss: 2026 Guide for El Paso Families'
 metaDescription: 'PCSing to Fort Bliss in 2026? Get a plain-language guide to El Paso neighborhoods, BAH, schools, and the commute, then connect with a local VeteranPCS agent.'
 description: 'A friendly, plain-language guide to moving your family to Fort Bliss in El Paso, Texas, from neighborhoods and BAH to schools, healthcare, and the desert weather.'
 slug: pcs-to-fort-bliss-el-paso-2026-guide
-publishedAt: '2026-07-27T09:00:00.000Z'
+publishedAt: '2025-08-02T09:00:00.000Z'
 updatedAt: '2026-06-19T00:00:00.000Z'
 reviewBy: '2026-12-19'
 component: PCS Help

--- a/content/blog/pcs-to-fort-bragg-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-bragg-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Bragg: 2026 Fayetteville, NC Move Guide'
 metaDescription: 'Planning a PCS to Fort Bragg (formerly Fort Liberty) in 2026? A plain-language guide to housing, BAH, schools, and where to live near Fayetteville. Start here.'
 description: 'A 2026 guide for military families moving to Fort Bragg, North Carolina (formerly Fort Liberty), covering where to live, BAH, schools, healthcare, and life near Fayetteville.'
 slug: pcs-to-fort-bragg-2026-guide
-publishedAt: '2026-08-26T09:00:00.000Z'
+publishedAt: '2025-09-25T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-carson-colorado-springs-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-carson-colorado-springs-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Carson: 2026 Colorado Springs Move Guide'
 metaDescription: 'Planning a PCS to Fort Carson in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Colorado Springs. Start here.'
 description: 'A 2026 guide for military families moving to Fort Carson, covering where to live, BAH, schools, healthcare, and life in Colorado Springs.'
 slug: pcs-to-fort-carson-colorado-springs-2026-guide
-publishedAt: '2026-07-31T09:00:00.000Z'
+publishedAt: '2025-08-12T09:00:00.000Z'
 updatedAt: '2026-06-19T00:00:00.000Z'
 reviewBy: '2026-12-19'
 component: PCS Help

--- a/content/blog/pcs-to-fort-drum-watertown-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-drum-watertown-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Drum: 2026 Watertown, New York Move Guide'
 metaDescription: 'Planning a PCS to Fort Drum in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Watertown, New York. Start here.'
 description: 'A 2026 guide for military families moving to Fort Drum, covering where to live, BAH, schools, healthcare, and life in New York North Country.'
 slug: pcs-to-fort-drum-watertown-2026-guide
-publishedAt: '2026-08-07T09:00:00.000Z'
+publishedAt: '2025-08-24T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-hood-killeen-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-hood-killeen-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Hood: 2026 Killeen Military Family Guide'
 metaDescription: 'Planning a PCS to Fort Hood (formerly Fort Cavazos) in 2026? See where to live near Killeen, plus BAH, schools, and healthcare. Connect with a local agent.'
 description: 'A plain-language 2026 guide to moving to Fort Hood near Killeen, Texas (formerly Fort Cavazos), covering housing, BAH, schools, healthcare, and things to do.'
 slug: pcs-to-fort-hood-killeen-2026-guide
-publishedAt: '2026-07-28T09:00:00.000Z'
+publishedAt: '2025-08-04T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-19'
 component: PCS Help

--- a/content/blog/pcs-to-fort-huachuca-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-huachuca-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Huachuca: 2026 Sierra Vista, AZ Move Guide'
 metaDescription: 'Planning a PCS to Fort Huachuca in 2026? Your plain-language guide to housing, BAH, schools, healthcare, and where to live near Sierra Vista, Arizona.'
 description: 'A 2026 guide for military families moving to Fort Huachuca, covering where to live, BAH, schools, healthcare, and high-desert life in southeastern Arizona.'
 slug: pcs-to-fort-huachuca-2026-guide
-publishedAt: '2026-08-21T09:00:00.000Z'
+publishedAt: '2025-09-18T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-irwin-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-irwin-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Irwin: A 2026 Mojave Desert Move Guide'
 metaDescription: 'Planning a PCS to Fort Irwin in 2026? A plain-language guide to on-post housing, BAH, schools, healthcare, and where to live near Barstow, California.'
 description: 'A 2026 guide for military families moving to Fort Irwin, the Army National Training Center, covering on-post housing, BAH, schools, healthcare, and Mojave Desert life.'
 slug: pcs-to-fort-irwin-2026-guide
-publishedAt: '2026-08-18T09:00:00.000Z'
+publishedAt: '2025-09-10T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-jackson-columbia-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-jackson-columbia-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Jackson: A 2026 Columbia, SC Move Guide'
 metaDescription: 'Planning a PCS to Fort Jackson in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Columbia, South Carolina.'
 description: 'A 2026 guide for military families moving to Fort Jackson, covering where to live, BAH, schools, healthcare, and life in Columbia, South Carolina.'
 slug: pcs-to-fort-jackson-columbia-2026-guide
-publishedAt: '2026-08-12T09:00:00.000Z'
+publishedAt: '2025-08-31T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-knox-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-knox-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Knox: 2026 Radcliff, Kentucky Move Guide'
 metaDescription: 'Planning a PCS to Fort Knox in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Radcliff, Kentucky. Start here.'
 description: 'A 2026 guide for military families moving to Fort Knox, covering where to live, BAH, schools, healthcare, and life in north-central Kentucky.'
 slug: pcs-to-fort-knox-2026-guide
-publishedAt: '2026-08-13T09:00:00.000Z'
+publishedAt: '2025-09-03T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-lee-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-lee-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Lee: 2026 Petersburg, Virginia Move Guide'
 metaDescription: 'Planning a PCS to Fort Lee (formerly Fort Gregg-Adams) in 2026? A plain-language guide to housing, BAH, schools, and where to live near Petersburg, Virginia.'
 description: 'A 2026 guide for military families moving to Fort Lee, Virginia (formerly Fort Gregg-Adams), covering where to live, BAH, schools, healthcare, and life in the Tri-Cities.'
 slug: pcs-to-fort-lee-2026-guide
-publishedAt: '2026-08-20T09:00:00.000Z'
+publishedAt: '2025-09-15T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-leonard-wood-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-leonard-wood-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Leonard Wood: 2026 Missouri Move Guide'
 metaDescription: 'Planning a PCS to Fort Leonard Wood in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Waynesville, Missouri.'
 description: 'A 2026 guide for military families moving to Fort Leonard Wood, covering where to live, BAH, schools, healthcare, and life in the Missouri Ozarks.'
 slug: pcs-to-fort-leonard-wood-2026-guide
-publishedAt: '2026-08-05T09:00:00.000Z'
+publishedAt: '2025-08-19T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-meade-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-meade-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Meade: A 2026 Guide for Odenton, Maryland'
 metaDescription: 'Planning a PCS to Fort Meade in 2026? A plain-language guide to housing, BAH, schools, healthcare, and where to live near Odenton, Maryland. Start here.'
 description: 'A 2026 guide for military families moving to Fort Meade, covering where to live, BAH, schools, healthcare, and life between Baltimore and Washington.'
 slug: pcs-to-fort-meade-2026-guide
-publishedAt: '2026-09-04T09:00:00.000Z'
+publishedAt: '2025-10-12T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2026-12-21'
 component: PCS Help

--- a/content/blog/pcs-to-fort-polk-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-polk-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Polk: A 2026 Leesville, Louisiana Guide'
 metaDescription: 'Planning a PCS to Fort Polk in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Leesville, Louisiana. Start here.'
 description: 'A 2026 guide for military families moving to Fort Polk, home of the Joint Readiness Training Center, covering where to live, BAH, schools, healthcare, and life in west-central Louisiana.'
 slug: pcs-to-fort-polk-2026-guide
-publishedAt: '2026-08-19T09:00:00.000Z'
+publishedAt: '2025-09-13T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-riley-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-riley-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Riley: 2026 Junction City, Kansas Guide'
 metaDescription: 'Planning a PCS to Fort Riley in 2026? A plain-language guide to housing, BAH, schools, healthcare, and where to live near Junction City, Kansas. Start here.'
 description: 'A 2026 guide for military families moving to Fort Riley, Kansas, covering where to live, BAH, schools, healthcare, and life in the Flint Hills.'
 slug: pcs-to-fort-riley-2026-guide
-publishedAt: '2026-08-17T09:00:00.000Z'
+publishedAt: '2025-09-08T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-rucker-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-rucker-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Rucker: 2026 Southeast Alabama Move Guide'
 metaDescription: 'Planning a PCS to Fort Rucker in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Daleville and Enterprise, AL.'
 description: 'A 2026 guide for military families moving to Fort Rucker, covering where to live, BAH, schools, healthcare, and life in southeast Alabama''s Wiregrass region.'
 slug: pcs-to-fort-rucker-2026-guide
-publishedAt: '2026-12-31T09:00:00.000Z'
+publishedAt: '2026-04-24T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-30'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-fort-sill-lawton-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-sill-lawton-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Sill: 2026 Lawton, Oklahoma Move Guide'
 metaDescription: 'Planning a PCS to Fort Sill in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Lawton, Oklahoma. Start here.'
 description: 'A 2026 guide for military families moving to Fort Sill, covering where to live, BAH, schools, healthcare, and life around Lawton, Oklahoma.'
 slug: pcs-to-fort-sill-lawton-2026-guide
-publishedAt: '2026-08-04T09:00:00.000Z'
+publishedAt: '2025-08-17T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-stewart-hunter-aaf-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-stewart-hunter-aaf-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Stewart and Hunter AAF: 2026 Move Guide'
 metaDescription: 'Planning a PCS to Fort Stewart or Hunter Army Airfield in 2026? A plain-language guide to housing, BAH, schools, and where to live near Hinesville, GA.'
 description: 'A 2026 guide for military families moving to Fort Stewart and Hunter Army Airfield, covering where to live, BAH, schools, healthcare, and coastal Georgia life.'
 slug: pcs-to-fort-stewart-hunter-aaf-2026-guide
-publishedAt: '2026-08-11T09:00:00.000Z'
+publishedAt: '2025-08-29T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-fort-wainwright-fairbanks-2026-guide.mdx
+++ b/content/blog/pcs-to-fort-wainwright-fairbanks-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Fort Wainwright: 2027 Fairbanks, Alaska Move Guide'
 metaDescription: 'Planning a PCS to Fort Wainwright in 2027? Get a plain-language guide to housing, BAH, schools, healthcare, and life in Fairbanks, Alaska. Start here.'
 description: 'A 2027 guide for military families moving to Fort Wainwright, covering where to live, BAH, schools, healthcare, and life in Fairbanks, Alaska.'
 slug: pcs-to-fort-wainwright-fairbanks-2026-guide
-publishedAt: '2027-01-12T09:00:00.000Z'
+publishedAt: '2026-05-11T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-12'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-goodfellow-afb-san-angelo-2026-guide.mdx
+++ b/content/blog/pcs-to-goodfellow-afb-san-angelo-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Goodfellow AFB: 2026 San Angelo, TX Move Guide'
 metaDescription: 'Planning a PCS to Goodfellow AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near San Angelo, Texas. Start here.'
 description: 'A 2026 guide for military families moving to Goodfellow AFB, covering where to live, BAH, schools, healthcare, and life in San Angelo, Texas.'
 slug: pcs-to-goodfellow-afb-san-angelo-2026-guide
-publishedAt: '2027-01-25T09:00:00.000Z'
+publishedAt: '2026-05-31T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-25'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-grand-forks-afb-2026-guide.mdx
+++ b/content/blog/pcs-to-grand-forks-afb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Grand Forks AFB: 2026 North Dakota Move Guide'
 metaDescription: 'Planning a PCS to Grand Forks AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Grand Forks, North Dakota.'
 description: 'A 2026 guide for military families moving to Grand Forks Air Force Base, covering where to live, BAH, schools, healthcare, and life in the Red River Valley.'
 slug: pcs-to-grand-forks-afb-2026-guide
-publishedAt: '2027-02-03T09:00:00.000Z'
+publishedAt: '2026-06-17T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-03'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-hanscom-afb-bedford-2026-guide.mdx
+++ b/content/blog/pcs-to-hanscom-afb-bedford-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Hanscom AFB: A 2026 Bedford, MA Family Guide'
 metaDescription: 'Planning a PCS to Hanscom AFB in 2026? Plain-language guide to housing, BAH, schools, healthcare, and where to live near Bedford, Massachusetts. Start here.'
 description: 'A 2026 guide for military families moving to Hanscom AFB, covering where to live, BAH, schools, healthcare, and life near Boston in Bedford, Massachusetts.'
 slug: pcs-to-hanscom-afb-bedford-2026-guide
-publishedAt: '2027-02-11T09:00:00.000Z'
+publishedAt: '2026-07-02T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-11'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-hill-afb-ogden-2026-guide.mdx
+++ b/content/blog/pcs-to-hill-afb-ogden-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Hill AFB: 2026 Guide for Families Near Ogden, Utah'
 metaDescription: 'Planning a PCS to Hill AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Ogden and Layton, Utah. Start here.'
 description: 'A 2026 guide for military families moving to Hill AFB, covering where to live, BAH, schools, healthcare, and life near Ogden and Layton, Utah.'
 slug: pcs-to-hill-afb-ogden-2026-guide
-publishedAt: '2026-12-04T09:00:00.000Z'
+publishedAt: '2026-03-11T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-04'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-holloman-afb-alamogordo-2026-guide.mdx
+++ b/content/blog/pcs-to-holloman-afb-alamogordo-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Holloman AFB: 2027 Alamogordo, NM Move Guide'
 metaDescription: 'Planning a PCS to Holloman AFB in 2027? Get a plain-language guide to housing, BAH, schools, healthcare, and life near Alamogordo, New Mexico. Start here.'
 description: 'A 2027 guide for military families moving to Holloman AFB, covering where to live near Alamogordo, BAH, schools, the 49th Medical Group, and White Sands.'
 slug: pcs-to-holloman-afb-alamogordo-2026-guide
-publishedAt: '2027-01-29T09:00:00.000Z'
+publishedAt: '2026-06-09T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-29'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-joint-base-andrews-2026-guide.mdx
+++ b/content/blog/pcs-to-joint-base-andrews-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Joint Base Andrews: 2026 Maryland Move Guide'
 metaDescription: "Planning a PCS to Joint Base Andrews in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live in Prince George's County."
 description: 'A 2026 guide for military families moving to Joint Base Andrews, covering where to live, BAH, schools, healthcare, and life in Prince George''s County, Maryland.'
 slug: pcs-to-joint-base-andrews-2026-guide
-publishedAt: '2026-11-25T09:00:00.000Z'
+publishedAt: '2026-02-24T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-05-25'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-joint-base-elmendorf-richardson-anchorage-2026-guide.mdx
+++ b/content/blog/pcs-to-joint-base-elmendorf-richardson-anchorage-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to JBER: 2026 Anchorage Military Family Move Guide'
 metaDescription: 'Planning a PCS to Joint Base Elmendorf-Richardson in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and life in Anchorage, Alaska.'
 description: 'A 2026 guide for military families moving to Joint Base Elmendorf-Richardson, covering where to live, BAH, schools, healthcare, and life in Anchorage, Alaska.'
 slug: pcs-to-joint-base-elmendorf-richardson-anchorage-2026-guide
-publishedAt: '2026-11-20T09:00:00.000Z'
+publishedAt: '2026-02-17T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-05-20'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-joint-base-langley-eustis-2026-guide.mdx
+++ b/content/blog/pcs-to-joint-base-langley-eustis-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Joint Base Langley-Eustis: 2026 Virginia Guide'
 metaDescription: 'Planning a PCS to Joint Base Langley-Eustis in 2026? A plain-language guide to housing, BAH, schools, and where to live near Hampton and Newport News, VA.'
 description: 'A 2026 guide for military families moving to Joint Base Langley-Eustis, covering where to live, BAH, schools, healthcare, and life on the Virginia Peninsula.'
 slug: pcs-to-joint-base-langley-eustis-2026-guide
-publishedAt: '2026-09-01T09:00:00.000Z'
+publishedAt: '2025-10-05T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2026-12-21'
 component: PCS Help

--- a/content/blog/pcs-to-joint-base-mcguire-dix-lakehurst-2026-guide.mdx
+++ b/content/blog/pcs-to-joint-base-mcguire-dix-lakehurst-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Joint Base McGuire-Dix-Lakehurst: 2026 Guide'
 metaDescription: 'Planning a PCS to Joint Base McGuire-Dix-Lakehurst in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live in New Jersey.'
 description: 'A 2026 guide for military families moving to Joint Base McGuire-Dix-Lakehurst, covering where to live, BAH, schools, healthcare, and life in central New Jersey.'
 slug: pcs-to-joint-base-mcguire-dix-lakehurst-2026-guide
-publishedAt: '2026-11-24T09:00:00.000Z'
+publishedAt: '2026-02-22T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-05-24'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-joint-base-pearl-harbor-hickam-2026-guide.mdx
+++ b/content/blog/pcs-to-joint-base-pearl-harbor-hickam-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Joint Base Pearl Harbor-Hickam: 2026 Move Guide'
 metaDescription: 'Planning a PCS to Joint Base Pearl Harbor-Hickam in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and life on Oahu. Start here.'
 description: 'A 2026 guide for military families moving to Joint Base Pearl Harbor-Hickam, covering where to live, BAH, schools, healthcare, and life on Oahu, Hawaii.'
 slug: pcs-to-joint-base-pearl-harbor-hickam-2026-guide
-publishedAt: '2026-11-19T09:00:00.000Z'
+publishedAt: '2026-02-14T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-05-19'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-joint-base-san-antonio-2026-guide.mdx
+++ b/content/blog/pcs-to-joint-base-san-antonio-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Joint Base San Antonio: 2026 JBSA Move Guide'
 metaDescription: 'Planning a PCS to Joint Base San Antonio in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near JBSA. Start here.'
 description: 'A 2026 guide for military families moving to Joint Base San Antonio, covering where to live, BAH, schools, healthcare, and life in South Texas.'
 slug: pcs-to-joint-base-san-antonio-2026-guide
-publishedAt: '2026-08-25T09:00:00.000Z'
+publishedAt: '2025-09-22T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-keesler-afb-biloxi-2026-guide.mdx
+++ b/content/blog/pcs-to-keesler-afb-biloxi-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Keesler AFB: 2026 Biloxi, Mississippi Move Guide'
 metaDescription: 'Planning a PCS to Keesler AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Biloxi, Mississippi. Start here.'
 description: 'A 2026 guide for military families moving to Keesler AFB, covering where to live, BAH, schools, healthcare, and life on the Mississippi Gulf Coast.'
 slug: pcs-to-keesler-afb-biloxi-2026-guide
-publishedAt: '2026-12-02T09:00:00.000Z'
+publishedAt: '2026-03-06T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-02'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-kirtland-afb-albuquerque-2026-guide.mdx
+++ b/content/blog/pcs-to-kirtland-afb-albuquerque-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Kirtland AFB: Your 2026 Albuquerque Move Guide'
 metaDescription: 'Planning a PCS to Kirtland AFB in 2026? Get a plain-language guide to BAH, housing, schools, healthcare, and where to live near Albuquerque, New Mexico.'
 description: 'A 2026 guide for military families moving to Kirtland AFB, covering where to live, BAH, schools, healthcare, and life in Albuquerque, New Mexico.'
 slug: pcs-to-kirtland-afb-albuquerque-2026-guide
-publishedAt: '2026-12-16T09:00:00.000Z'
+publishedAt: '2026-03-30T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-16'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-macdill-afb-tampa-2026-guide.mdx
+++ b/content/blog/pcs-to-macdill-afb-tampa-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to MacDill AFB: 2026 Tampa, Florida Move Guide'
 metaDescription: 'Planning a PCS to MacDill AFB in 2026? A plain-language guide to housing, BAH, schools, healthcare, and where to live near Tampa, Florida. Start here.'
 description: 'A 2026 guide for military families moving to MacDill Air Force Base, covering where to live, BAH, schools, healthcare, and life in Tampa, Florida.'
 slug: pcs-to-macdill-afb-tampa-2026-guide
-publishedAt: '2026-09-02T09:00:00.000Z'
+publishedAt: '2025-10-07T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2026-12-21'
 component: PCS Help

--- a/content/blog/pcs-to-malmstrom-afb-great-falls-2026-guide.mdx
+++ b/content/blog/pcs-to-malmstrom-afb-great-falls-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Malmstrom AFB: 2026 Great Falls, Montana Guide'
 metaDescription: 'Planning a PCS to Malmstrom AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and life in Great Falls, Montana. Start here.'
 description: 'A 2026 guide for military families moving to Malmstrom Air Force Base, covering where to live, BAH, schools, healthcare, and life in Great Falls, Montana.'
 slug: pcs-to-malmstrom-afb-great-falls-2026-guide
-publishedAt: '2027-02-05T09:00:00.000Z'
+publishedAt: '2026-06-22T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-05'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-maxwell-afb-montgomery-2026-guide.mdx
+++ b/content/blog/pcs-to-maxwell-afb-montgomery-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Maxwell AFB: 2026 Montgomery, Alabama Move Guide'
 metaDescription: 'Planning a PCS to Maxwell AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Montgomery, Alabama. Start here.'
 description: 'A 2026 guide for military families moving to Maxwell AFB, covering where to live, BAH, schools, healthcare, and life in Montgomery, Alabama.'
 slug: pcs-to-maxwell-afb-montgomery-2026-guide
-publishedAt: '2026-12-07T09:00:00.000Z'
+publishedAt: '2026-03-13T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-07'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-mcas-beaufort-2026-guide.mdx
+++ b/content/blog/pcs-to-mcas-beaufort-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to MCAS Beaufort: 2026 South Carolina Move Guide'
 metaDescription: 'Planning a PCS to MCAS Beaufort in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Beaufort, South Carolina.'
 description: 'A 2026 guide for military families moving to MCAS Beaufort, covering where to live, BAH, schools, healthcare, and life in the South Carolina Lowcountry.'
 slug: pcs-to-mcas-beaufort-2026-guide
-publishedAt: '2027-01-21T09:00:00.000Z'
+publishedAt: '2026-05-26T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-21'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-mcas-cherry-point-2026-guide.mdx
+++ b/content/blog/pcs-to-mcas-cherry-point-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to MCAS Cherry Point: 2026 Havelock NC Move Guide'
 metaDescription: 'Planning a PCS to MCAS Cherry Point in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Havelock, NC. Start here.'
 description: 'A 2026 guide for military families moving to MCAS Cherry Point, covering where to live, BAH, schools, healthcare, and life on the North Carolina Crystal Coast.'
 slug: pcs-to-mcas-cherry-point-2026-guide
-publishedAt: '2026-12-18T09:00:00.000Z'
+publishedAt: '2026-04-04T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-18'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-mcb-camp-pendleton-2026-guide.mdx
+++ b/content/blog/pcs-to-mcb-camp-pendleton-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Camp Pendleton: 2026 Oceanside, CA Move Guide'
 metaDescription: 'Planning a PCS to MCB Camp Pendleton in 2026? A plain-language guide to housing, BAH, schools, healthcare, and where to live near Oceanside, California.'
 description: 'A 2026 guide for military families moving to MCB Camp Pendleton, covering where to live, BAH, schools, healthcare, and coastal Southern California life.'
 slug: pcs-to-mcb-camp-pendleton-2026-guide
-publishedAt: '2026-08-14T09:00:00.000Z'
+publishedAt: '2025-09-05T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-mcb-hawaii-kaneohe-bay-2026-guide.mdx
+++ b/content/blog/pcs-to-mcb-hawaii-kaneohe-bay-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to MCB Hawaii at Kaneohe Bay: 2026 Family Guide'
 metaDescription: 'PCS to Marine Corps Base Hawaii in 2026? Plain-language guide to BAH, housing, schools, healthcare, and windward Oahu life for military families. Start here.'
 description: 'A 2026 guide for military families moving to Marine Corps Base Hawaii at Kaneohe Bay, covering where to live, BAH, schools, healthcare, and life on windward Oahu.'
 slug: pcs-to-mcb-hawaii-kaneohe-bay-2026-guide
-publishedAt: '2026-12-01T09:00:00.000Z'
+publishedAt: '2026-03-03T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-01'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-mcb-quantico-2026-guide.mdx
+++ b/content/blog/pcs-to-mcb-quantico-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to MCB Quantico: 2026 Guide for Military Families'
 metaDescription: 'PCS to MCB Quantico in 2026? Get the guide to housing, BAH, schools, healthcare, and where to live near Quantico, Virginia. Connect with a local agent today.'
 description: 'A plain-language guide to moving your family to Marine Corps Base Quantico in Northern Virginia, covering housing, schools, healthcare, and the I-95 commute.'
 slug: pcs-to-mcb-quantico-2026-guide
-publishedAt: '2026-07-29T09:00:00.000Z'
+publishedAt: '2025-08-07T09:00:00.000Z'
 updatedAt: '2026-06-19T00:00:00.000Z'
 reviewBy: '2026-12-19'
 component: PCS Help

--- a/content/blog/pcs-to-mcconnell-afb-wichita-2026-guide.mdx
+++ b/content/blog/pcs-to-mcconnell-afb-wichita-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to McConnell AFB: 2026 Wichita, Kansas Move Guide'
 metaDescription: 'Planning a PCS to McConnell AFB in 2026? Plain-language guide to housing, BAH, schools, healthcare, and where to live near Wichita, Kansas. Start here.'
 description: 'A 2026 guide for military families moving to McConnell AFB, covering where to live, BAH, schools, healthcare, and life in Wichita, Kansas.'
 slug: pcs-to-mcconnell-afb-wichita-2026-guide
-publishedAt: '2026-12-15T09:00:00.000Z'
+publishedAt: '2026-03-28T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-15'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-mcrd-parris-island-2026-guide.mdx
+++ b/content/blog/pcs-to-mcrd-parris-island-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to MCRD Parris Island: 2026 Beaufort Move Guide'
 metaDescription: 'Planning a PCS to MCRD Parris Island in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Beaufort, South Carolina.'
 description: 'A 2026 guide for military families moving to MCRD Parris Island, covering where to live, BAH, schools, healthcare, and life in the South Carolina Lowcountry.'
 slug: pcs-to-mcrd-parris-island-2026-guide
-publishedAt: '2026-08-06T09:00:00.000Z'
+publishedAt: '2025-08-22T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-minot-afb-2026-guide.mdx
+++ b/content/blog/pcs-to-minot-afb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Minot AFB: 2026 North Dakota Family Move Guide'
 metaDescription: 'Planning a PCS to Minot AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Minot, North Dakota. Start here.'
 description: 'A 2026 guide for military families moving to Minot AFB, covering where to live, BAH, schools, healthcare, climate, and life in North Dakota.'
 slug: pcs-to-minot-afb-2026-guide
-publishedAt: '2027-02-02T09:00:00.000Z'
+publishedAt: '2026-06-14T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-02'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-moody-afb-valdosta-2026-guide.mdx
+++ b/content/blog/pcs-to-moody-afb-valdosta-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Moody AFB: 2027 Valdosta, Georgia Move Guide'
 metaDescription: 'Planning a PCS to Moody AFB in 2027? Plain-language guide to housing, BAH, schools, healthcare, and where to live near Valdosta, Georgia. Start planning now.'
 description: 'A 2027 guide for military families moving to Moody Air Force Base, covering where to live, BAH, schools, healthcare, and life near Valdosta, Georgia.'
 slug: pcs-to-moody-afb-valdosta-2026-guide
-publishedAt: '2027-01-19T09:00:00.000Z'
+publishedAt: '2026-05-21T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-19'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-mountain-home-afb-2026-guide.mdx
+++ b/content/blog/pcs-to-mountain-home-afb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Mountain Home AFB: 2027 Idaho Military Move Guide'
 metaDescription: 'Planning a PCS to Mountain Home AFB in 2027? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Boise, Idaho. Start here.'
 description: 'A 2027 guide for military families moving to Mountain Home AFB, covering where to live, BAH, schools, healthcare, and life on the Snake River Plain.'
 slug: pcs-to-mountain-home-afb-2026-guide
-publishedAt: '2027-02-01T09:00:00.000Z'
+publishedAt: '2026-06-12T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-01'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-nas-corpus-christi-2026-guide.mdx
+++ b/content/blog/pcs-to-nas-corpus-christi-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to NAS Corpus Christi: 2026 South Texas Move Guide'
 metaDescription: 'Planning a PCS to NAS Corpus Christi? Plain-language 2026 guide to housing, BAH, schools, healthcare, and where to live on the Texas Gulf Coast. Start here.'
 description: 'A 2026 guide for military families moving to NAS Corpus Christi, covering where to live, BAH, schools, healthcare, and life on the Texas Gulf Coast.'
 slug: pcs-to-nas-corpus-christi-2026-guide
-publishedAt: '2027-01-26T09:00:00.000Z'
+publishedAt: '2026-06-02T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-26'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-nas-lemoore-2026-guide.mdx
+++ b/content/blog/pcs-to-nas-lemoore-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to NAS Lemoore: 2027 Central Valley Move Guide'
 metaDescription: 'Planning a PCS to NAS Lemoore in 2027? Get a plain-language guide to housing, BAH, schools, healthcare, and life in California''s Central Valley. Start here.'
 description: 'A 2027 guide for military families moving to Naval Air Station Lemoore, covering where to live, BAH, schools, healthcare, and life in the San Joaquin Valley.'
 slug: pcs-to-nas-lemoore-2026-guide
-publishedAt: '2027-01-04T09:00:00.000Z'
+publishedAt: '2026-04-26T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-04'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-nas-oceana-jeb-little-creek-virginia-beach-2026-guide.mdx
+++ b/content/blog/pcs-to-nas-oceana-jeb-little-creek-virginia-beach-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to NAS Oceana Virginia Beach: 2026 Family Guide'
 metaDescription: 'Moving to NAS Oceana or JEB Little Creek? Get a plain-language 2026 guide to housing, BAH, schools, healthcare, and where to live near Virginia Beach.'
 description: 'A 2026 guide for military families moving to NAS Oceana or JEB Little Creek-Fort Story, covering where to live, BAH, schools, healthcare, and life in Virginia Beach.'
 slug: pcs-to-nas-oceana-jeb-little-creek-virginia-beach-2026-guide
-publishedAt: '2026-11-30T09:00:00.000Z'
+publishedAt: '2026-03-01T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-05-30'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-nas-pensacola-2026-guide.mdx
+++ b/content/blog/pcs-to-nas-pensacola-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to NAS Pensacola: 2026 Guide for Military Families'
 metaDescription: 'Planning a PCS to NAS Pensacola in 2026? Get a plain-language guide to housing, BAH, schools, and where to live near Pensacola. Connect with a local agent.'
 description: 'A 2026 guide for military families moving to NAS Pensacola, covering where to live, BAH, schools, healthcare, and life on the Gulf Coast.'
 slug: pcs-to-nas-pensacola-2026-guide
-publishedAt: '2026-08-28T09:00:00.000Z'
+publishedAt: '2025-09-30T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-nas-whidbey-island-oak-harbor-2026-guide.mdx
+++ b/content/blog/pcs-to-nas-whidbey-island-oak-harbor-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to NAS Whidbey Island: 2026 Oak Harbor Move Guide'
 metaDescription: 'Planning a PCS to NAS Whidbey Island in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and life in Oak Harbor, Washington. Start here.'
 description: 'A 2026 guide for military families moving to NAS Whidbey Island, covering where to live, BAH, schools, healthcare, and life on Washington''s Whidbey Island.'
 slug: pcs-to-nas-whidbey-island-oak-harbor-2026-guide
-publishedAt: '2027-01-27T09:00:00.000Z'
+publishedAt: '2026-06-05T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-27'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-naval-academy-annapolis-2026-guide.mdx
+++ b/content/blog/pcs-to-naval-academy-annapolis-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Naval Academy Annapolis: 2026 Family Move Guide'
 metaDescription: 'PCS to the Naval Academy or NSA Annapolis in 2026? Plain-language guide to housing, BAH, schools, healthcare, and where to live near Annapolis, Maryland.'
 description: 'A 2026 guide for military families moving to the Naval Academy and NSA Annapolis, covering where to live, BAH, schools, healthcare, and life on the Chesapeake Bay.'
 slug: pcs-to-naval-academy-annapolis-2026-guide
-publishedAt: '2026-12-24T09:00:00.000Z'
+publishedAt: '2026-04-14T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-24'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-naval-base-ventura-county-2026-guide.mdx
+++ b/content/blog/pcs-to-naval-base-ventura-county-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Naval Base Ventura County, CA: 2026 Move Guide'
 metaDescription: 'Planning a PCS to Naval Base Ventura County in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Port Hueneme.'
 description: 'A 2026 guide for military families moving to Naval Base Ventura County, covering where to live, BAH, schools, healthcare, and life on the Southern California coast.'
 slug: pcs-to-naval-base-ventura-county-2026-guide
-publishedAt: '2027-01-05T09:00:00.000Z'
+publishedAt: '2026-04-29T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-05'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-naval-station-great-lakes-2026-guide.mdx
+++ b/content/blog/pcs-to-naval-station-great-lakes-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Naval Station Great Lakes: 2026 Illinois Guide'
 metaDescription: 'Planning a PCS to Naval Station Great Lakes in 2026? A plain-language guide to housing, BAH, schools, healthcare, and where to live near North Chicago, IL.'
 description: 'A 2026 guide for military families moving to Naval Station Great Lakes, covering where to live, BAH, schools, healthcare, and life on the North Shore of Lake Michigan.'
 slug: pcs-to-naval-station-great-lakes-2026-guide
-publishedAt: '2026-11-23T09:00:00.000Z'
+publishedAt: '2026-02-19T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-05-23'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-naval-station-mayport-nas-jacksonville-2026-guide.mdx
+++ b/content/blog/pcs-to-naval-station-mayport-nas-jacksonville-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Naval Station Mayport & NAS Jax: 2026 Guide'
 metaDescription: 'PCS to Naval Station Mayport or NAS Jacksonville in 2026? Plain-language guide to housing, BAH, schools, healthcare, and where to live in northeast Florida.'
 description: 'A 2026 guide for military families moving to Naval Station Mayport or NAS Jacksonville, covering where to live, BAH, schools, healthcare, and life in northeast Florida.'
 slug: pcs-to-naval-station-mayport-nas-jacksonville-2026-guide
-publishedAt: '2026-11-27T09:00:00.000Z'
+publishedAt: '2026-02-26T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-05-27'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-naval-station-newport-2026-guide.mdx
+++ b/content/blog/pcs-to-naval-station-newport-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Naval Station Newport: 2026 Rhode Island Move Guide'
 metaDescription: 'Planning a PCS to Naval Station Newport in 2026? Get a plain-language guide to where to live, BAH, schools, healthcare, and life on the Rhode Island coast.'
 description: 'A 2026 guide for military families moving to Naval Station Newport, covering where to live, BAH, schools, healthcare, and life on the Rhode Island coast.'
 slug: pcs-to-naval-station-newport-2026-guide
-publishedAt: '2027-02-10T09:00:00.000Z'
+publishedAt: '2026-06-29T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-10'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-naval-station-norfolk-2026-guide.mdx
+++ b/content/blog/pcs-to-naval-station-norfolk-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Naval Station Norfolk: Your 2026 Moving Guide'
 metaDescription: 'Planning a PCS to Naval Station Norfolk? See our 2026 guide to housing, BAH, schools, healthcare, and commutes in Hampton Roads. Start your move today.'
 description: 'A plain-language 2026 guide to moving your family to Naval Station Norfolk, from where to live to BAH and schools.'
 slug: pcs-to-naval-station-norfolk-2026-guide
-publishedAt: '2026-07-30T09:00:00.000Z'
+publishedAt: '2025-08-09T09:00:00.000Z'
 updatedAt: '2026-06-19T00:00:00.000Z'
 reviewBy: '2026-12-19'
 component: PCS Help

--- a/content/blog/pcs-to-naval-submarine-base-kings-bay-2026-guide.mdx
+++ b/content/blog/pcs-to-naval-submarine-base-kings-bay-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Naval Submarine Base Kings Bay: 2026 Move Guide'
 metaDescription: 'Planning a PCS to Naval Submarine Base Kings Bay in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live in coastal Georgia.'
 description: 'A 2026 guide for military families moving to Naval Submarine Base Kings Bay, covering where to live, BAH, schools, healthcare, and life on the Georgia coast.'
 slug: pcs-to-naval-submarine-base-kings-bay-2026-guide
-publishedAt: '2027-01-20T09:00:00.000Z'
+publishedAt: '2026-05-23T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-20'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-nellis-afb-las-vegas-2026-guide.mdx
+++ b/content/blog/pcs-to-nellis-afb-las-vegas-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Nellis AFB: 2026 Las Vegas, Nevada Move Guide'
 metaDescription: 'Planning a PCS to Nellis AFB in 2026? A plain-language guide to housing, BAH, schools, healthcare, and where to live near Las Vegas, Nevada. Start here.'
 description: 'A 2026 guide for military families moving to Nellis Air Force Base, covering where to live, BAH, schools, healthcare, and life in the Las Vegas area.'
 slug: pcs-to-nellis-afb-las-vegas-2026-guide
-publishedAt: '2026-09-03T09:00:00.000Z'
+publishedAt: '2025-10-10T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2026-12-21'
 component: PCS Help

--- a/content/blog/pcs-to-patrick-sfb-cocoa-beach-2026-guide.mdx
+++ b/content/blog/pcs-to-patrick-sfb-cocoa-beach-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Patrick Space Force Base: 2026 Cocoa Beach Guide'
 metaDescription: 'Planning a PCS to Patrick Space Force Base in 2026? Plain-language guide to housing, BAH, schools, healthcare, and life on Florida Space Coast. Start here.'
 description: 'A 2026 guide for military families moving to Patrick Space Force Base, covering where to live, BAH, schools, healthcare, and life on Florida Space Coast near Cocoa Beach.'
 slug: pcs-to-patrick-sfb-cocoa-beach-2026-guide
-publishedAt: '2027-01-15T09:00:00.000Z'
+publishedAt: '2026-05-18T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-15'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-peterson-schriever-sfb-colorado-springs-2026-guide.mdx
+++ b/content/blog/pcs-to-peterson-schriever-sfb-colorado-springs-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Peterson Space Force Base: 2026 Colorado Guide'
 metaDescription: 'PCSing to Peterson or Schriever Space Force Base in 2026? Plain-language guide to housing, BAH, schools, and Space Force life east of Colorado Springs.'
 description: 'A 2026 PCS guide for Peterson and Schriever Space Force Base, covering where to live on the east side of Colorado Springs, BAH, schools, healthcare, and the Space Force mission.'
 slug: pcs-to-peterson-schriever-sfb-colorado-springs-2026-guide
-publishedAt: '2026-12-29T09:00:00.000Z'
+publishedAt: '2026-04-19T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-29'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-portsmouth-naval-shipyard-2026-guide.mdx
+++ b/content/blog/pcs-to-portsmouth-naval-shipyard-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Portsmouth Naval Shipyard: 2026 Seacoast Guide'
 metaDescription: 'Planning a PCS to Portsmouth Naval Shipyard? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live on the Seacoast. Start here.'
 description: 'A 2026 guide for military families moving to Portsmouth Naval Shipyard, covering where to live in Maine and New Hampshire, BAH, schools, healthcare, and Seacoast life.'
 slug: pcs-to-portsmouth-naval-shipyard-2026-guide
-publishedAt: '2027-02-12T09:00:00.000Z'
+publishedAt: '2026-07-04T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-12'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-presidio-of-monterey-dli-2026-guide.mdx
+++ b/content/blog/pcs-to-presidio-of-monterey-dli-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to the Presidio of Monterey: 2027 DLI Move Guide'
 metaDescription: 'Planning a PCS to the Presidio of Monterey and DLIFLC in 2027? Get a plain-language guide to housing, BAH, schools, healthcare, and life on the Monterey coast.'
 description: 'A 2027 guide for military families moving to the Presidio of Monterey and the Defense Language Institute, covering where to live, BAH, schools, healthcare, and life on the California coast.'
 slug: pcs-to-presidio-of-monterey-dli-2026-guide
-publishedAt: '2027-01-11T09:00:00.000Z'
+publishedAt: '2026-05-09T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-11'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-robins-afb-warner-robins-2026-guide.mdx
+++ b/content/blog/pcs-to-robins-afb-warner-robins-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Robins AFB: Your 2026 Warner Robins Move Guide'
 metaDescription: 'Planning a PCS to Robins AFB in 2026? A plain-language guide to housing, BAH, schools, healthcare, and where to live near Warner Robins, Georgia. Start here.'
 description: 'A 2026 guide for military families moving to Robins AFB, covering where to live, BAH, schools, healthcare, and life in Middle Georgia.'
 slug: pcs-to-robins-afb-warner-robins-2026-guide
-publishedAt: '2026-12-08T09:00:00.000Z'
+publishedAt: '2026-03-16T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-08'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-san-diego-naval-bases-2026-guide.mdx
+++ b/content/blog/pcs-to-san-diego-naval-bases-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to San Diego Military Bases: 2026 Family Guide'
 metaDescription: 'Planning a PCS to San Diego in 2026? A plain-language guide to Naval Base San Diego, Coronado, Miramar, and MCRD: BAH, schools, housing, and where to live.'
 description: 'A 2026 guide for military families moving to the San Diego military bases, covering where to live, BAH, schools, healthcare, and life in Southern California.'
 slug: pcs-to-san-diego-naval-bases-2026-guide
-publishedAt: '2026-11-18T09:00:00.000Z'
+publishedAt: '2026-02-12T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-05-18'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-schofield-barracks-2026-guide.mdx
+++ b/content/blog/pcs-to-schofield-barracks-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Schofield Barracks, Hawaii: 2026 Move Guide'
 metaDescription: 'Planning a PCS to Schofield Barracks in 2026? A plain-language guide to housing, BAH, schools, healthcare, and where to live on Oahu, Hawaii. Start here.'
 description: 'A 2026 guide for military families moving to Schofield Barracks, covering where to live, BAH, schools, healthcare, and life on Oahu, Hawaii.'
 slug: pcs-to-schofield-barracks-2026-guide
-publishedAt: '2026-08-31T09:00:00.000Z'
+publishedAt: '2025-10-02T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2026-12-21'
 component: PCS Help

--- a/content/blog/pcs-to-scott-afb-2026-guide.mdx
+++ b/content/blog/pcs-to-scott-afb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Scott AFB: 2026 Metro East Illinois Move Guide'
 metaDescription: 'Planning a PCS to Scott AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Belleville and O''Fallon, Illinois.'
 description: 'A 2026 guide for military families moving to Scott AFB, covering where to live, BAH, schools, healthcare, and life in the Metro East area near St. Louis.'
 slug: pcs-to-scott-afb-2026-guide
-publishedAt: '2026-12-10T09:00:00.000Z'
+publishedAt: '2026-03-21T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-10'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-selfridge-angb-2026-guide.mdx
+++ b/content/blog/pcs-to-selfridge-angb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Selfridge ANGB: 2027 Metro Detroit Move Guide'
 metaDescription: 'Planning a PCS to Selfridge ANGB in 2027? Plain-language guide to housing, BAH, schools, healthcare, and where to live near Harrison Township, Michigan.'
 description: 'A 2027 guide for military families moving to Selfridge Air National Guard Base, covering where to live, BAH, schools, healthcare, and life in metro Detroit.'
 slug: pcs-to-selfridge-angb-2026-guide
-publishedAt: '2027-02-09T09:00:00.000Z'
+publishedAt: '2026-06-27T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-08-09'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-seymour-johnson-afb-goldsboro-2026-guide.mdx
+++ b/content/blog/pcs-to-seymour-johnson-afb-goldsboro-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Seymour Johnson AFB: 2026 Goldsboro Move Guide'
 metaDescription: 'Planning a PCS to Seymour Johnson AFB? Get a plain-language 2026 guide to housing, BAH, schools, healthcare, and where to live near Goldsboro, NC. Start here.'
 description: 'A 2026 guide for military families moving to Seymour Johnson AFB, covering where to live, BAH, schools, healthcare, and life in Goldsboro, North Carolina.'
 slug: pcs-to-seymour-johnson-afb-goldsboro-2026-guide
-publishedAt: '2026-12-21T09:00:00.000Z'
+publishedAt: '2026-04-07T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-21'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-shaw-afb-sumter-2026-guide.mdx
+++ b/content/blog/pcs-to-shaw-afb-sumter-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Shaw AFB: 2026 Sumter, South Carolina Guide'
 metaDescription: 'Planning a PCS to Shaw AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Sumter, South Carolina. Start here.'
 description: 'A 2026 guide for military families moving to Shaw AFB, covering where to live, BAH, schools, healthcare, and life in the South Carolina Midlands.'
 slug: pcs-to-shaw-afb-sumter-2026-guide
-publishedAt: '2026-12-11T09:00:00.000Z'
+publishedAt: '2026-03-23T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-11'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-travis-afb-fairfield-2026-guide.mdx
+++ b/content/blog/pcs-to-travis-afb-fairfield-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Travis AFB: Your 2026 Solano County Move Guide'
 metaDescription: 'Planning a PCS to Travis AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Fairfield, California. Start here.'
 description: 'A 2026 guide for military families moving to Travis AFB, covering where to live, BAH, schools, healthcare, and life in Solano County, California.'
 slug: pcs-to-travis-afb-fairfield-2026-guide
-publishedAt: '2026-08-10T09:00:00.000Z'
+publishedAt: '2025-08-27T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pcs-to-tyndall-afb-panama-city-2026-guide.mdx
+++ b/content/blog/pcs-to-tyndall-afb-panama-city-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Tyndall AFB: 2026 Panama City, FL Move Guide'
 metaDescription: 'Planning a PCS to Tyndall AFB in 2026? Plain-language guide to housing, BAH, schools, healthcare, and where to live near Panama City, Florida. Start here.'
 description: 'A 2026 guide for military families moving to Tyndall Air Force Base, covering where to live, BAH, schools, healthcare, and life on the Florida Gulf coast.'
 slug: pcs-to-tyndall-afb-panama-city-2026-guide
-publishedAt: '2027-01-14T09:00:00.000Z'
+publishedAt: '2026-05-16T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-14'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-vandenberg-sfb-2026-guide.mdx
+++ b/content/blog/pcs-to-vandenberg-sfb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Vandenberg SFB: 2027 Central Coast Move Guide'
 metaDescription: 'Planning a PCS to Vandenberg Space Force Base in 2027? Plain-language guide to housing, BAH, schools, healthcare, and where to live near Lompoc. Start here.'
 description: 'A 2027 guide for military families moving to Vandenberg Space Force Base, covering where to live, BAH, schools, healthcare, and life on California''s Central Coast.'
 slug: pcs-to-vandenberg-sfb-2026-guide
-publishedAt: '2027-01-07T09:00:00.000Z'
+publishedAt: '2026-05-04T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-07-07'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-west-point-2026-guide.mdx
+++ b/content/blog/pcs-to-west-point-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to West Point, NY: 2026 Military Family Move Guide'
 metaDescription: 'Planning a PCS to West Point in 2026? Plain-language guide for military families: where to live near the Hudson Valley, BAH rates, schools, and healthcare.'
 description: 'A 2026 guide for military families moving to West Point, covering where to live, BAH, schools, healthcare, and life in New York''s Hudson Valley.'
 slug: pcs-to-west-point-2026-guide
-publishedAt: '2026-12-09T09:00:00.000Z'
+publishedAt: '2026-03-18T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-09'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-whiteman-afb-2026-guide.mdx
+++ b/content/blog/pcs-to-whiteman-afb-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Whiteman AFB: 2026 Guide for Military Families'
 metaDescription: 'Planning a PCS to Whiteman AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Knob Noster. Start here.'
 description: 'A 2026 guide for military families moving to Whiteman Air Force Base, covering where to live, BAH, schools, healthcare, and life near Knob Noster, Missouri.'
 slug: pcs-to-whiteman-afb-2026-guide
-publishedAt: '2026-12-22T09:00:00.000Z'
+publishedAt: '2026-04-09T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-06-22'
 component: U.S. Military Bases

--- a/content/blog/pcs-to-wright-patterson-afb-dayton-2026-guide.mdx
+++ b/content/blog/pcs-to-wright-patterson-afb-dayton-2026-guide.mdx
@@ -5,7 +5,7 @@ metaTitle: 'PCS to Wright-Patterson AFB: 2026 Dayton Move Guide'
 metaDescription: 'Planning a PCS to Wright-Patterson AFB in 2026? Get a plain-language guide to housing, BAH, schools, healthcare, and where to live near Dayton-Fairborn, Ohio.'
 description: 'A 2026 guide for military families moving to Wright-Patterson AFB, covering where to live, BAH, schools, healthcare, and life around Dayton, Ohio.'
 slug: pcs-to-wright-patterson-afb-dayton-2026-guide
-publishedAt: '2026-08-03T09:00:00.000Z'
+publishedAt: '2025-08-14T09:00:00.000Z'
 updatedAt: '2026-06-20T00:00:00.000Z'
 reviewBy: '2026-12-20'
 component: PCS Help

--- a/content/blog/pennsylvania-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/pennsylvania-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Pennsylvania Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Pennsylvania veterans can qualify for a full property tax exemption, plus how the state taxes military pay. Talk with a VeteranPCS agent in Pennsylvania.'
 description: "A plain-language guide to Pennsylvania's need-based real estate tax exemption for 100 percent disabled wartime veterans and surviving spouses, plus how the state treats military pay."
 slug: pennsylvania-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-28T09:00:00.000Z'
+publishedAt: '2025-11-18T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/rhode-island-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/rhode-island-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Rhode Island Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Rhode Island cities and towns exempt part of a disabled veteran's property tax, and how the state exempts military pensions. Talk with a VeteranPCS agent."
 description: "A plain-language guide to Rhode Island's local veteran property tax exemptions, the larger amounts for disabled veterans, and how the state exempts military pay."
 slug: rhode-island-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-16T09:00:00.000Z'
+publishedAt: '2026-02-07T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/south-carolina-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/south-carolina-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'South Carolina Veteran Property Tax Exemptions 2026'
 metaDescription: "How South Carolina veterans can lower property taxes, plus the state's full military retirement tax break. Talk with a VeteranPCS agent in Columbia today."
 description: "A plain-language look at South Carolina's total property tax exemption for disabled veterans and surviving spouses, plus the state's full military retirement income tax break."
 slug: south-carolina-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-23T09:00:00.000Z'
+publishedAt: '2025-11-11T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/south-dakota-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/south-dakota-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'South Dakota Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How South Dakota exempts up to $200,000 of a disabled veteran's home value, with no state income tax on military pay. Connect with a VeteranPCS agent today."
 description: "A plain-language guide to South Dakota's disabled veteran property tax exemption, the paraplegic exemption, and why the state taxes no military pay."
 slug: south-dakota-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-29T09:00:00.000Z'
+publishedAt: '2026-01-11T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/tennessee-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/tennessee-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Tennessee Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Tennessee veterans can lower property taxes through state tax relief, plus what no state income tax means for your pay. Talk with a VeteranPCS agent today.'
 description: "A plain-language look at Tennessee's property tax relief for disabled veterans and surviving spouses, plus what having no state income tax means for military pay."
 slug: tennessee-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-24T09:00:00.000Z'
+publishedAt: '2025-11-13T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/texas-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/texas-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Texas Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Texas veterans and military families can lower property taxes, plus homestead and no-income-tax rules. Connect with a VeteranPCS agent in Texas today.'
 description: 'A plain-language look at the property tax breaks Texas offers veterans and military families, from partial exemptions by disability rating to the full homestead exemption for 100% disabled veterans.'
 slug: texas-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-08T09:00:00.000Z'
+publishedAt: '2025-10-15T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/utah-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/utah-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Utah Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Utah's disabled veteran exemption lowers your home's taxable value by rating, plus how it taxes military pay. Talk with a VeteranPCS agent in Utah."
 description: "A plain-language guide to Utah's rating-scaled veteran property tax exemption, the active-duty exemption, and how the state credits military retirement pay."
 slug: utah-veteran-property-tax-exemptions-2026
-publishedAt: '2026-10-15T09:00:00.000Z'
+publishedAt: '2025-12-17T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/vermont-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/vermont-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Vermont Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Vermont exempts $10,000 to $40,000 of a disabled veteran's home value and now excludes military retirement pay. Talk to a VeteranPCS agent in Vermont."
 description: "A plain-language guide to Vermont's town-set veteran property tax exemption, who qualifies, and the new Act 71 exclusion for military retirement pay."
 slug: vermont-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-09T09:00:00.000Z'
+publishedAt: '2026-01-28T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/virginia-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/virginia-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Virginia Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Virginia veterans and military families can cut property taxes, plus homestead and military pay tax rules. Talk with a VeteranPCS agent in Virginia today.'
 description: 'A plain-language look at Virginia property tax relief for disabled veterans and surviving spouses, plus how military pay and retirement pay are treated by the state.'
 slug: virginia-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-09T09:00:00.000Z'
+publishedAt: '2025-10-17T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/washington-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/washington-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Washington Military & Veteran Property Tax Exemptions 2026'
 metaDescription: 'How Washington veterans and military families can lower property taxes, plus the state no-income-tax rules. Talk with a VeteranPCS agent in Washington today.'
 description: 'A plain-language look at Washington property tax relief for disabled veterans, how the income-based exemption works by county, and how the state treats military pay.'
 slug: washington-veteran-property-tax-exemptions-2026
-publishedAt: '2026-09-16T09:00:00.000Z'
+publishedAt: '2025-10-29T09:00:00.000Z'
 updatedAt: '2026-06-21T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/west-virginia-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/west-virginia-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'West Virginia Veteran Property Tax Exemptions 2026'
 metaDescription: "How West Virginia's new refundable credit can repay a disabled veteran's property tax, plus how the state treats military pay. Talk with a VeteranPCS agent."
 description: "A plain-language guide to West Virginia's refundable disabled-veteran property tax credit, the homestead exemption, and how the state treats military pay."
 slug: west-virginia-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-17T09:00:00.000Z'
+publishedAt: '2026-02-09T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/what-military-bases-are-in-massachusetts.mdx
+++ b/content/blog/what-military-bases-are-in-massachusetts.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Massachusetts?
 metaTitle: 'Active Military Bases in Massachusetts: A Veteran PCS Guide'
 metaDescription: 'A guide to active military bases in Massachusetts, from Hanscom Air Force Base to Natick Soldier Systems Center, plus PCS tips and veteran-friendly agents.'
 slug: what-military-bases-are-in-massachusetts
-publishedAt: '2026-07-09T09:00:00.000Z'
+publishedAt: '2025-07-13T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: massachusetts
 categories:

--- a/content/blog/what-military-bases-are-in-michigan.mdx
+++ b/content/blog/what-military-bases-are-in-michigan.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Michigan?
 metaTitle: 'Active Military Bases in Michigan: A Veteran PCS Guide'
 metaDescription: 'A guide to active military bases in Michigan, from Selfridge Air National Guard Base to the Detroit Arsenal, plus PCS tips and veteran-friendly agents.'
 slug: what-military-bases-are-in-michigan
-publishedAt: '2026-07-10T09:00:00.000Z'
+publishedAt: '2025-07-16T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: michigan
 categories:

--- a/content/blog/what-military-bases-are-in-mississippi.mdx
+++ b/content/blog/what-military-bases-are-in-mississippi.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Mississippi?
 metaTitle: 'Active Military Bases in Mississippi: A Veteran PCS Guide'
 metaDescription: 'A guide to the active military bases in Mississippi, led by Keesler Air Force Base, plus PCS housing tips, VA-loan guidance, and veteran-friendly agents.'
 slug: what-military-bases-are-in-mississippi
-publishedAt: '2026-07-08T09:00:00.000Z'
+publishedAt: '2025-07-11T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: mississippi
 categories:

--- a/content/blog/what-military-bases-are-in-nevada.mdx
+++ b/content/blog/what-military-bases-are-in-nevada.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Nevada?
 metaTitle: 'Active Military Bases in Nevada: A Veteran PCS Guide'
 metaDescription: 'A guide to active military bases in Nevada, from Nellis Air Force Base to NAS Fallon, plus PCS housing tips, VA-loan guidance, and veteran-friendly agents.'
 slug: what-military-bases-are-in-nevada
-publishedAt: '2026-07-06T09:00:00.000Z'
+publishedAt: '2025-07-06T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: nevada
 categories:

--- a/content/blog/what-military-bases-are-in-new-hampshire.mdx
+++ b/content/blog/what-military-bases-are-in-new-hampshire.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in New Hampshire?
 metaTitle: 'Active Military Bases in New Hampshire: A Veteran PCS Guide'
 metaDescription: 'A guide to the active military bases in New Hampshire, from Pease Air National Guard Base to New Boston Space Force Station, plus PCS tips and veteran agents.'
 slug: what-military-bases-are-in-new-hampshire
-publishedAt: '2026-07-17T09:00:00.000Z'
+publishedAt: '2025-07-28T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: new-hampshire
 categories:

--- a/content/blog/what-military-bases-are-in-oregon.mdx
+++ b/content/blog/what-military-bases-are-in-oregon.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Oregon?
 metaTitle: 'Active Military Bases in Oregon: A Veteran PCS Guide'
 metaDescription: 'A guide to active military bases in Oregon, from Portland Air National Guard Base to Kingsley Field, plus PCS housing tips and veteran-friendly agents.'
 slug: what-military-bases-are-in-oregon
-publishedAt: '2026-07-13T09:00:00.000Z'
+publishedAt: '2025-07-18T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: oregon
 categories:

--- a/content/blog/what-military-bases-are-in-pennsylvania.mdx
+++ b/content/blog/what-military-bases-are-in-pennsylvania.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Pennsylvania?
 metaTitle: 'Active Military Bases in Pennsylvania: A Veteran PCS Guide'
 metaDescription: 'A guide to active military bases in Pennsylvania, from Carlisle Barracks to Tobyhanna Army Depot, with PCS housing tips, VA-loan help, and veteran agents.'
 slug: what-military-bases-are-in-pennsylvania
-publishedAt: '2026-07-07T09:00:00.000Z'
+publishedAt: '2025-07-08T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: pennsylvania
 categories:

--- a/content/blog/what-military-bases-are-in-rhode-island.mdx
+++ b/content/blog/what-military-bases-are-in-rhode-island.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Rhode Island?
 metaTitle: 'Active Military Bases in Rhode Island: A Veteran PCS Guide'
 metaDescription: 'A guide to the active military bases in Rhode Island, led by Naval Station Newport, plus PCS housing tips, VA-loan guidance, and veteran-friendly agents.'
 slug: what-military-bases-are-in-rhode-island
-publishedAt: '2026-07-14T09:00:00.000Z'
+publishedAt: '2025-07-21T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: rhode-island
 categories:

--- a/content/blog/what-military-bases-are-in-south-dakota.mdx
+++ b/content/blog/what-military-bases-are-in-south-dakota.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in South Dakota?
 metaTitle: 'Active Military Bases in South Dakota: A Veteran PCS Guide'
 metaDescription: 'A guide to the active military bases in South Dakota, led by Ellsworth Air Force Base, plus PCS housing tips, VA-loan guidance, and veteran-friendly agents.'
 slug: what-military-bases-are-in-south-dakota
-publishedAt: '2026-07-15T09:00:00.000Z'
+publishedAt: '2025-07-23T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: south-dakota
 categories:

--- a/content/blog/what-military-bases-are-in-utah.mdx
+++ b/content/blog/what-military-bases-are-in-utah.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Utah?
 metaTitle: 'Active Military Bases in Utah: A Veteran PCS Guide'
 metaDescription: 'A guide to active military bases in Utah, from Hill Air Force Base to Dugway Proving Ground, plus PCS housing tips, VA-loan help, and veteran-friendly agents.'
 slug: what-military-bases-are-in-utah
-publishedAt: '2026-07-16T09:00:00.000Z'
+publishedAt: '2025-07-26T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: utah
 categories:

--- a/content/blog/what-military-bases-are-in-vermont.mdx
+++ b/content/blog/what-military-bases-are-in-vermont.mdx
@@ -4,7 +4,7 @@ shortTitle: What Military Bases are in Vermont?
 metaTitle: 'Active Military Bases in Vermont: A Veteran PCS Guide'
 metaDescription: 'A guide to the active military bases in Vermont, led by Burlington Air National Guard Base, plus PCS housing tips, VA-loan guidance, and veteran agents.'
 slug: what-military-bases-are-in-vermont
-publishedAt: '2026-07-20T09:00:00.000Z'
+publishedAt: '2025-07-31T09:00:00.000Z'
 component: U.S. Military Bases
 stateSlug: vermont
 categories:

--- a/content/blog/wisconsin-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/wisconsin-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Wisconsin Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Wisconsin's refundable credit can repay 100% of a disabled veteran's property taxes, plus how it treats military pay. Connect with a VeteranPCS agent today."
 description: "A plain-language guide to Wisconsin's refundable veterans property tax credit, who qualifies at a 100 percent rating, and how the state treats military pay."
 slug: wisconsin-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-03T09:00:00.000Z'
+publishedAt: '2026-01-18T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance

--- a/content/blog/wyoming-veteran-property-tax-exemptions-2026.mdx
+++ b/content/blog/wyoming-veteran-property-tax-exemptions-2026.mdx
@@ -5,7 +5,7 @@ metaTitle: 'Wyoming Military & Veteran Property Tax Exemptions 2026'
 metaDescription: "How Wyoming exempts $6,000 of a veteran's assessed home value, with no state income tax on military pay. Connect with a VeteranPCS agent who serves Wyoming."
 description: "A plain-language guide to Wyoming's veteran property tax exemption, who qualifies, the vehicle-fee option, and why the state taxes no military pay."
 slug: wyoming-veteran-property-tax-exemptions-2026
-publishedAt: '2026-11-10T09:00:00.000Z'
+publishedAt: '2026-01-30T09:00:00.000Z'
 updatedAt: '2026-06-22T00:00:00.000Z'
 reviewBy: '2027-01-15'
 component: Financial Guidance


### PR DESCRIPTION
Follow-up to the 2026-07-05 backdating policy (per Harper): maps every remaining forward-dated post (the what-military-bases-are-in-*, pcs-to-*-2026-guide, and *-veteran-property-tax-exemptions-2026 drip, previously queued Jul 2026 - Feb 2027) evenly onto Jul 6 2025 - Jul 4 2026, one post per day, queue order preserved. Dates only - no content changes. All 149 go live on merge; indexing submitted post-merge in the same run.