### PR TITLE
Rationalize blog post CTAs: single intent-driven band, intent-driven sticky, carousel removed

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -226,7 +226,7 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
                 headingIds={firstHeadingIds}
             />
             {bridgeState && ctaIntent === 'agent' && (
-                <FindAgentInState state={bridgeState} blogSlug={slug} position="top" />
+                <FindAgentInState state={bridgeState} blogSlug={slug} />
             )}
             <BlogDetailsCta stateSlug={bridgeState} componentSlug={blogComponent?.slug ?? null} contentSlug={slug} />
             <EndBlogPostDetails

--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -226,7 +226,7 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
                 <FindAgentInState state={bridgeState} blogSlug={slug} position="top" />
             )}
             <Testimonials />
-            <BlogDetailsCta stateSlug={bridgeState} componentSlug={blogComponent?.slug ?? null} />
+            <BlogDetailsCta stateSlug={bridgeState} componentSlug={blogComponent?.slug ?? null} contentSlug={slug} />
             <EndBlogPostDetails
                 bodySecondHalf={bodySecondHalf}
                 resolvedAuthor={resolvedAuthor}

--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -4,7 +4,6 @@ import { cache } from "react";
 import { BlogPosting, WithContext } from "schema-dts";
 import BlogDetailsHeroSection from "@/components/BlogDetails/BlogDetailsHeroSection/BlogDetailsHeroSection";
 import BlogBeginingPostAgent from "@/components/BlogDetails/BlogBeginingBlogPostAgent/BlogBeginingBlogPostAgent";
-import Testimonials from "@/components/Testimonials/TestimonialPage";
 import BlogDetailsCta from "@/components/BlogDetails/BlogDetailsCta/BlogDetailsCta";
 import EndBlogPostDetails from "@/components/BlogDetails/EndBlogPostDetails/EndBlogPostDetails";
 import FrequentlyAskedQuestion from "@/components/stories/FrequentlyAskedQuestions/FrequentlyAskedQuestions";
@@ -22,7 +21,7 @@ import {
     getBlogSlugs,
     readingTimeMinutes,
 } from "@/lib/blog/mdx";
-import { getBlogComponentBySlug } from "@/lib/blog/components";
+import { getBlogComponentBySlug, getBlogCtaIntent } from "@/lib/blog/components";
 import { toBlogCardData } from "@/lib/blog/cards";
 import { pickNextGuide, rankRelatedBlogs } from "@/lib/blog/related";
 import { resolveAuthor } from "@/lib/blog/authors";
@@ -99,11 +98,15 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
     const firstHeadingIds = tocHeadings.slice(0, firstHeadingCount);
     const secondHeadingIds = tocHeadings.slice(firstHeadingCount);
     const readingMinutes = readingTimeMinutes(blog.content);
-    const contactHref = buildContactCtaHref({ stateSlug: bridgeState, form: "agent" });
-    const ctaLabel = bridgeState
-        ? `Find an agent in ${getStateDisplayName(bridgeState)}`
-        : "Find an Agent";
     const blogComponent = getBlogComponentBySlug(componentSlugForBlog(blog));
+    const ctaIntent = getBlogCtaIntent(blogComponent?.slug);
+    const contactHref = buildContactCtaHref({ stateSlug: bridgeState, form: ctaIntent });
+    const partnerLabel = ctaIntent === 'agent' ? 'an agent' : 'a lender';
+    const ctaLabel = bridgeState
+        ? `Find ${partnerLabel} in ${getStateDisplayName(bridgeState)}`
+        : `Find ${partnerLabel}`;
+    const stickyCtaId = ctaIntent === 'agent' ? 'blog_mobile_sticky_agent' : 'blog_mobile_sticky_lender';
+    const stickyCtaIntent = ctaIntent === 'agent' ? 'contact_agent' : 'contact_lender';
     const allBlogs = await getAllBlogs();
     const rankedRelated = rankRelatedBlogs(allBlogs, blog);
     const nextGuide = pickNextGuide(rankedRelated);
@@ -222,10 +225,9 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
                 tocHeadings={tocHeadings}
                 headingIds={firstHeadingIds}
             />
-            {bridgeState && (
+            {bridgeState && ctaIntent === 'agent' && (
                 <FindAgentInState state={bridgeState} blogSlug={slug} position="top" />
             )}
-            <Testimonials />
             <BlogDetailsCta stateSlug={bridgeState} componentSlug={blogComponent?.slug ?? null} contentSlug={slug} />
             <EndBlogPostDetails
                 bodySecondHalf={bodySecondHalf}
@@ -250,9 +252,6 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
                     </div>
                 </div>
             )}
-            {bridgeState && (
-                <FindAgentInState state={bridgeState} blogSlug={slug} position="bottom" />
-            )}
             <CommonBlog
                 component={blog.component || ""}
                 blog={blog}
@@ -271,13 +270,16 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
             </div>
             <FrequentlyAskedQuestion />
             <KeepInTouch />
-            <div className="fixed inset-x-0 bottom-0 z-40 border-t border-[#E5E7EB] bg-white/95 px-5 py-3 shadow-lg md:hidden">
+            <div
+                className="fixed inset-x-0 bottom-0 z-40 border-t border-[#E5E7EB] bg-white/95 px-5 py-3 shadow-lg md:hidden"
+                data-cta-id={stickyCtaId}
+            >
                 <TrackedCtaLink
                     href={contactHref}
                     className="block min-h-11 rounded-custom bg-[#a81f23] px-5 py-3 text-center text-sm font-bold text-white"
                     cta={{
-                        ctaId: 'blog_mobile_sticky_agent',
-                        ctaIntent: 'contact_agent',
+                        ctaId: stickyCtaId,
+                        ctaIntent: stickyCtaIntent,
                         ctaPosition: 'mobile_sticky_footer',
                         ctaComponent: 'blog_mobile_sticky_cta',
                         ctaLabel,
@@ -286,7 +288,7 @@ export default async function Home(props: { params: Promise<{ slug: string }> })
                         stateSlug: bridgeState,
                         contentSlug: slug,
                         contentType: 'blog_post',
-                        partnerType: 'agent',
+                        partnerType: ctaIntent,
                     }}
                 >
                     {ctaLabel}

--- a/components/Blog/FindAgentInState/FindAgentInState.tsx
+++ b/components/Blog/FindAgentInState/FindAgentInState.tsx
@@ -39,7 +39,7 @@ export default function FindAgentInState({ state, blogSlug, position }: Props) {
   };
 
   return (
-    <div className="container mx-auto w-full my-12 px-4">
+    <div className="container mx-auto w-full my-12 px-4" data-cta-id="blog_find_agent_in_state">
       <div
         className="rounded-[32px] p-8 sm:p-12 text-white text-center"
         style={{
@@ -50,7 +50,7 @@ export default function FindAgentInState({ state, blogSlug, position }: Props) {
           Find a veteran-friendly agent in {displayName}
         </h2>
         <p className="text-base sm:text-lg mb-6 max-w-2xl mx-auto">
-          Our {displayName} agents are PCS-fluent and VA-loan experts. Get matched in minutes — no spam, no pressure.
+          Our {displayName} agents are PCS-fluent and VA-loan experts. Get matched in minutes. No spam, no pressure.
         </p>
         <Link
           href={href}

--- a/components/Blog/FindAgentInState/FindAgentInState.tsx
+++ b/components/Blog/FindAgentInState/FindAgentInState.tsx
@@ -6,15 +6,14 @@ import { getStateDisplayName } from '@/lib/blog/getStateForBlog';
 import { trackCtaClicked } from '@/lib/analytics/client';
 import { buildCtaProperties } from '@/lib/analytics/cta';
 
-type Position = 'top' | 'bottom';
-
+// The 'bottom' placement was retired (zero organic clicks); this component
+// now renders only in the single top position on agent-intent posts.
 type Props = {
   state: string;
   blogSlug: string;
-  position: Position;
 };
 
-export default function FindAgentInState({ state, blogSlug, position }: Props) {
+export default function FindAgentInState({ state, blogSlug }: Props) {
   const displayName = getStateDisplayName(state);
   const href = `/${state}?source=blog&blog_slug=${encodeURIComponent(blogSlug)}`;
 
@@ -23,12 +22,12 @@ export default function FindAgentInState({ state, blogSlug, position }: Props) {
       event: 'blog_to_state_cta_click',
       state,
       blog_slug: blogSlug,
-      position,
+      position: 'top',
     });
     trackCtaClicked(buildCtaProperties({
       ctaId: 'blog_find_agent_in_state',
       ctaIntent: 'state_agent_search',
-      ctaPosition: position,
+      ctaPosition: 'top',
       ctaComponent: 'blog_find_agent_in_state',
       destination: href,
       pageType: 'blog_post',

--- a/components/BlogDetails/BlogDetailsCta/BlogDetailsCta.tsx
+++ b/components/BlogDetails/BlogDetailsCta/BlogDetailsCta.tsx
@@ -2,32 +2,33 @@ import Button from "@/components/common/Button";
 import classes from "./BlogDetailsCta.module.css";
 import TrackedCtaLink from "@/components/common/TrackedCtaLink";
 import { buildContactCtaHref } from "@/lib/contactAgentUrl";
-import { getBlogComponentBySlug } from "@/lib/blog/components";
+import { getBlogCtaIntent } from "@/lib/blog/components";
 import { getStateDisplayName } from "@/lib/blog/state";
 
 type Props = {
   stateSlug?: string | null;
   componentSlug?: string | null;
+  contentSlug: string;
 };
 
-const BlogDetailsCta = ({ stateSlug = null, componentSlug = null }: Props) => {
+const BlogDetailsCta = ({ stateSlug = null, componentSlug = null, contentSlug }: Props) => {
   const stateName = stateSlug ? getStateDisplayName(stateSlug) : null;
   const agentHref = buildContactCtaHref({ stateSlug, form: "agent" });
   const lenderHref = buildContactCtaHref({ stateSlug, form: "lender" });
-  const agentLabel = stateName ? `Find an Agent in ${stateName}` : "Find An Agent";
-  const lenderLabel = stateName ? `Find a Lender in ${stateName}` : "Find A Lender";
-  // Lender-led categories (VA Loan Help, Financial Guidance) put the lender
-  // CTA first, driven by ctaCopy in content/_data/blog-components.json.
-  const lenderFirst = getBlogComponentBySlug(componentSlug)?.ctaCopy === "Find a Lender";
+  const agentLabel = stateName ? `Find an agent in ${stateName}` : "Find an agent";
+  const lenderLabel = stateName ? `Find a lender in ${stateName}` : "Find a lender";
+  // Category-driven intent (agent vs. lender) comes from partnerIntent in
+  // content/_data/blog-components.json via getBlogCtaIntent.
+  const intent = getBlogCtaIntent(componentSlug);
 
   const agentBlock = (
-    <div key="agent">
+    <div>
       <div>
         <h2 className="text-[#FFFFFF] lg:text-[40px] md:text-[40px] sm:text-[30px] text-[30px] font-bold">
           Buying Or Selling
         </h2>
       </div>
-      <div>
+      <div data-cta-id="blog_details_find_agent">
         <TrackedCtaLink
           href={agentHref}
           cta={{
@@ -39,6 +40,8 @@ const BlogDetailsCta = ({ stateSlug = null, componentSlug = null }: Props) => {
             destination: agentHref,
             pageType: 'blog_post',
             stateSlug,
+            contentSlug,
+            contentType: 'blog_post',
             partnerType: 'agent',
           }}
         >
@@ -49,13 +52,13 @@ const BlogDetailsCta = ({ stateSlug = null, componentSlug = null }: Props) => {
   );
 
   const lenderBlock = (
-    <div key="lender">
+    <div>
       <div>
         <h2 className="text-[#FFFFFF] lg:text-[40px] md:text-[40px] sm:text-[30px] text-[30px] font-bold">
           VA Loan Expert
         </h2>
       </div>
-      <div>
+      <div data-cta-id="blog_details_find_lender">
         <TrackedCtaLink
           href={lenderHref}
           cta={{
@@ -67,6 +70,8 @@ const BlogDetailsCta = ({ stateSlug = null, componentSlug = null }: Props) => {
             destination: lenderHref,
             pageType: 'blog_post',
             stateSlug,
+            contentSlug,
+            contentType: 'blog_post',
             partnerType: 'lender',
           }}
         >
@@ -78,11 +83,9 @@ const BlogDetailsCta = ({ stateSlug = null, componentSlug = null }: Props) => {
 
   return (
     <div className="container mx-auto w-full mt-12 sm:mb-12">
-      <div className={classes.blogdetailsctacontainer}>
-        <div className="items-center grid lg:grid-cols-2 md:grid-cols-2 sm:grid-cols-1 grid-cols-1 mt-10 justify-center xl:gap-10 lg:gap-10 md:gap-10 sm:gap-2 gap-2">
-          <div className="md:pl-20">
-            {lenderFirst ? [lenderBlock, agentBlock] : [agentBlock, lenderBlock]}
-          </div>
+      <div className={classes.blogdetailsctacontainer} data-testid="blog-details-cta-band">
+        <div className="items-center grid grid-cols-1 justify-center text-center mt-10 xl:gap-10 lg:gap-10 md:gap-10 sm:gap-2 gap-2">
+          {intent === 'lender' ? lenderBlock : agentBlock}
         </div>
       </div>
     </div>

--- a/content/_data/blog-components.json
+++ b/content/_data/blog-components.json
@@ -4,48 +4,55 @@
     "label": "PCS Help",
     "description": "PCS planning, timelines, move strategy, and relocation guidance.",
     "ctaCopy": "Find an Agent",
-    "intro": "PCS orders set a lot in motion. These guides walk you through timelines, entitlements, and the decisions that make a military move easier from start to finish."
+    "intro": "PCS orders set a lot in motion. These guides walk you through timelines, entitlements, and the decisions that make a military move easier from start to finish.",
+    "partnerIntent": "agent"
   },
   {
     "slug": "us-military-bases",
     "label": "U.S. Military Bases",
     "description": "Installation guides, state base lists, and local PCS context.",
     "ctaCopy": "Find an Agent",
-    "intro": "Every installation has its own housing picture, commute patterns, and local quirks. Start here to learn what daily life looks like at your next duty station."
+    "intro": "Every installation has its own housing picture, commute patterns, and local quirks. Start here to learn what daily life looks like at your next duty station.",
+    "partnerIntent": "agent"
   },
   {
     "slug": "va-loan-help",
     "label": "VA Loan Help",
     "description": "VA loan education, entitlement, funding fee, assumptions, and lender guidance.",
     "ctaCopy": "Find a Lender",
-    "intro": "The VA loan is one of the strongest benefits you have earned, and it is easier to use than most people think. These guides cover entitlement, funding fees, and how to work with a lender who knows the program."
+    "intro": "The VA loan is one of the strongest benefits you have earned, and it is easier to use than most people think. These guides cover entitlement, funding fees, and how to work with a lender who knows the program.",
+    "partnerIntent": "lender"
   },
   {
     "slug": "military-transition-help",
     "label": "Military Transition Help",
     "description": "Separation, retirement, SkillBridge, and civilian move planning.",
     "ctaCopy": "Find an Agent",
-    "intro": "Leaving the service brings a new set of choices about where to live and what comes next. These guides help you plan the move from military life to your next chapter."
+    "intro": "Leaving the service brings a new set of choices about where to live and what comes next. These guides help you plan the move from military life to your next chapter.",
+    "partnerIntent": "agent"
   },
   {
     "slug": "financial-guidance",
     "label": "Financial Guidance",
     "description": "Budgeting, BAH, taxes, cost of living, and military money decisions.",
     "ctaCopy": "Find a Lender",
-    "intro": "Military pay, BAH, and frequent moves make money planning different for service members. These guides break down budgets, taxes, and cost of living in plain terms."
+    "intro": "Military pay, BAH, and frequent moves make money planning different for service members. These guides break down budgets, taxes, and cost of living in plain terms.",
+    "partnerIntent": "lender"
   },
   {
     "slug": "things-to-do-near-you",
     "label": "Things to Do Near You",
     "description": "Local activities and neighborhood context near military communities.",
     "ctaCopy": "Find an Agent",
-    "intro": "A new duty station is easier to call home once you know the area. Explore local activities and family favorites near military communities."
+    "intro": "A new duty station is easier to call home once you know the area. Explore local activities and family favorites near military communities.",
+    "partnerIntent": "agent"
   },
   {
     "slug": "real-estate-insights",
     "label": "Real Estate Insights",
     "description": "Market, agent, and home-buying guidance for military families.",
     "ctaCopy": "Find an Agent",
-    "intro": "Buying or selling a home during military life comes with its own timing and tradeoffs. These guides share what military families should know about the market and choosing the right agent."
+    "intro": "Buying or selling a home during military life comes with its own timing and tradeoffs. These guides share what military families should know about the market and choosing the right agent.",
+    "partnerIntent": "agent"
   }
 ]

--- a/content/blog/florida-va-loan-benefits-hidden-savings.mdx
+++ b/content/blog/florida-va-loan-benefits-hidden-savings.mdx
@@ -9,6 +9,7 @@ description: >-
   disabled veteran, and Save Our Homes tax savings on top. Often worth
   thousands a year.
 slug: florida-va-loan-benefits-hidden-savings
+stateSlug: florida
 publishedAt: '2026-05-25T15:00:00.000Z'
 component: VA Loan Help
 categories:

--- a/docs/analytics/telemetry-taxonomy.md
+++ b/docs/analytics/telemetry-taxonomy.md
@@ -227,7 +227,7 @@ Pre/post comparison windows must start no earlier than 2026-06-27, when `cta_cli
 
 Dashboard disposition: any saved PostHog insight or dashboard tile that filters `cta_id = 'blog_mobile_sticky_agent'` alone now undercounts total mobile sticky footer engagement, because lender-intent posts fire `blog_mobile_sticky_lender` instead. File a follow-up to add `blog_mobile_sticky_lender` to those filters. The same applies to any saved insight built around `blog_find_agent_in_state` that does not segment out the retired `bottom` position.
 
-This is a ticketed CTA change under `docs/ai-first/homepage-followups.md:33` ("No route/href/`ctaId`/form/data-attribute changes except where a ticket explicitly says so"), which is the guardrail this doc update and its underlying code change satisfy.
+These ctaId changes are ticketed by the Blog Post CTA Rationalization plan (branch `feat/blog-post-cta-rationalization`); this keeps them consistent with the ctaId-stability rule recorded for the homepage cycle in `docs/ai-first/homepage-followups.md:33`, which requires a ticket for any ctaId change.
 
 ## Customer Form IDs
 

--- a/docs/analytics/telemetry-taxonomy.md
+++ b/docs/analytics/telemetry-taxonomy.md
@@ -227,7 +227,7 @@ Pre/post comparison windows must start no earlier than 2026-06-27, when `cta_cli
 
 Dashboard disposition: any saved PostHog insight or dashboard tile that filters `cta_id = 'blog_mobile_sticky_agent'` alone now undercounts total mobile sticky footer engagement, because lender-intent posts fire `blog_mobile_sticky_lender` instead. File a follow-up to add `blog_mobile_sticky_lender` to those filters. The same applies to any saved insight built around `blog_find_agent_in_state` that does not segment out the retired `bottom` position.
 
-These ctaId changes are ticketed by the Blog Post CTA Rationalization plan (branch `feat/blog-post-cta-rationalization`); this keeps them consistent with the ctaId-stability rule recorded for the homepage cycle in `docs/ai-first/homepage-followups.md:33`, which requires a ticket for any ctaId change.
+These ctaId changes are ticketed by the Blog Post CTA Rationalization plan (PR #170, branch `feat/blog-post-cta-rationalization`); this keeps them consistent with the ctaId-stability rule recorded for the homepage cycle in `docs/superpowers/plans/2026-07-08-homepage-followups.md:16`, which requires a ticket for any ctaId change.
 
 ## Customer Form IDs
 

--- a/docs/analytics/telemetry-taxonomy.md
+++ b/docs/analytics/telemetry-taxonomy.md
@@ -1,6 +1,6 @@
 # VeteranPCS Telemetry Taxonomy
 
-Last updated: 2026-06-26
+Last updated: 2026-07-12
 
 This is the durable reference for VeteranPCS web telemetry. Use it when changing analytics code, troubleshooting PostHog, comparing against Google Analytics, or planning Salesforce closed-loop reporting.
 
@@ -170,10 +170,12 @@ Post template (`page_type: blog_post`):
 | cta_id | cta_position | cta_intent |
 |---|---|---|
 | `blog_breadcrumb_category` | `blog_post_breadcrumb` | `content_navigation` |
-| `blog_details_find_agent` / `blog_details_find_lender` (kept; now carry `state_slug`) | `blog_details_cta_band` | `contact_agent` / `contact_lender` |
+| `blog_details_find_agent` / `blog_details_find_lender` (kept; carry `state_slug`; single-intent rationalization now renders exactly one block per post, chosen by the post's category `partnerIntent` in `content/_data/blog-components.json`; payload now also carries `content_slug` and `content_type: 'blog_post'`) | `blog_details_cta_band` | `contact_agent` / `contact_lender` |
 | `blog_next_guide` | `blog_post_after_body` | `content_navigation` |
-| `blog_related_card` / `blog_related_card_view_all` | `blog_post_related_rail` | `content_navigation` |
-| `blog_find_agent_in_state` (kept; now built via `buildCtaProperties`) | `top` / `bottom` | `state_agent_search` |
+| `blog_related_card` / `blog_related_card_view_all` (`blog_related_card_view_all` is documented, not yet wired in code; see PR #169) | `blog_post_related_rail` | `content_navigation` |
+| `blog_find_agent_in_state` (kept; built via `buildCtaProperties`; renders only on agent-intent, state-matched posts; position `top` only, `bottom` retired) | `top` | `state_agent_search` |
+| `blog_mobile_sticky_agent` (fixed mobile footer on agent-intent posts; added to correct prior documentation drift, the id already fires in code) | `mobile_sticky_footer` | `contact_agent` |
+| `blog_mobile_sticky_lender` (fixed mobile footer on lender-intent posts; new) | `mobile_sticky_footer` | `contact_lender` |
 
 Blog landing (`page_type: blog_landing`):
 
@@ -209,6 +211,23 @@ Search results (`page_type: blog_search`):
 | `blog_search_results_all_guides`, `blog_search_no_results_all_guides`, `blog_search_no_results_category` (unchanged) | `blog_search_results_header` / `blog_search_no_results` | `content_navigation` |
 
 Retired ids (stop appearing after the refactor deploy): `blog_article_card` (hub grid), `blog_search_result_image`, `blog_search_result_title`. `pcs_resources_blog_card` no longer fires on post pages (the related rail now emits `blog_related_card`) but still fires on `/va-loan-help`, `/pcs-resources`, and `/thank-you`.
+
+The single-intent CTA rationalization change (branch `feat/blog-post-cta-rationalization`, pending deploy as of 2026-07-12) retires `blog_find_agent_in_state` position `bottom`. Only position `top` continues to fire, and only on agent-intent, state-matched posts. This does not retire the `blog_find_agent_in_state` id itself, only the `bottom` position value.
+
+### Blog Post CTA Comparability (2026-07 single-intent rationalization)
+
+Before this change, `blog_details_find_agent` and `blog_details_find_lender` both rendered on every blog post, so a click-through rate could be computed against total blog post views. As of this change, the `blog_details_cta_band` renders exactly one block per post, chosen by the post's category `partnerIntent`. Treat the two ids as separate populations with separate denominators, not two variants sharing one pool:
+
+- `blog_details_find_agent`, `blog_mobile_sticky_agent`, and `blog_find_agent_in_state` (position `top`): denominator is agent-intent posts only, 247 posts as of 2026-07-12 (`pcs-help`, `us-military-bases`, `military-transition-help`, `things-to-do-near-you`, and `real-estate-insights` categories).
+- `blog_details_find_lender` and `blog_mobile_sticky_lender`: denominator is lender-intent posts only, 95 posts as of 2026-07-12 (`va-loan-help` and `financial-guidance` categories).
+
+Build the denominator from `content_viewed` (carries `content_slug` and `topic_cluster`) sequenced or joined with `cta_clicked` per `cta_id`, and segment both sides by category intent by mapping `topic_cluster` to `partnerIntent` in `content/_data/blog-components.json`. Do not divide clicks on one id by pageviews of the whole blog post population; that overstates the denominator for both intents now that only one CTA block renders per post.
+
+Pre/post comparison windows must start no earlier than 2026-06-27, when `cta_clicked` with `page_type: blog_post` first fired in PostHog. Blog `$pageview` capture started earlier, on 2026-06-22, but that is a pageview-only signal and understates the CTA baseline if used as the instrumentation start date. Exclude a QA burst on 2026-07-12 between 23:40 and 23:43 UTC: a single test session produced roughly 30 `cta_clicked` events in that window while validating the PR #169 blog discovery surfaces (`blog_category` and `blog_archive` page types). Verified against the PostHog `events` table on 2026-07-12.
+
+Dashboard disposition: any saved PostHog insight or dashboard tile that filters `cta_id = 'blog_mobile_sticky_agent'` alone now undercounts total mobile sticky footer engagement, because lender-intent posts fire `blog_mobile_sticky_lender` instead. File a follow-up to add `blog_mobile_sticky_lender` to those filters. The same applies to any saved insight built around `blog_find_agent_in_state` that does not segment out the retired `bottom` position.
+
+This is a ticketed CTA change under `docs/ai-first/homepage-followups.md:33` ("No route/href/`ctaId`/form/data-attribute changes except where a ticket explicitly says so"), which is the guardrail this doc update and its underlying code change satisfy.
 
 ## Customer Form IDs
 
@@ -284,6 +303,7 @@ Known GTM events in the current app:
 | `state_map_interaction` | Homepage state map interaction |
 | `get_listed_agent_submitted` | Agent listing request |
 | `get_listed_lender_submitted` | Lender listing request |
+| `blog_to_state_cta_click` | `FindAgentInState` blog post CTA (`blog_find_agent_in_state`), position `top`, agent-intent posts only; comparator alongside the PostHog `cta_clicked` event |
 
 If a GTM conversion fires before a confirmed Salesforce acceptance, use the PostHog `lead_conversion_created` event for accepted-lead reporting.
 

--- a/lib/blog/__tests__/components-state.test.ts
+++ b/lib/blog/__tests__/components-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { BLOG_COMPONENTS, normalizeBlogComponentSlug, getBlogCtaIntent } from '@/lib/blog/components';
+import { BLOG_COMPONENTS, normalizeBlogComponentSlug, getBlogCtaIntent, __testables } from '@/lib/blog/components';
 import { resolveBlogStateSlug, resolveBlogState } from '@/lib/blog/state';
 import type { BlogPost } from '@/lib/blog/types';
 
@@ -70,5 +70,29 @@ describe('getBlogCtaIntent', () => {
     }
     expect(BLOG_COMPONENTS.filter((c) => c.partnerIntent === 'lender').map((c) => c.slug).sort())
       .toEqual(['financial-guidance', 'va-loan-help']);
+  });
+});
+
+describe('validateBlogComponents', () => {
+  const { validateBlogComponents } = __testables;
+  const valid = { slug: 'pcs-help', label: 'PCS Help', description: 'x', partnerIntent: 'agent' };
+
+  it('accepts entries with a valid partnerIntent', () => {
+    expect(validateBlogComponents([valid, { ...valid, slug: 'va-loan-help', partnerIntent: 'lender' }]))
+      .toHaveLength(2);
+  });
+
+  it('throws naming the offending slug when partnerIntent is missing', () => {
+    expect(() => validateBlogComponents([valid, { slug: 'new-category', label: 'New', description: 'x' }]))
+      .toThrow(/new-category.*missing or invalid partnerIntent/);
+  });
+
+  it('throws when partnerIntent is not agent or lender', () => {
+    expect(() => validateBlogComponents([{ ...valid, slug: 'bad-intent', partnerIntent: 'both' }]))
+      .toThrow(/bad-intent.*got "both"/);
+  });
+
+  it('throws when the JSON root is not an array', () => {
+    expect(() => validateBlogComponents({ categories: [] })).toThrow(/must be an array/);
   });
 });

--- a/lib/blog/__tests__/components-state.test.ts
+++ b/lib/blog/__tests__/components-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { BLOG_COMPONENTS, normalizeBlogComponentSlug } from '@/lib/blog/components';
+import { BLOG_COMPONENTS, normalizeBlogComponentSlug, getBlogCtaIntent } from '@/lib/blog/components';
 import { resolveBlogStateSlug, resolveBlogState } from '@/lib/blog/state';
 import type { BlogPost } from '@/lib/blog/types';
 
@@ -43,5 +43,32 @@ describe('blog state resolver', () => {
   it('does not resolve ambiguous token aliases without an exact post pin', () => {
     expect(resolveBlogStateSlug(post({ slug: 'housing-near-fort-campbell' }))).toBeNull();
     expect(resolveBlogStateSlug(post({ slug: 'best-of-washington-state-not-dc' }))).toBeNull();
+  });
+});
+
+describe('getBlogCtaIntent', () => {
+  it('maps lender-led categories to lender', () => {
+    expect(getBlogCtaIntent('va-loan-help')).toBe('lender');
+    expect(getBlogCtaIntent('financial-guidance')).toBe('lender');
+  });
+
+  it('maps all other categories to agent', () => {
+    for (const slug of ['pcs-help', 'us-military-bases', 'military-transition-help', 'things-to-do-near-you', 'real-estate-insights']) {
+      expect(getBlogCtaIntent(slug)).toBe('agent');
+    }
+  });
+
+  it('defaults to agent for null, undefined, and unknown slugs', () => {
+    expect(getBlogCtaIntent(null)).toBe('agent');
+    expect(getBlogCtaIntent(undefined)).toBe('agent');
+    expect(getBlogCtaIntent('not-a-component')).toBe('agent');
+  });
+
+  it('every component declares a valid partnerIntent (fail loud on new categories)', () => {
+    for (const c of BLOG_COMPONENTS) {
+      expect(['agent', 'lender']).toContain(c.partnerIntent);
+    }
+    expect(BLOG_COMPONENTS.filter((c) => c.partnerIntent === 'lender').map((c) => c.slug).sort())
+      .toEqual(['financial-guidance', 'va-loan-help']);
   });
 });

--- a/lib/blog/components.ts
+++ b/lib/blog/components.ts
@@ -10,7 +10,32 @@ export type BlogComponent = {
   partnerIntent: BlogCtaIntent;
 };
 
-export const BLOG_COMPONENTS = components as readonly BlogComponent[];
+function isBlogCtaIntent(value: unknown): value is BlogCtaIntent {
+  return value === 'agent' || value === 'lender';
+}
+
+// JSON imports are only assertion-checked by TypeScript, so a category added
+// without a valid partnerIntent would silently fall back to 'agent'. Fail the
+// build instead: every canonical category must declare its intent explicitly.
+function validateBlogComponents(raw: unknown): readonly BlogComponent[] {
+  if (!Array.isArray(raw)) {
+    throw new Error('blog-components.json must be an array of categories');
+  }
+  for (const entry of raw) {
+    if (!isBlogCtaIntent(entry?.partnerIntent)) {
+      throw new Error(
+        `blog-components.json: category "${entry?.slug}" has a missing or invalid partnerIntent ` +
+        `(expected 'agent' or 'lender', got ${JSON.stringify(entry?.partnerIntent)})`,
+      );
+    }
+  }
+  return raw as readonly BlogComponent[];
+}
+
+export const BLOG_COMPONENTS = validateBlogComponents(components);
+
+// Only import __testables from tests.
+export const __testables = { validateBlogComponents };
 
 export const BLOG_COMPONENT_BY_SLUG: ReadonlyMap<string, BlogComponent> = new Map(
   BLOG_COMPONENTS.map((component) => [component.slug, component]),

--- a/lib/blog/components.ts
+++ b/lib/blog/components.ts
@@ -1,10 +1,13 @@
 import components from '@/content/_data/blog-components.json';
 
+export type BlogCtaIntent = 'agent' | 'lender';
+
 export type BlogComponent = {
   slug: string;
   label: string;
   description: string;
   ctaCopy?: string;
+  partnerIntent: BlogCtaIntent;
 };
 
 export const BLOG_COMPONENTS = components as readonly BlogComponent[];
@@ -42,6 +45,10 @@ export function normalizeBlogComponentSlug(value: string | null | undefined): st
 export function getBlogComponentBySlug(slug: string | null | undefined): BlogComponent | null {
   if (!slug) return null;
   return BLOG_COMPONENT_BY_SLUG.get(slug) ?? null;
+}
+
+export function getBlogCtaIntent(componentSlug: string | null | undefined): BlogCtaIntent {
+  return getBlogComponentBySlug(componentSlug)?.partnerIntent ?? 'agent';
 }
 
 export function getBlogComponentByLabel(label: string | null | undefined): BlogComponent | null {


### PR DESCRIPTION
## Summary

Rationalizes the blog post template's CTAs from "every CTA on every post" to intent-driven rendering, per the Blog Post CTA Rationalization plan (all three product decisions pre-resolved):

- **Decision 1 (Option A):** FindAgentInState survives only as the `top` instance, only on agent-intent + state-matched posts; the `bottom` instance (zero organic clicks ever recorded) is retired.
- **Decision 2 (intent-driven sticky):** the mobile sticky footer now routes by post intent — `blog_mobile_sticky_agent` → `/contact-agent` on agent posts, new `blog_mobile_sticky_lender` → `/contact-lender` on lender posts, state-personalized label/href when the post resolves a state.
- **Decision 3 (carousel removed):** the Testimonials react-slick carousel is deleted from the post template outright.

Intent is an explicit `partnerIntent` field on each category in `content/_data/blog-components.json` (`lender` for VA Loan Help + Financial Guidance = 95 posts; `agent` for the other five categories = 247 posts), read via the new `getBlogCtaIntent()` helper (defaults to `agent`; test locks the lender set to exactly those two slugs).

## cta_id disposition

| cta_id | Disposition |
|---|---|
| `blog_details_find_agent` | Kept; renders only on agent-intent posts; payload gains `content_slug`/`content_type` |
| `blog_details_find_lender` | Kept; renders only on lender-intent posts; payload gains `content_slug`/`content_type` |
| `blog_mobile_sticky_agent` | Kept on agent posts; added to registry (doc drift fix) |
| `blog_mobile_sticky_lender` | New on lender posts (Decision 2) |
| `blog_find_agent_in_state` | Agent-intent posts only, position `top`; position `bottom` retired (Decision 1: Option A) |
| `blog_breadcrumb_category`, `blog_next_guide`, `blog_related_card`, search ids | Untouched (PR #169 surface) |
| GTM `blog_to_state_cta_click` | Survives on agent-intent posts, top position only |

## PostHog baseline (pre-change, pulled 2026-07-12)

A pre-change baseline was pulled from PostHog on 2026-07-12 over the instrumented window (blog CTA instrumentation began 2026-06-27; a QA burst on 2026-07-12 23:40–23:43 UTC is excluded). Directionally: the mobile sticky agent CTA was the clear strongest performer; the `blog_find_agent_in_state` `bottom` position had never received an organic click, which is what justified retiring it (Decision 1: Option A) while keeping `top`. Exact counts intentionally omitted from this public PR; they live in the local plan doc.

**Denominator change:** band CTR denominators are now per-intent subsets (247 agent / 95 lender posts), not all posts. The comparability section added to `docs/analytics/telemetry-taxonomy.md` documents the `content_viewed`-join denominator query, the 2026-06-27 window start, the QA-burst exclusion, and the dashboard disposition for both sticky ids (saved insights filtering only `blog_mobile_sticky_agent` now undercount; follow-up ticket noted in the doc).

## ctaId-change guardrail

These ctaId changes are ticketed by this plan/branch, keeping them consistent with the ctaId-stability rule recorded for the homepage cycle in `docs/ai-first/homepage-followups.md:33` (a ticket for any ctaId change). **Adjudication note for review:** the plan mandated citing that guardrail line as the *authorizing* ticket; the task reviewer flagged that its scope is the homepage cycle, so the doc keeps the citation but attributes authorization to this plan/branch. Flagging so a human can confirm that framing.

## Plan-fact correction (one file beyond the plan's 7-file edit surface)

Playwright verification caught that the plan's lender archetype post (`florida-va-loan-benefits-hidden-savings`) did **not** resolve to Florida as the plan asserted — it was missing the frontmatter `stateSlug` that every sibling state-specific lender guide carries (`texas-va-loan-benefits-…`, all `*-veteran-property-tax-exemptions-2026`). Root cause was the content data, not the CTA code (this branch never touched state resolution). Fixed with a one-line frontmatter addition (`stateSlug: florida`) in commit 304f5bb; re-verification then passed all assertions. This is the only file in the diff outside the plan's 7 planned files, disclosed here deliberately.

## Verification evidence

- Gates on final branch state: `lint` / `type-check` / `build` / `test` all exit 0 (65 test files, 443 tests).
- Build generates 342 `/blog/[slug]` routes == 342 eligible (non-future-dated) posts.
- Playwright MCP, 3 archetype posts × desktop 1280 + mobile 390: zero `slick` elements on all posts; exactly one intent-correct band link per post (Tennessee-personalized agent on Fort Campbell, Florida-personalized lender on the FL VA-loan post, plain agent on 12 Tips); FindAgentInState only on the agent+state post (top only); sticky footer id/href/label match intent on all three. All 9 surviving-CTA clicks produced `cta_clicked` with the exact expected `cta_id`/`content_slug` (decoded `/ingest` payloads, all 200 OK); FindAgentInState click also pushed GTM `blog_to_state_cta_click` (corroborated by a live GA4 collect request).
- Regression spot-checks: homepage FeaturedLogos slider intact; `/va-loan-help` TestimonialPage carousel intact; TOC anchors all resolve.
- Codex review (full branch diff vs main): "no actionable regressions were identified."
- Final whole-branch review: READY TO MERGE; 0 Critical / 0 Important; all Minor findings triaged ship-as-is (noted for follow-up: dead `'bottom'` member of the `Position` type, `cta_label` casing split at deploy boundary for saved insights breaking down by label, inert grid classes in the band wrapper).

## react-slick retained

The dependency stays: homepage FeaturedLogos and TestimonialPage (`/va-loan-help` and other non-blog routes) still use it. Only the blog post template's Testimonials render (and its Sanity fetch) was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
