### PR TITLE
test: de-flake salesforceLeadOwnerService no-Lead case

### DIFF
--- a/services/__tests__/salesforceLeadOwnerService.test.ts
+++ b/services/__tests__/salesforceLeadOwnerService.test.ts
@@ -163,9 +163,12 @@ describe('salesforceLeadOwnerService', () => {
   });
 
   it('does not patch when lookup finds no Lead', async () => {
-    vi.mocked(salesForceAPIWithRefresh)
-      .mockResolvedValueOnce(queryResponse([]) as any)
-      .mockResolvedValueOnce(queryResponse([]) as any);
+    // Every lookup returns empty. Use a persistent default rather than a fixed pair of
+    // `...Once` values: with LEAD_LOOKUP_TIMEOUT_MS=0 the poll loop in findCreatedLead runs
+    // one or two passes depending on sub-millisecond timing, so pinning an exact call count
+    // made this test flaky (a third, unstubbed call returned undefined → "status unknown").
+    // A default keeps the assertion deterministic no matter how many empty polls occur.
+    vi.mocked(salesForceAPIWithRefresh).mockResolvedValue(queryResponse([]) as any);
 
     await expect(routeSalesforceLeadOwner(routeParams())).rejects.toThrow(
       'Unable to locate unique Salesforce Lead',


### PR DESCRIPTION
## What

Fixes a non-deterministic failure in `services/__tests__/salesforceLeadOwnerService.test.ts` → **"does not patch when lookup finds no Lead"**. This was the only thing keeping `npm test` from passing reliably on `main` (the final gate of the AI-codegen remediation goal).

## Root cause

`findCreatedLead` polls for the just-created Lead in a `while (Date.now() <= deadline)` loop. In test mode `LEAD_LOOKUP_TIMEOUT_MS = 0`, so `deadline = Date.now()` and the loop runs a **second** pass whenever one iteration (two awaited mock resolutions + `delay(0)`) completes inside the same millisecond it started. The test queued exactly two `mockResolvedValueOnce([])` values, so that extra third query returned `undefined` and `runSalesforceQuery` threw `"query failed with status unknown"` instead of the expected `"Unable to locate unique Salesforce Lead"`.

Reproduced in **4/25 isolated runs (~16%)** before the fix — timing-dependent, which is why it passed some full-suite runs and failed others on identical code.

## Fix

Model "no Lead is ever found" with a persistent `mockResolvedValue([])` instead of a fixed pair of `...Once` empties, so the assertion holds no matter how many empty polls the loop makes. This mirrors the sibling `"throws when owner confirmation does not match"` test, which already uses a persistent default for its own polling loop. Production code is unchanged.

## Verification

- Fixed file: **40/40 isolated runs** pass, 0 `status unknown`.
- Full suite: **373/373 across 4 consecutive runs**, 0 `status unknown`.
- `npm run lint`, `npm run type-check`, `npm run build` green (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)