### PR TITLE
Fix contact form route scroll behavior

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -155,7 +155,7 @@ export default function RootLayout({
     children: React.ReactNode;
 }>) {
     return (
-        <html lang="en" className={`scroll-pt-20 ${inter.variable} ${poppins.variable} ${roboto.variable} ${lora.variable}`}>
+        <html lang="en" data-scroll-behavior="smooth" className={`scroll-pt-20 ${inter.variable} ${poppins.variable} ${roboto.variable} ${lora.variable}`}>
             <head>
                 <GoogleTagManager gtmId={GTM_ID} />
                 <Script id={`json-ld-real-estate-agent`} type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />

--- a/components/StatePage/StatePageCityAgents/StatePageCityAgents.tsx
+++ b/components/StatePage/StatePageCityAgents/StatePageCityAgents.tsx
@@ -8,6 +8,7 @@ import orderMilitaryServiceInfo from "@/utils/getMilitaryServiceInfo";
 import { sanitizeCityName } from "@/utils/sanitizeCityName";
 import { Agent } from "@/services/stateService";
 import { trackCtaClicked } from "@/lib/analytics/client";
+import { buildContactCtaHref } from "@/lib/contactAgentUrl";
 
 type Props = {
   city: string;
@@ -88,6 +89,13 @@ const AgentBio = ({ bio }: { bio: string }) => {
 
 
 const StatePageCityAgents = ({ city, agent_data, state }: Props) => {
+  const agentContactHref = (agent: Agent) => buildContactCtaHref({
+    firstName: agent.FirstName,
+    salesforceId: agent.AccountId_15__c,
+    stateSlug: state,
+    form: 'agent',
+  });
+
   const trackAgentCta = (agentId: string, position: string) => {
     trackCtaClicked({
       cta_id: 'state_agent_card_contact',
@@ -112,55 +120,59 @@ const StatePageCityAgents = ({ city, agent_data, state }: Props) => {
             <div className="bg-[#7E1618] py-[3px] w-24 mx-auto my-5"></div>
           </div>
           <div className="grid lg:grid-cols-2 grid-cols-1 items-start justify-between gap-10 mt-10">
-            {agent_data.map((agent) => (
-              <div
-                key={agent.AccountId_15__c}
-                className="rounded-[30px] border bg-white shadow-[0px_5px_14px_0px_rgba(8,_15,_52,_0.04)] flex sm:p-8 p-4"
-              >
-                <div className="justify-center items-center flex flex-col">
-                  <div className="rounded-full bg-[#E1EDFB] md:w-[200px] md:h-[200px] w-[100px] h-[100px] flex justify-center items-center overflow-hidden mb-4 sm:mb-0">
-                    <Link
-                      href={`/contact-agent?form=agent&fn=${agent.FirstName}&id=${agent.AccountId_15__c}&state=${state}`}
-                      onClick={() => trackAgentCta(agent.AccountId_15__c, 'card_image')}
-                    >
-                      <Image
-                        src={agent?.PhotoUrl || ""}
-                        alt={`${agent?.Name}'s Profile Picture`}
-                        width={1000}
-                        height={1000}
-                        sizes="(min-width: 768px) 200px, 100px"
-                        className="object-cover"
-                      />
-                    </Link>
-                  </div>
-                  <Link
-                    href={`/contact-agent?form=agent&fn=${agent.FirstName}&id=${agent.AccountId_15__c}&state=${state}`}
-                    onClick={() => trackAgentCta(agent.AccountId_15__c, 'card_button')}
-                  >
-                    <Button buttonText="Contact Now" />
-                  </Link>
-                </div>
-                <div className="md:pl-10 pl-4">
-                  <div>
-                    <Link
-                      href={`/contact-agent?form=agent&fn=${agent.FirstName}&id=${agent.AccountId_15__c}&state=${state}`}
-                      onClick={() => trackAgentCta(agent.AccountId_15__c, 'card_heading')}
-                    >
-                      <h3 className="text-[#292F6C] tahoma md:text-[34px] text-[20px] font-bold">
-                        {agent?.Name}
-                      </h3>
-                    </Link>
-                    <div className="text-[#6C757D] tahoma md:text-[18px] text-sm font-normal sm:mt-4 mt-0">
-                      <p className="font-bold">
-                        {orderMilitaryServiceInfo(agent?.Military_Status__pc || "", agent?.Military_Service__pc || "")}
-                      </p>
-                      <p>{agent?.Brokerage_Name__pc}</p>
+            {agent_data.map((agent) => {
+              const contactHref = agentContactHref(agent);
+
+              return (
+                <div
+                  key={agent.AccountId_15__c}
+                  className="rounded-[30px] border bg-white shadow-[0px_5px_14px_0px_rgba(8,_15,_52,_0.04)] flex sm:p-8 p-4"
+                >
+                  <div className="justify-center items-center flex flex-col">
+                    <div className="rounded-full bg-[#E1EDFB] md:w-[200px] md:h-[200px] w-[100px] h-[100px] flex justify-center items-center overflow-hidden mb-4 sm:mb-0">
+                      <Link
+                        href={contactHref}
+                        onClick={() => trackAgentCta(agent.AccountId_15__c, 'card_image')}
+                      >
+                        <Image
+                          src={agent?.PhotoUrl || ""}
+                          alt={`${agent?.Name}'s Profile Picture`}
+                          width={1000}
+                          height={1000}
+                          sizes="(min-width: 768px) 200px, 100px"
+                          className="object-cover"
+                        />
+                      </Link>
                     </div>
-                    <AgentBio bio={agent?.Agent_Bio__pc || ""} />
+                    <Link
+                      href={contactHref}
+                      onClick={() => trackAgentCta(agent.AccountId_15__c, 'card_button')}
+                    >
+                      <Button buttonText="Contact Now" />
+                    </Link>
+                  </div>
+                  <div className="md:pl-10 pl-4">
+                    <div>
+                      <Link
+                        href={contactHref}
+                        onClick={() => trackAgentCta(agent.AccountId_15__c, 'card_heading')}
+                      >
+                        <h3 className="text-[#292F6C] tahoma md:text-[34px] text-[20px] font-bold">
+                          {agent?.Name}
+                        </h3>
+                      </Link>
+                      <div className="text-[#6C757D] tahoma md:text-[18px] text-sm font-normal sm:mt-4 mt-0">
+                        <p className="font-bold">
+                          {orderMilitaryServiceInfo(agent?.Military_Status__pc || "", agent?.Military_Service__pc || "")}
+                        </p>
+                        <p>{agent?.Brokerage_Name__pc}</p>
+                      </div>
+                      <AgentBio bio={agent?.Agent_Bio__pc || ""} />
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </div>

--- a/components/StatePage/StatePageVaLoan/StatePageVaLoan.tsx
+++ b/components/StatePage/StatePageVaLoan/StatePageVaLoan.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { LendersData, Lenders } from "@/services/stateService";
 import orderMilitaryServiceInfo from "@/utils/getMilitaryServiceInfo";
 import { trackCtaClicked } from "@/lib/analytics/client";
+import { buildContactCtaHref } from "@/lib/contactAgentUrl";
 
 const LenderBio = ({ bio }: { bio: string }) => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -56,6 +57,13 @@ const LenderBio = ({ bio }: { bio: string }) => {
 };
 
 const StatePageVaLoan = ({ cityName, lendersData, state }: { cityName: string, lendersData: LendersData | [], state: string }) => {
+  const lenderContactHref = (lender: Lenders) => buildContactCtaHref({
+    firstName: lender.FirstName,
+    salesforceId: lender.AccountId_15__c,
+    stateSlug: state,
+    form: 'lender',
+  });
+
   const trackLenderCta = (lenderId: string, position: string) => {
     trackCtaClicked({
       cta_id: 'state_lender_card_contact',
@@ -87,59 +95,63 @@ const StatePageVaLoan = ({ cityName, lendersData, state }: { cityName: string, l
         <div className="grid lg:grid-cols-2 grid-cols-1 items-start justify-between gap-10 mt-10">
           {Array.isArray(lendersData) || !lendersData.records
             ? <p>No lenders available</p>
-            : lendersData.records.map((lender: Lenders) => (
-              <div key={lender.AccountId_15__c} className="rounded-[30px] border bg-white shadow-[0px_5px_14px_0px_rgba(8,_15,_52,_0.04)] flex sm:p-8 p-4">
-                <div className="justify-center items-center flex flex-col">
-                  <div className="rounded-full bg-[#E1EDFB] sm:w-[200px] sm:h-[200px] w-[100px] h-[100px] flex justify-center items-center overflow-hidden mb-4 sm:mb-0">
-                    <Link
-                      href={`/contact-lender?form=lender&fn=${lender.FirstName}&id=${lender.AccountId_15__c}&state=${state}`}
-                      onClick={() => trackLenderCta(lender.AccountId_15__c, 'card_image')}
-                    >
-                      <Image
-                        src={lender?.PhotoUrl || ""}
-                        alt={`${lender?.Name}'s Profile Picture`}
-                        width={1000}
-                        height={1000}
-                        sizes="(min-width: 640px) 200px, 100px"
-                        className="object-cover"
-                      />
-                    </Link>
-                  </div>
-                  <Link
-                    href={`/contact-lender?form=lender&fn=${lender.FirstName}&id=${lender.AccountId_15__c}&state=${state}`}
-                    onClick={() => trackLenderCta(lender.AccountId_15__c, 'card_button')}
-                  >
-                    <Button buttonText="Contact Now" />
-                  </Link>
-                </div>
-                <div className="md:pl-10 pl-4">
-                  <div>
-                    <Link
-                      href={`/contact-lender?form=lender&fn=${lender.FirstName}&id=${lender.AccountId_15__c}&state=${state}`}
-                      onClick={() => trackLenderCta(lender.AccountId_15__c, 'card_heading')}
-                    >
-                      <h3 className="text-[#292F6C] tahoma md:text-[34px] text-[24px] font-bold">
-                        {lender?.Name}
-                      </h3>
-                    </Link>
-                    <div className="text-[#6C757D] tahoma md:text-[18px] text-sm font-normal sm:mt-4 mt-0">
-                      <p className="font-bold">
-                        {orderMilitaryServiceInfo(lender?.Military_Status__pc || "", lender?.Military_Service__pc || "")}
-                      </p>
-                      <p>NMLS: {lender.Individual_NMLS_ID__pc}</p>
-                      {lender.Company_NMLS_ID__pc &&
-                        <>
-                          <p>{lender.Brokerage_Name__pc}</p>
-                          <p>NMLS: {lender.Company_NMLS_ID__pc}</p>
-                        </>
-                      }
-                    </div>
-                    <LenderBio bio={lender?.Agent_Bio__pc || ""} />
+            : lendersData.records.map((lender: Lenders) => {
+              const contactHref = lenderContactHref(lender);
 
+              return (
+                <div key={lender.AccountId_15__c} className="rounded-[30px] border bg-white shadow-[0px_5px_14px_0px_rgba(8,_15,_52,_0.04)] flex sm:p-8 p-4">
+                  <div className="justify-center items-center flex flex-col">
+                    <div className="rounded-full bg-[#E1EDFB] sm:w-[200px] sm:h-[200px] w-[100px] h-[100px] flex justify-center items-center overflow-hidden mb-4 sm:mb-0">
+                      <Link
+                        href={contactHref}
+                        onClick={() => trackLenderCta(lender.AccountId_15__c, 'card_image')}
+                      >
+                        <Image
+                          src={lender?.PhotoUrl || ""}
+                          alt={`${lender?.Name}'s Profile Picture`}
+                          width={1000}
+                          height={1000}
+                          sizes="(min-width: 640px) 200px, 100px"
+                          className="object-cover"
+                        />
+                      </Link>
+                    </div>
+                    <Link
+                      href={contactHref}
+                      onClick={() => trackLenderCta(lender.AccountId_15__c, 'card_button')}
+                    >
+                      <Button buttonText="Contact Now" />
+                    </Link>
+                  </div>
+                  <div className="md:pl-10 pl-4">
+                    <div>
+                      <Link
+                        href={contactHref}
+                        onClick={() => trackLenderCta(lender.AccountId_15__c, 'card_heading')}
+                      >
+                        <h3 className="text-[#292F6C] tahoma md:text-[34px] text-[24px] font-bold">
+                          {lender?.Name}
+                        </h3>
+                      </Link>
+                      <div className="text-[#6C757D] tahoma md:text-[18px] text-sm font-normal sm:mt-4 mt-0">
+                        <p className="font-bold">
+                          {orderMilitaryServiceInfo(lender?.Military_Status__pc || "", lender?.Military_Service__pc || "")}
+                        </p>
+                        <p>NMLS: {lender.Individual_NMLS_ID__pc}</p>
+                        {lender.Company_NMLS_ID__pc &&
+                          <>
+                            <p>{lender.Brokerage_Name__pc}</p>
+                            <p>NMLS: {lender.Company_NMLS_ID__pc}</p>
+                          </>
+                        }
+                      </div>
+                      <LenderBio bio={lender?.Agent_Bio__pc || ""} />
+
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Adds Next's data-scroll-behavior marker to the root html element so route-transition scroll restoration works correctly with the site's global smooth scrolling CSS.
- Routes state-page agent and lender contact card links through the shared contact CTA URL builder, keeping partner form URLs consistent and encoded.

## Root Cause
Next.js warned that global scroll-behavior: smooth was active without the required HTML marker. On long state pages navigating to shorter contact form pages, that can interfere with route-transition scroll resets and leave mobile users near the bottom of the destination page.

## Validation
- Mobile /texas agent card -> /contact-agent?... landed at scrollY: 0 with the form heading and first fields visible.
- Mobile /texas lender card -> /contact-lender?... landed at scrollY: 0 with the form heading and first fields visible.
- npm run type-check
- npm run lint
- npm run build