### PR TITLE
chore: Dependabot remediation sweep 2026-07 (31 alerts: 30 fixed, 1 dismissed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@actions/github/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -480,29 +480,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -553,13 +553,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -784,13 +784,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -11588,9 +11588,9 @@
       }
     },
     "node_modules/deeks": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/deeks/-/deeks-3.1.0.tgz",
-      "integrity": "sha512-e7oWH1LzIdv/prMQ7pmlDlaVoL64glqzvNgkgQNgyec9ORPHrT2jaOqMtRyqJuwWjtfb6v+2rk9pmaHj+F137A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/deeks/-/deeks-3.2.1.tgz",
+      "integrity": "sha512-D/o0k3pCG1aI1cxb/dDiWmtMc4Rh7ZQBybXpfMsw9Rbtqwg8kUA9SpYkWcw0pAUjZSnPm8MluctiS0o68r69jQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -11754,9 +11754,9 @@
       "license": "MIT"
     },
     "node_modules/doc-path": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-4.1.1.tgz",
-      "integrity": "sha512-h1ErTglQAVv2gCnOpD3sFS6uolDbOKHDU1BZq+Kl3npPqroU3dYL42lUgMfd5UimlwtRgp7C9dLGwqQ5D2HYgQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-4.1.4.tgz",
+      "integrity": "sha512-yw5D++UCIB6a033PvQaUvSpW2QuKW0+DOId763n0Q4z3brxS7G8oQr8yBQ1nQFkognKrAVrV6I55TLeU9cfXTg==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -11832,9 +11832,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -13623,16 +13623,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -14631,9 +14631,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -14827,9 +14827,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -15095,9 +15095,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -16516,10 +16516,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -16615,13 +16625,13 @@
       }
     },
     "node_modules/json-2-csv": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-5.5.10.tgz",
-      "integrity": "sha512-Dep8wO3Fr5wNjQevO2Z8Y7yeee/nYSGRsi7q6zJDKEVHxXkXT+v21vxHmDX923UzmCXXkSo62HaTz6eTWzFLaw==",
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-5.5.11.tgz",
+      "integrity": "sha512-kVuwgVL7rfad9ETf02ZZxJPuMR5ZSUn139+T34BfmVxYhb/IsAIm/LzEeQ8YLJmXfuQ5z7LUAFrgPZZM6VLJPw==",
       "license": "MIT",
       "dependencies": {
-        "deeks": "3.1.0",
-        "doc-path": "4.1.1"
+        "deeks": "3.2.1",
+        "doc-path": "4.1.4"
       },
       "engines": {
         "node": ">= 16"
@@ -16938,9 +16948,9 @@
       }
     },
     "node_modules/load-yaml-file/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -23902,9 +23912,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -24662,9 +24672,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
Remediates all 31 open Dependabot alerts (inventory pulled 2026-07-13). **30 fixed** by a lockfile-only `npm update` of 8 transitive packages; **1 dismissed** via API with the reachability analysis below. No package.json changes, no `overrides`, no parent-package bumps: every parent's existing semver range already admitted the patched version.

## Triage table

| Alert | Sev | Package | Advisory | Dependency path | Class* | Action |
|---|---|---|---|---|---|---|
| #86 | **Critical** | decompress 4.2.1 | GHSA-mp2f-45pm-3cg9 (Zip Slip) | sanity → @sanity/cli (declared, **never imported**) | (c)+(d) | **Dismissed `not_used`** — analysis below |
| #78 | High | undici 7.25.0 | GHSA-vxpw-j846-p89q (WebSocket DoS) | cheerio; sanity → jsdom | (b) | Fixed → **7.28.0** |
| #77 | High | undici 6.25.0 | GHSA-vxpw-j846-p89q (WebSocket DoS) | sanity → @sanity/cli → @actions/* | (b)+(d) | Fixed → **6.27.0** |
| #76 | High | undici 7.25.0 | GHSA-hm92-r4w5-c3mj (SOCKS5 cross-origin) | cheerio; sanity → jsdom | (b) | Fixed → **7.28.0** |
| #71 | High | undici 7.25.0 | GHSA-vmh5-mc38-953g (SOCKS5 TLS bypass) | cheerio; sanity → jsdom | (b) | Fixed → **7.28.0** |
| #68 | High | hono 4.12.21 | GHSA-88fw-hqm2-52qc (CORS reflect) | @modelcontextprotocol/sdk | (b) | Fixed → **4.12.30** |
| #65 | High | form-data 4.0.5 | GHSA-hmw2-7cc7-3qxx (CRLF injection) | axios; sanity; sanity → jsdom | (b) | Fixed → **4.0.6** |
| #80 | Med | undici 7.25.0 | GHSA-p88m-4jfj-68fv (header injection) | cheerio; sanity → jsdom | (b) | Fixed → **7.28.0** |
| #79 | Med | undici 6.25.0 | GHSA-p88m-4jfj-68fv (header injection) | sanity → @sanity/cli → @actions/* | (b)+(d) | Fixed → **6.27.0** |
| #72 | Med | undici 7.25.0 | GHSA-pr7r-676h-xcf6 (cache disclosure) | cheerio; sanity → jsdom | (b) | Fixed → **7.28.0** |
| #70 | Med | hono 4.12.21 | GHSA-rv63-4mwf-qqc2 (Lambda body-limit) | @modelcontextprotocol/sdk | (b) | Fixed → **4.12.30** |
| #69 | Med | hono 4.12.21 | GHSA-wgpf-jwqj-8h8p (Lambda@Edge headers) | @modelcontextprotocol/sdk | (b) | Fixed → **4.12.30** |
| #67 | Med | hono 4.12.21 | GHSA-wwfh-h76j-fc44 (Windows serve-static) | @modelcontextprotocol/sdk | (b) | Fixed → **4.12.30** |
| #66 | Med | hono 4.12.21 | GHSA-j6c9-x7qj-28xf (Lambda Set-Cookie) | @modelcontextprotocol/sdk | (b) | Fixed → **4.12.30** |
| #73 | Med | dompurify 3.4.0 | GHSA-cmwh-pvxp-8882 (setConfig pollution) | posthog-js; sanity → isomorphic-dompurify | (b) | Fixed → **3.4.12** |
| #60 | Med | dompurify 3.4.0 | GHSA-rp9w-3fw7-7cwq (IN_PLACE shadow root) | posthog-js; sanity → isomorphic-dompurify | (b) | Fixed → **3.4.12** |
| #59 | Med | dompurify 3.4.0 | GHSA-76mc-f452-cxcm (hook pollution) | posthog-js; sanity → isomorphic-dompurify | (b) | Fixed → **3.4.12** |
| #57 | Med | dompurify 3.4.0 | GHSA-r47g-fvhr-h676 (IN_PLACE clobbered root) | posthog-js; sanity → isomorphic-dompurify | (b) | Fixed → **3.4.12** |
| #56 | Med | dompurify 3.4.0 | GHSA-hpcv-96wg-7vj8 (cross-realm IN_PLACE) | posthog-js; sanity → isomorphic-dompurify | (b) | Fixed → **3.4.12** |
| #85 | Med | js-yaml 3.14.2 | GHSA-h67p-54hq-rp68 (merge-key DoS) | gray-matter | (b) | Fixed → **3.15.0** |
| #84 | Med | js-yaml 4.1.1 | GHSA-h67p-54hq-rp68 (merge-key DoS) | eslint → @eslint/eslintrc (dev) | (d) | Fixed → **4.3.0** |
| #83 | Med | json-2-csv 5.5.10 | GHSA-g27c-q7cp-mhx6 (CSV injection) | @sanity/vision (Studio-only) | (b) | Fixed → **5.5.11** |
| #64 | Med | tar 7.5.13 | GHSA-vmf3-w455-68vh (parser differential) | sanity → @sanity/export (CLI) | (b)+(d) | Fixed → **7.5.20** |
| #82 | Low | undici 7.25.0 | GHSA-g8m3-5g58-fq7m (SameSite downgrade) | cheerio; sanity → jsdom | (b) | Fixed → **7.28.0** |
| #81 | Low | undici 6.25.0 | GHSA-g8m3-5g58-fq7m (SameSite downgrade) | sanity → @sanity/cli → @actions/* | (b)+(d) | Fixed → **6.27.0** |
| #75 | Low | undici 7.25.0 | GHSA-35p6-xmwp-9g52 (queue poisoning) | cheerio; sanity → jsdom | (b) | Fixed → **7.28.0** |
| #74 | Low | undici 6.25.0 | GHSA-35p6-xmwp-9g52 (queue poisoning) | sanity → @sanity/cli → @actions/* | (b)+(d) | Fixed → **6.27.0** |
| #61 | Low | dompurify 3.4.0 | GHSA-vxr8-fq34-vvx9 (Trusted Types) | posthog-js; sanity → isomorphic-dompurify | (b) | Fixed → **3.4.12** |
| #58 | Low | dompurify 3.4.0 | GHSA-x4vx-rjvf-j5p4 (IN_PLACE nodeName) | posthog-js; sanity → isomorphic-dompurify | (b) | Fixed → **3.4.12** (exits <=3.4.6 range) |
| #55 | Low | dompurify 3.4.0 | GHSA-gvmj-g25r-r7wr (SAFE_FOR_TEMPLATES) | posthog-js; sanity → isomorphic-dompurify | (b) | Fixed → **3.4.12** |
| #62 | Low | @babel/core 7.29.0 | GHSA-4x5r-pxfx-6jf8 (sourceMappingURL read) | eslint-config-next; @sanity/codegen; @vitejs/plugin-react (build-time; runtime uses SWC) | (d) | Fixed → **7.29.7** |

\* Class: (b) transitive, fixable by normal bump; (c) transitive, pinned by upstream; (d) dev/build/CLI-only.

## Dismissal reachability analysis — #86 decompress (Critical)

**No patched version exists**: `decompress@4.2.1` is the newest release ever published (`npm view decompress versions`); the package is abandoned, so neither a bump nor an `overrides` pin can resolve this alert. Reachability was verified three independent ways:

1. **The parent never imports it.** A full recursive grep of `node_modules/@sanity/cli` finds the string `decompress` only in its own `package.json` manifest — zero `require`/`import`/dynamic-import call sites in the compiled CLI or its bin. The CLI's actual template extraction uses bundled `tar`. The vulnerable Zip Slip code cannot execute through `@sanity/cli` at all; the dependency is vestigial.
2. **Our code performs no archive extraction anywhere** (grep of app/, lib/, services/, scripts/, actions/ for decompress/zip/tar/extract usage — only unrelated matches like BAH HTML scraping).
3. **Not in the deployed bundle.** `@sanity/cli` is invoked only by the local `typegen`/`schema extract` npm scripts; the Next.js/Vercel runtime never imports it. No attacker-controllable input path exists.

Dismissed via `gh api` as `not_used`, matching the June 2026 precedent for uuid.

**Durable elimination (follow-up, not this PR):** `@sanity/cli` dropped `decompress` at v5; upgrading `sanity` 3.x → 6.x (a 3-major upgrade needing Studio/typegen migration testing) removes it from the tree entirely.

## Reachability notes on the fixed set

None of the 30 fixed alerts had a plausibly exploitable path in our deployment (Vercel Fluid Compute, Linux, no AWS Lambda/Lambda@Edge/Windows): no direct undici imports (cheerio is parse-only in the BAH scraper; fetching uses `node:https`); the MCP route uses the SDK's `webStandardStreamableHttp.js` which imports zero hono modules (`hono/cors` exists only in an SDK example file); no DOMPurify usage in our code (all `dangerouslySetInnerHTML` sites are self-controlled JSON-LD); axios sends only JSON/urlencoded (no multipart); gray-matter parses only repo-committed blog frontmatter; json-2-csv is authenticated-Studio-only; tar/@babel/core are CLI/build-time. All were patched anyway since every fix was a free in-range bump.

## Verification

- `npm ls --all` confirms: undici 7.28.0 + 6.27.0 (both nested copies), hono 4.12.30, dompurify 3.4.12, form-data 4.0.6, js-yaml 3.15.0 + 4.3.0, json-2-csv 5.5.11, tar 7.5.20, @babel/core 7.29.7
- Lockfile diff touches only the 8 package families + their own lockstep sub-deps (@babel/helpers etc., deeks/doc-path, hasown); `package.json` unchanged
- `npm run lint` / `type-check` / `build` all pass (pre-commit hook); `npm test` 447/447 pass
- Remaining `npm audit` findings are only the two documented-unfixable chains: decompress (dismissed here) and uuid (dismissed `not_used` 2026-06-05)

**Note:** the 30 fixed alerts auto-close when this lockfile merges to main — check `gh api .../dependabot/alerts?state=open` post-merge, not before. #86 is dismissed immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
