### PR TITLE
Fix PostHog exception sanitization

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,9 @@ const __dirname = path.dirname(__filename);
 
 export default defineConfig([
     {
+        ignores: [".claude/**"],
+    },
+    {
         extends: [...nextCoreWebVitals],
     },
     {

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,42 +1,32 @@
 import posthog from 'posthog-js';
 import { initializeClientAnalytics } from '@/lib/analytics/client';
-import { sanitizeAnalyticsProperties, safePath } from '@/lib/analytics/sanitizer';
+import {
+  sanitizePostHogBeforeSendEvent,
+  shouldInitializePostHog,
+} from '@/lib/analytics/posthog-before-send';
 
-const visitorId = initializeClientAnalytics();
+const hostname = typeof window !== 'undefined' ? window.location.hostname : undefined;
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
-  api_host: '/ingest',
-  ui_host: 'https://us.posthog.com',
-  defaults: '2026-01-30',
-  bootstrap: {
-    distinctID: visitorId,
-  },
-  autocapture: false,
-  capture_pageview: true,
-  capture_exceptions: true,
-  disable_session_recording: true,
-  mask_all_text: true,
-  mask_all_element_attributes: true,
-  before_send: (event) => {
-    if (!event) return event;
-    if (event.properties) {
-      const currentPath = safePath(event.properties.$current_url);
-      const referrerPath = safePath(event.properties.$referrer);
-      delete event.properties.$current_url;
-      delete event.properties.$referrer;
-      delete event.properties.$initial_current_url;
-      delete event.properties.$initial_referrer;
-      event.properties = {
-        ...sanitizeAnalyticsProperties(event.properties),
-        ...(currentPath ? { $pathname: currentPath } : {}),
-        ...(referrerPath ? { $referring_path: referrerPath } : {}),
-        vpcs_visitor_id: visitorId,
-      };
-    }
-    return event;
-  },
-  loaded: (client) => {
-    client.register({ vpcs_visitor_id: visitorId });
-  },
-  debug: process.env.NODE_ENV === 'development',
-});
+if (shouldInitializePostHog(hostname)) {
+  const visitorId = initializeClientAnalytics();
+
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
+    defaults: '2026-01-30',
+    bootstrap: {
+      distinctID: visitorId,
+    },
+    autocapture: false,
+    capture_pageview: true,
+    capture_exceptions: true,
+    disable_session_recording: true,
+    mask_all_text: true,
+    mask_all_element_attributes: true,
+    before_send: (event) => sanitizePostHogBeforeSendEvent(event, visitorId),
+    loaded: (client) => {
+      client.register({ vpcs_visitor_id: visitorId });
+    },
+    debug: process.env.NODE_ENV === 'development',
+  });
+}

--- a/lib/analytics/__tests__/posthog-before-send.test.ts
+++ b/lib/analytics/__tests__/posthog-before-send.test.ts
@@ -1,0 +1,109 @@
+import type { CaptureResult } from 'posthog-js';
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizePostHogBeforeSendEvent,
+  shouldInitializePostHog,
+} from '@/lib/analytics/posthog-before-send';
+
+function captureResult(event: string, properties: Record<string, unknown>): CaptureResult {
+  return {
+    uuid: '00000000-0000-4000-8000-000000000000',
+    event,
+    properties,
+  };
+}
+
+describe('PostHog before_send handling', () => {
+  it('sanitizes normal events with path-only URL metadata and visitor id', () => {
+    const result = sanitizePostHogBeforeSendEvent(
+      captureResult('$pageview', {
+        $current_url: 'https://www.veteranpcs.com/contact-agent?email=alex@example.com',
+        $referrer: 'https://www.google.com/search?q=pcs+move',
+        $initial_current_url: 'https://www.veteranpcs.com/contact-agent?phone=5555551212',
+        $initial_referrer: 'https://www.google.com/search?q=raw',
+        email: 'alex@example.com',
+        source_page_path: '/contact-agent?email=alex@example.com',
+        safe_flag: true,
+      }),
+      'vpcs_test_visitor',
+    );
+
+    expect(result?.properties).toEqual({
+      source_page_path: '/contact-agent',
+      safe_flag: true,
+      $pathname: '/contact-agent',
+      $referring_path: '/search',
+      vpcs_visitor_id: 'vpcs_test_visitor',
+    });
+  });
+
+  it('uses exception-specific sanitization for valid exception events', () => {
+    const result = sanitizePostHogBeforeSendEvent(
+      captureResult('$exception', {
+        $current_url: 'https://www.veteranpcs.com/contact-agent?email=alex@example.com',
+        $referrer: 'https://www.veteranpcs.com/?phone=5555551212',
+        $lib: 'web',
+        $exception_level: 'error',
+        $exception_values: ['Bad email alex@example.com at https://www.veteranpcs.com/foo?bar=baz'],
+        $exception_list: [
+          {
+            type: 'Error',
+            value: 'Bad email alex@example.com at https://www.veteranpcs.com/foo?bar=baz',
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'https://www.veteranpcs.com/_next/static/chunks/app.js?bar=baz',
+                  function: 'render',
+                  lineno: 10,
+                  colno: 2,
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      }),
+      'vpcs_test_visitor',
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.properties.$current_url).toBeUndefined();
+    expect(result?.properties.$referrer).toBeUndefined();
+    expect(result?.properties.$pathname).toBe('/contact-agent');
+    expect(result?.properties.$referring_path).toBe('/');
+    expect(result?.properties.vpcs_visitor_id).toBe('vpcs_test_visitor');
+    expect(result?.properties.$exception_values).toEqual([
+      'Bad email [redacted_email] at /foo',
+    ]);
+
+    const exceptionList = result?.properties.$exception_list as Array<Record<string, unknown>> | undefined;
+    expect(exceptionList).toHaveLength(1);
+    const exception = exceptionList?.[0];
+    if (!exception) throw new Error('Expected sanitized exception');
+
+    expect(exception.value).toBe('Bad email [redacted_email] at /foo');
+  });
+
+  it('drops exception events without a valid exception list', () => {
+    const result = sanitizePostHogBeforeSendEvent(
+      captureResult('$exception', {
+        $lib: 'web',
+        $exception_level: 'error',
+      }),
+      'vpcs_test_visitor',
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('gates browser initialization to production hosts unless local capture is explicit', () => {
+    expect(shouldInitializePostHog('www.veteranpcs.com')).toBe(true);
+    expect(shouldInitializePostHog('veteranpcs.com')).toBe(true);
+    expect(shouldInitializePostHog('WWW.VETERANPCS.COM')).toBe(true);
+    expect(shouldInitializePostHog('127.0.0.1')).toBe(false);
+    expect(shouldInitializePostHog('localhost')).toBe(false);
+    expect(shouldInitializePostHog('preview.veteranpcs.com')).toBe(false);
+    expect(shouldInitializePostHog('127.0.0.1', { enableLocalCapture: true })).toBe(true);
+    expect(shouldInitializePostHog('localhost', { enableLocalCapture: true })).toBe(true);
+  });
+});

--- a/lib/analytics/__tests__/sanitizer.test.ts
+++ b/lib/analytics/__tests__/sanitizer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   errorCodesFromErrors,
   queryMetrics,
+  sanitizeExceptionProperties,
   sanitizeAnalyticsProperties,
   zipPrefix,
 } from '@/lib/analytics/sanitizer';
@@ -111,5 +112,106 @@ describe('analytics sanitizer', () => {
       utm_source: 'codex',
       landing_page_path: '/pcs-resources',
     });
+  });
+
+  it('preserves required exception fields while redacting risky exception text', () => {
+    const clean = sanitizeExceptionProperties({
+      $lib: 'web',
+      $lib_version: '1.391.2',
+      $exception_level: 'error',
+      $exception_handled: false,
+      $exception_fingerprint: ['TypeError', 'https://www.veteranpcs.com/contact-agent?email=alex@example.com'],
+      $exception_types: ['TypeError'],
+      $exception_values: [
+        'Failed for alex@example.com at https://www.veteranpcs.com/contact-agent?email=alex@example.com zip 80920 phone 555-555-1212',
+      ],
+      $exception_steps: [
+        { event: 'clicked submit', html: '<input value="alex@example.com">' },
+      ],
+      $exception_list: [
+        {
+          type: 'TypeError',
+          value: 'Failed for alex@example.com at https://www.veteranpcs.com/contact-agent?email=alex@example.com zip 80920 phone 555-555-1212',
+          stacktrace: {
+            frames: [
+              {
+                filename: 'https://www.veteranpcs.com/_next/static/chunks/app.js?email=alex@example.com',
+                function: 'submitLead',
+                module: 'components/contact-agent',
+                lineno: 57,
+                colno: '14',
+                in_app: true,
+                context_line: 'const email = "alex@example.com"',
+                vars: { email: 'alex@example.com' },
+              },
+            ],
+          },
+          mechanism: {
+            type: 'onerror',
+            handled: false,
+            synthetic: true,
+            data: { raw: 'alex@example.com' },
+          },
+          extra: { raw: 'alex@example.com' },
+        },
+      ],
+    });
+
+    expect(clean).toBeDefined();
+    expect(clean?.$lib).toBe('web');
+    expect(clean?.$exception_level).toBe('error');
+    expect(clean?.$exception_handled).toBe(false);
+    expect(clean?.$exception_fingerprint).toEqual(['TypeError', '/contact-agent']);
+    expect(clean?.$exception_values).toEqual([
+      'Failed for [redacted_email] at /contact-agent zip [redacted_zip] phone [redacted_phone]',
+    ]);
+    expect(clean).not.toHaveProperty('$exception_steps');
+
+    const exceptionList = clean?.$exception_list as Array<Record<string, unknown>> | undefined;
+    expect(exceptionList).toHaveLength(1);
+    const exception = exceptionList?.[0];
+    if (!exception) throw new Error('Expected sanitized exception');
+
+    expect(exception.type).toBe('TypeError');
+    expect(exception.value).toBe(
+      'Failed for [redacted_email] at /contact-agent zip [redacted_zip] phone [redacted_phone]',
+    );
+    expect(exception).not.toHaveProperty('extra');
+
+    const stacktrace = exception.stacktrace as Record<string, unknown>;
+    const frames = stacktrace.frames as Array<Record<string, unknown>>;
+    expect(frames).toHaveLength(1);
+    const frame = frames[0];
+    if (!frame) throw new Error('Expected sanitized exception frame');
+
+    expect(frame).toEqual({
+      filename: '/_next/static/chunks/app.js',
+      function: 'submitLead',
+      module: 'components/contact-agent',
+      lineno: 57,
+      colno: 14,
+      in_app: true,
+    });
+
+    expect(exception.mechanism).toEqual({
+      type: 'onerror',
+      handled: false,
+      synthetic: true,
+    });
+  });
+
+  it('drops malformed exception payloads instead of producing invalid PostHog exceptions', () => {
+    expect(sanitizeExceptionProperties({
+      $lib: 'web',
+      $exception_level: 'error',
+    })).toBeUndefined();
+
+    expect(sanitizeExceptionProperties({
+      $lib: 'web',
+      $exception_list: [
+        { value: { raw: 'not a string' } },
+        'not an exception object',
+      ],
+    })).toBeUndefined();
   });
 });

--- a/lib/analytics/posthog-before-send.ts
+++ b/lib/analytics/posthog-before-send.ts
@@ -1,0 +1,63 @@
+import type { CaptureResult } from 'posthog-js';
+import {
+  sanitizeAnalyticsProperties,
+  sanitizeExceptionProperties,
+  safePath,
+} from '@/lib/analytics/sanitizer';
+
+const PRODUCTION_POSTHOG_HOSTS = new Set(['www.veteranpcs.com', 'veteranpcs.com']);
+const LOCAL_POSTHOG_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+interface PostHogInitOptions {
+  enableLocalCapture?: boolean;
+}
+
+export function shouldInitializePostHog(
+  hostname: string | undefined,
+  options: PostHogInitOptions = {},
+): boolean {
+  if (!hostname) return false;
+
+  const normalizedHost = hostname.toLowerCase();
+  if (PRODUCTION_POSTHOG_HOSTS.has(normalizedHost)) return true;
+
+  const enableLocalCapture = options.enableLocalCapture
+    ?? process.env.NEXT_PUBLIC_POSTHOG_ENABLE_LOCAL_CAPTURE === '1';
+
+  return enableLocalCapture && LOCAL_POSTHOG_HOSTS.has(normalizedHost);
+}
+
+export function sanitizePostHogBeforeSendEvent(
+  event: CaptureResult | null,
+  visitorId: string,
+): CaptureResult | null {
+  if (!event) return event;
+
+  const originalProperties = event.properties as Record<string, unknown> | undefined;
+  if (!originalProperties) return event.event === '$exception' ? null : event;
+
+  const properties = { ...originalProperties };
+  const currentPath = safePath(properties.$current_url);
+  const referrerPath = safePath(properties.$referrer);
+
+  delete properties.$current_url;
+  delete properties.$referrer;
+  delete properties.$initial_current_url;
+  delete properties.$initial_referrer;
+
+  const cleanProperties = event.event === '$exception'
+    ? sanitizeExceptionProperties(properties)
+    : sanitizeAnalyticsProperties(properties);
+
+  if (!cleanProperties) return null;
+
+  return {
+    ...event,
+    properties: {
+      ...cleanProperties,
+      ...(currentPath ? { $pathname: currentPath } : {}),
+      ...(referrerPath ? { $referring_path: referrerPath } : {}),
+      vpcs_visitor_id: visitorId,
+    },
+  };
+}

--- a/lib/analytics/sanitizer.ts
+++ b/lib/analytics/sanitizer.ts
@@ -4,6 +4,11 @@ export type JourneyStage = 'top' | 'mid' | 'bottom' | 'outcome';
 
 export type AnalyticsValue = string | number | boolean | null | undefined;
 export type AnalyticsProperties = Record<string, unknown>;
+export type SanitizedAnalyticsProperties = Record<
+  string,
+  AnalyticsValue | AnalyticsValue[] | Record<string, AnalyticsValue>
+>;
+export type SanitizedExceptionProperties = Record<string, unknown>;
 
 const BLOCKED_KEY_RE =
   /(^|_)(name|first_name|firstname|last_name|lastname|email|e_mail|phone|mobile|tel|street|address|captcha|message|comment|comments|free_text|payload|form_data|query|search_query|raw_text|text|zip_code|zipcode|zip)$/i;
@@ -16,9 +21,13 @@ const SAFE_BLOCKED_KEY_EXCEPTIONS = new Set([
 ]);
 
 const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
+const EMAIL_GLOBAL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
 const LONG_PHONE_RE = /(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}/;
+const LONG_PHONE_GLOBAL_RE = /(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}/g;
 const FULL_ZIP_RE = /^\d{5}(?:-\d{4})?$/;
+const FULL_ZIP_GLOBAL_RE = /\b\d{5}(?:-\d{4})?\b/g;
 const UNSAFE_URL_RE = /^https?:\/\/.+[?&][^#]+/i;
+const URL_GLOBAL_RE = /https?:\/\/[^\s"'<>]+/gi;
 
 const ALLOWED_ATTRIBUTION_KEYS = new Set([
   'utm_source',
@@ -49,6 +58,10 @@ const SAFE_ERROR_CODE_FIELDS = new Set([
 
 function isBlockedKey(key: string): boolean {
   return !SAFE_BLOCKED_KEY_EXCEPTIONS.has(key) && BLOCKED_KEY_RE.test(key);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 export function safePath(value: unknown): string | undefined {
@@ -107,6 +120,34 @@ export function hasPii(value: unknown): boolean {
     || UNSAFE_URL_RE.test(trimmed);
 }
 
+function urlToSafePath(value: string): string {
+  const trailingMatch = /[.,;:!?]+$/.exec(value);
+  const trailing = trailingMatch?.[0] ?? '';
+  const rawUrl = trailing ? value.slice(0, -trailing.length) : value;
+
+  try {
+    const url = new URL(rawUrl);
+    return `${url.pathname || '/'}${trailing}`;
+  } catch {
+    return `[redacted_url]${trailing}`;
+  }
+}
+
+export function redactAnalyticsText(value: string, maxLength = 512): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const clean = trimmed
+    .replace(URL_GLOBAL_RE, urlToSafePath)
+    .replace(EMAIL_GLOBAL_RE, '[redacted_email]')
+    .replace(LONG_PHONE_GLOBAL_RE, '[redacted_phone]')
+    .replace(FULL_ZIP_GLOBAL_RE, '[redacted_zip]')
+    .slice(0, maxLength)
+    .trim();
+
+  return clean || undefined;
+}
+
 function cleanScalar(key: string, value: unknown): AnalyticsValue {
   if (value === undefined) return undefined;
   if (value === null || typeof value === 'number' || typeof value === 'boolean') return value;
@@ -134,8 +175,8 @@ function cleanScalar(key: string, value: unknown): AnalyticsValue {
 
 export function sanitizeAnalyticsProperties(
   properties: AnalyticsProperties = {},
-): Record<string, AnalyticsValue | AnalyticsValue[] | Record<string, AnalyticsValue>> {
-  const clean: Record<string, AnalyticsValue | AnalyticsValue[] | Record<string, AnalyticsValue>> = {};
+): SanitizedAnalyticsProperties {
+  const clean: SanitizedAnalyticsProperties = {};
 
   for (const [key, value] of Object.entries(properties)) {
     if (isBlockedKey(key)) continue;
@@ -164,6 +205,159 @@ export function sanitizeAnalyticsProperties(
     const safeValue = cleanScalar(key, value);
     if (safeValue !== undefined) clean[key] = safeValue;
   }
+
+  return clean;
+}
+
+function cleanExceptionText(value: unknown, maxLength = 512): string | undefined {
+  return typeof value === 'string' ? redactAnalyticsText(value, maxLength) : undefined;
+}
+
+function cleanExceptionNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string') return undefined;
+
+  const trimmed = value.trim();
+  if (!/^-?\d+(?:\.\d+)?$/.test(trimmed)) return undefined;
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function cleanExceptionBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function sanitizeExceptionFrame(frame: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(frame)) return undefined;
+
+  const clean: Record<string, unknown> = {};
+
+  for (const key of ['filename', 'abs_path', 'function', 'module']) {
+    const value = cleanExceptionText(frame[key], key === 'function' || key === 'module' ? 256 : 1024);
+    if (value !== undefined) clean[key] = value;
+  }
+
+  for (const key of ['lineno', 'colno', 'line', 'column']) {
+    const value = cleanExceptionNumber(frame[key]);
+    if (value !== undefined) clean[key] = value;
+  }
+
+  const inApp = cleanExceptionBoolean(frame.in_app);
+  if (inApp !== undefined) clean.in_app = inApp;
+
+  return Object.keys(clean).length > 0 ? clean : undefined;
+}
+
+function sanitizeExceptionFrames(value: unknown): Record<string, unknown>[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const frames = value
+    .map(sanitizeExceptionFrame)
+    .filter((frame): frame is Record<string, unknown> => frame !== undefined);
+
+  return frames.length > 0 ? frames : undefined;
+}
+
+function sanitizeExceptionStacktrace(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const frames = sanitizeExceptionFrames(value.frames);
+  if (!frames) return undefined;
+
+  return { frames };
+}
+
+function sanitizeExceptionMechanism(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const clean: Record<string, unknown> = {};
+  const type = cleanExceptionText(value.type, 128);
+  const handled = cleanExceptionBoolean(value.handled);
+  const synthetic = cleanExceptionBoolean(value.synthetic);
+
+  if (type !== undefined) clean.type = type;
+  if (handled !== undefined) clean.handled = handled;
+  if (synthetic !== undefined) clean.synthetic = synthetic;
+
+  return Object.keys(clean).length > 0 ? clean : undefined;
+}
+
+function sanitizeExceptionItem(item: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(item)) return undefined;
+
+  const clean: Record<string, unknown> = {};
+  const type = cleanExceptionText(item.type, 256);
+  const value = cleanExceptionText(item.value, 1024);
+  const stacktrace = sanitizeExceptionStacktrace(item.stacktrace);
+  const mechanism = sanitizeExceptionMechanism(item.mechanism);
+  const hasExceptionDetail = type !== undefined || value !== undefined || stacktrace !== undefined;
+
+  if (!hasExceptionDetail) return undefined;
+
+  if (type !== undefined) clean.type = type;
+  if (value !== undefined) clean.value = value;
+  if (stacktrace !== undefined) clean.stacktrace = stacktrace;
+  if (mechanism !== undefined) clean.mechanism = mechanism;
+
+  return Object.keys(clean).length > 0 ? clean : undefined;
+}
+
+export function sanitizeExceptionList(value: unknown): Record<string, unknown>[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const exceptions = value
+    .map(sanitizeExceptionItem)
+    .filter((item): item is Record<string, unknown> => item !== undefined);
+
+  return exceptions.length > 0 ? exceptions : undefined;
+}
+
+function sanitizeExceptionTextArray(value: unknown, maxLength = 512): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const clean = value
+    .map((entry) => cleanExceptionText(entry, maxLength))
+    .filter((entry): entry is string => entry !== undefined);
+
+  return clean.length > 0 ? clean : undefined;
+}
+
+function sanitizeExceptionFingerprint(value: unknown): string | string[] | undefined {
+  if (typeof value === 'string') return cleanExceptionText(value, 512);
+
+  const values = sanitizeExceptionTextArray(value, 512);
+  return values && values.length > 0 ? values : undefined;
+}
+
+export function sanitizeExceptionProperties(
+  properties: AnalyticsProperties = {},
+): SanitizedExceptionProperties | undefined {
+  const exceptionList = sanitizeExceptionList(properties.$exception_list);
+  if (!exceptionList) return undefined;
+
+  const clean: SanitizedExceptionProperties = sanitizeAnalyticsProperties(properties);
+
+  clean.$exception_list = exceptionList;
+  delete clean.$exception_steps;
+
+  const exceptionFrames = sanitizeExceptionFrames(properties.$exception_frames);
+  if (exceptionFrames) clean.$exception_frames = exceptionFrames;
+
+  const exceptionTypes = sanitizeExceptionTextArray(properties.$exception_types, 256);
+  if (exceptionTypes) clean.$exception_types = exceptionTypes;
+
+  const exceptionValues = sanitizeExceptionTextArray(properties.$exception_values, 1024);
+  if (exceptionValues) clean.$exception_values = exceptionValues;
+
+  const exceptionFingerprint = sanitizeExceptionFingerprint(properties.$exception_fingerprint);
+  if (exceptionFingerprint !== undefined) clean.$exception_fingerprint = exceptionFingerprint;
+
+  const exceptionLevel = cleanExceptionText(properties.$exception_level, 64);
+  if (exceptionLevel !== undefined) clean.$exception_level = exceptionLevel;
+
+  const exceptionHandled = cleanExceptionBoolean(properties.$exception_handled);
+  if (exceptionHandled !== undefined) clean.$exception_handled = exceptionHandled;
 
   return clean;
 }


### PR DESCRIPTION
## Summary

- Preserve valid PostHog exception payloads with an exception-specific sanitizer so Error Tracking can process browser exceptions again.
- Redact risky exception text values and gate browser PostHog initialization to production domains by default.

## Validation

- npm test
- npm run lint
- npm run type-check
- npm run build
- pre-commit hook also passed lint, type-check, and build