### PR TITLE
Fix RealEstateAgent JSON-LD data errors (address, postal code, opening hours)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -88,8 +88,9 @@ const jsonLd: WithContext<RealEstateAgent> =
     address: {
         "@type": "PostalAddress",
         streetAddress: "415 N. Tejon St.",
-        addressLocality: "Colorado Spring",
-        postalCode: "CO 809003",
+        addressLocality: "Colorado Springs",
+        addressRegion: "CO",
+        postalCode: "80903",
         addressCountry: "US"
     },
     geo: {
@@ -98,8 +99,8 @@ const jsonLd: WithContext<RealEstateAgent> =
         longitude: "-104.813499"
     },
     openingHours: [
-        "Mon - Fri 9:00 am - 17:00 pm",
-        "Sat - 9:00 am - 17:00 pm"
+        "Mo-Fr 09:00-17:00",
+        "Sa 09:00-17:00"
     ],
     priceRange: "$",
     brand: {


### PR DESCRIPTION
Fixes four data errors in the site-wide RealEstateAgent JSON-LD block in `app/layout.tsx`. This structured data renders in the root layout, so it affects the Organization schema on every page of the site.

## Before → After

- `addressLocality`: `"Colorado Spring"` → `"Colorado Springs"`
- `postalCode`: `"CO 809003"` → `"80903"` (state code removed; extra digit dropped)
- `addressRegion`: missing → `"CO"`
- `openingHours`: `"Mon - Fri 9:00 am - 17:00 pm"` / `"Sat - 9:00 am - 17:00 pm"` → `"Mo-Fr 09:00-17:00"` / `"Sa 09:00-17:00"` (valid schema.org format; same hours, no am/pm mixing)

No other changes to the file. Lint, type-check, and build all pass (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)